### PR TITLE
fix(ci): Use older Ubuntu image to use older GLIBC

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -2,7 +2,7 @@ name: Bazel
 on: [push]
 jobs:
   bazel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1


### PR DESCRIPTION
This should prevent issues such as 
![image](https://github.com/dfinity/dre/assets/34031969/29ec47b1-6a7b-434c-85eb-19ad7a65976a)
