### PR TITLE
chore: Consolidate and deduplicate cargo deps

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,123 +1,6 @@
 {
-  "checksum": "c02ec9d24a31d5f25804ffe28f52fb2be2483fc64b5a77f32d69a29f5b7eac01",
+  "checksum": "38c9344e8b6664b93f01cbf67920fd888059878f260afaefb47eadff68247ad7",
   "crates": {
-    "actix 0.13.1": {
-      "name": "actix",
-      "version": "0.13.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/actix/0.13.1/download",
-          "sha256": "cba56612922b907719d4a01cf11c8d5b458e7d3dba946d0435f20f58d6795ed2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "actix",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "actix",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "actix-macros",
-            "actix_derive",
-            "default",
-            "macros"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "actix-rt 2.9.0",
-              "target": "actix_rt"
-            },
-            {
-              "id": "bitflags 2.4.1",
-              "target": "bitflags"
-            },
-            {
-              "id": "bytes 1.5.0",
-              "target": "bytes"
-            },
-            {
-              "id": "crossbeam-channel 0.5.10",
-              "target": "crossbeam_channel"
-            },
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-sink 0.3.30",
-              "target": "futures_sink"
-            },
-            {
-              "id": "futures-task 0.3.30",
-              "target": "futures_task"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "once_cell 1.19.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "parking_lot 0.12.1",
-              "target": "parking_lot"
-            },
-            {
-              "id": "pin-project-lite 0.2.13",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "smallvec 1.11.2",
-              "target": "smallvec"
-            },
-            {
-              "id": "tokio 1.35.1",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-util 0.7.10",
-              "target": "tokio_util"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "actix-macros 0.2.4",
-              "target": "actix_macros"
-            },
-            {
-              "id": "actix_derive 0.6.1",
-              "target": "actix_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.13.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "actix-codec 0.5.1": {
       "name": "actix-codec",
       "version": "0.5.1",
@@ -218,19 +101,13 @@
           "common": [
             "__compress",
             "base64",
-            "brotli",
-            "compress-brotli",
             "compress-gzip",
-            "compress-zstd",
             "default",
             "flate2",
-            "h2",
-            "http2",
             "local-channel",
             "rand",
             "sha1",
-            "ws",
-            "zstd"
+            "ws"
           ],
           "selects": {}
         },
@@ -257,16 +134,12 @@
               "target": "ahash"
             },
             {
-              "id": "base64 0.21.5",
+              "id": "base64 0.21.7",
               "target": "base64"
             },
             {
               "id": "bitflags 2.4.1",
               "target": "bitflags"
-            },
-            {
-              "id": "brotli 3.4.0",
-              "target": "brotli"
             },
             {
               "id": "bytes 1.5.0",
@@ -287,10 +160,6 @@
             {
               "id": "futures-core 0.3.30",
               "target": "futures_core"
-            },
-            {
-              "id": "h2 0.3.22",
-              "target": "h2"
             },
             {
               "id": "http 0.2.11",
@@ -351,10 +220,6 @@
             {
               "id": "tracing 0.1.40",
               "target": "tracing"
-            },
-            {
-              "id": "zstd 0.13.0",
-              "target": "zstd"
             }
           ],
           "selects": {}
@@ -463,7 +328,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -740,13 +605,7 @@
             "__compress",
             "actix-macros",
             "actix-web-codegen",
-            "compress-brotli",
             "compress-gzip",
-            "compress-zstd",
-            "cookie",
-            "cookies",
-            "default",
-            "http2",
             "macros"
           ],
           "selects": {}
@@ -798,10 +657,6 @@
               "target": "cfg_if"
             },
             {
-              "id": "cookie 0.16.2",
-              "target": "cookie"
-            },
-            {
               "id": "encoding_rs 0.8.33",
               "target": "encoding_rs"
             },
@@ -842,7 +697,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -942,53 +797,6 @@
         },
         "edition": "2021",
         "version": "4.2.2"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "actix_derive 0.6.1": {
-      "name": "actix_derive",
-      "version": "0.6.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/actix_derive/0.6.1/download",
-          "sha256": "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "actix_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "actix_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.75",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.48",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.6.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1327,75 +1135,6 @@
       },
       "license": "Unlicense OR MIT"
     },
-    "alloc-no-stdlib 2.0.4": {
-      "name": "alloc-no-stdlib",
-      "version": "2.0.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/alloc-no-stdlib/2.0.4/download",
-          "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "alloc_no_stdlib",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "alloc_no_stdlib",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "2.0.4"
-      },
-      "license": "BSD-3-Clause"
-    },
-    "alloc-stdlib 0.2.2": {
-      "name": "alloc-stdlib",
-      "version": "0.2.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/alloc-stdlib/0.2.2/download",
-          "sha256": "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "alloc_stdlib",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "alloc_stdlib",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "alloc-no-stdlib 2.0.4",
-              "target": "alloc_no_stdlib"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.2.2"
-      },
-      "license": "BSD-3-Clause"
-    },
     "allocator-api2 0.2.16": {
       "name": "allocator-api2",
       "version": "0.2.16",
@@ -1501,13 +1240,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "anstream 0.6.5": {
+    "anstream 0.6.7": {
       "name": "anstream",
-      "version": "0.6.5",
+      "version": "0.6.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstream/0.6.5/download",
-          "sha256": "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+          "url": "https://crates.io/api/v1/crates/anstream/0.6.7/download",
+          "sha256": "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
         }
       },
       "targets": [
@@ -1567,7 +1306,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.6.5"
+        "version": "0.6.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2187,7 +1926,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -3137,65 +2876,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-timer 0.7.4": {
-      "name": "async-timer",
-      "version": "0.7.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/async-timer/0.7.4/download",
-          "sha256": "ba5fa6ed76cb2aa820707b4eb9ec46f42da9ce70b0eafab5e5e34942b38a44d5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "async_timer",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "async_timer",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(any(target_arch = \"wasm32\"))": [
-              {
-                "id": "wasm-bindgen 0.2.89",
-                "target": "wasm_bindgen"
-              }
-            ],
-            "cfg(any(target_os = \"macos\", target_os = \"ios\", unix))": [
-              {
-                "id": "libc 0.2.151",
-                "target": "libc"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.7.4"
-      },
-      "license": "BSL-1.0"
-    },
     "async-trait 0.1.77": {
       "name": "async-trait",
       "version": "0.1.77",
@@ -3260,52 +2940,6 @@
         ]
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "atomic 0.6.0": {
-      "name": "atomic",
-      "version": "0.6.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/atomic/0.6.0/download",
-          "sha256": "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "atomic",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "atomic",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "fallback"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytemuck 1.14.0",
-              "target": "bytemuck"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.6.0"
-      },
-      "license": "Apache-2.0/MIT"
     },
     "atomic-waker 1.1.2": {
       "name": "atomic-waker",
@@ -3513,7 +3147,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -3976,13 +3610,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "base64 0.21.5": {
+    "base64 0.21.7": {
       "name": "base64",
-      "version": "0.21.5",
+      "version": "0.21.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/base64/0.21.5/download",
-          "sha256": "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+          "url": "https://crates.io/api/v1/crates/base64/0.21.7/download",
+          "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
         }
       },
       "targets": [
@@ -4010,7 +3644,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.21.5"
+        "version": "0.21.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4114,7 +3748,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -4877,112 +4511,6 @@
       },
       "license": "Apache-2.0"
     },
-    "brotli 3.4.0": {
-      "name": "brotli",
-      "version": "3.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/brotli/3.4.0/download",
-          "sha256": "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "brotli",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "brotli",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc-stdlib",
-            "default",
-            "ffi-api",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "alloc-no-stdlib 2.0.4",
-              "target": "alloc_no_stdlib"
-            },
-            {
-              "id": "alloc-stdlib 0.2.2",
-              "target": "alloc_stdlib"
-            },
-            {
-              "id": "brotli-decompressor 2.5.1",
-              "target": "brotli_decompressor"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "3.4.0"
-      },
-      "license": "BSD-3-Clause/MIT"
-    },
-    "brotli-decompressor 2.5.1": {
-      "name": "brotli-decompressor",
-      "version": "2.5.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/brotli-decompressor/2.5.1/download",
-          "sha256": "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "brotli_decompressor",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "brotli_decompressor",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc-stdlib",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "alloc-no-stdlib 2.0.4",
-              "target": "alloc_no_stdlib"
-            },
-            {
-              "id": "alloc-stdlib 0.2.2",
-              "target": "alloc_stdlib"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "2.5.1"
-      },
-      "license": "BSD-3-Clause/MIT"
-    },
     "bstr 0.2.17": {
       "name": "bstr",
       "version": "0.2.17",
@@ -5241,7 +4769,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -5471,7 +4999,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -5632,36 +5160,6 @@
         "version": "0.6.7"
       },
       "license": "Apache-2.0/MIT"
-    },
-    "bytemuck 1.14.0": {
-      "name": "bytemuck",
-      "version": "1.14.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/bytemuck/1.14.0/download",
-          "sha256": "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bytemuck",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "bytemuck",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "1.14.0"
-      },
-      "license": "Zlib OR Apache-2.0 OR MIT"
     },
     "byteorder 1.5.0": {
       "name": "byteorder",
@@ -5937,7 +5435,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -6064,7 +5562,7 @@
               "target": "pretty"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -6189,7 +5687,7 @@
               "target": "anyhow"
             },
             {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
@@ -6209,7 +5707,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -6260,7 +5758,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -6317,7 +5815,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -6357,20 +5855,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "jobserver",
-            "parallel"
-          ],
-          "selects": {}
-        },
         "deps": {
-          "common": [
-            {
-              "id": "jobserver 0.1.27",
-              "target": "jobserver"
-            }
-          ],
+          "common": [],
           "selects": {
             "cfg(unix)": [
               {
@@ -6494,7 +5980,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -6577,7 +6063,7 @@
               "target": "ciborium_ll"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -6798,13 +6284,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap 4.4.13": {
+    "clap 4.4.17": {
       "name": "clap",
-      "version": "4.4.13",
+      "version": "4.4.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/4.4.13/download",
-          "sha256": "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+          "url": "https://crates.io/api/v1/crates/clap/4.4.17/download",
+          "sha256": "80932e03c33999b9235edb8655bc9df3204adc9887c2f95b50cb1deb9fd54253"
         }
       },
       "targets": [
@@ -6843,7 +6329,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.4.12",
+              "id": "clap_builder 4.4.17",
               "target": "clap_builder"
             }
           ],
@@ -6859,7 +6345,7 @@
           ],
           "selects": {}
         },
-        "version": "4.4.13"
+        "version": "4.4.17"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6902,13 +6388,13 @@
       },
       "license": "MIT"
     },
-    "clap_builder 4.4.12": {
+    "clap_builder 4.4.17": {
       "name": "clap_builder",
-      "version": "4.4.12",
+      "version": "4.4.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_builder/4.4.12/download",
-          "sha256": "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+          "url": "https://crates.io/api/v1/crates/clap_builder/4.4.17/download",
+          "sha256": "d6c0db58c659eef1c73e444d298c27322a1b52f6927d2ad470c0c0f96fa7b8fa"
         }
       },
       "targets": [
@@ -6945,7 +6431,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstream 0.6.5",
+              "id": "anstream 0.6.7",
               "target": "anstream"
             },
             {
@@ -6968,7 +6454,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.4.12"
+        "version": "4.4.17"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7379,7 +6865,7 @@
               "target": "pretty_assertions"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -7582,7 +7068,7 @@
               "target": "crossbeam_channel"
             },
             {
-              "id": "erased-serde 0.3.31",
+              "id": "erased-serde 0.4.2",
               "target": "erased_serde"
             },
             {
@@ -7598,7 +7084,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -7628,7 +7114,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.194",
+              "id": "serde_derive 1.0.195",
               "target": "serde_derive"
             }
           ],
@@ -7803,83 +7289,6 @@
       },
       "license": "MIT"
     },
-    "cookie 0.16.2": {
-      "name": "cookie",
-      "version": "0.16.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cookie/0.16.2/download",
-          "sha256": "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "cookie",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "cookie",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "percent-encode",
-            "percent-encoding"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cookie 0.16.2",
-              "target": "build_script_build"
-            },
-            {
-              "id": "percent-encoding 2.3.1",
-              "target": "percent_encoding"
-            },
-            {
-              "id": "time 0.3.31",
-              "target": "time"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.16.2"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "core-foundation 0.9.4": {
       "name": "core-foundation",
       "version": "0.9.4",
@@ -7966,45 +7375,6 @@
         "version": "0.8.6"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "counter 0.5.7": {
-      "name": "counter",
-      "version": "0.5.7",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/counter/0.5.7/download",
-          "sha256": "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "counter",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "counter",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "num-traits 0.2.17",
-              "target": "num_traits"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.5.7"
-      },
-      "license": "MIT"
     },
     "cpufeatures 0.2.11": {
       "name": "cpufeatures",
@@ -8326,7 +7696,6 @@
           "common": [
             "crossbeam-epoch",
             "crossbeam-utils",
-            "default",
             "std"
           ],
           "selects": {}
@@ -8489,7 +7858,6 @@
         ],
         "crate_features": {
           "common": [
-            "default",
             "std"
           ],
           "selects": {}
@@ -8838,7 +8206,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -9245,7 +8613,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -9803,36 +9171,20 @@
               "target": "anyhow"
             },
             {
-              "id": "chrono 0.4.31",
-              "target": "chrono"
-            },
-            {
               "id": "colored 2.1.0",
               "target": "colored"
-            },
-            {
-              "id": "easy-parallel 3.3.1",
-              "target": "easy_parallel"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
             },
             {
               "id": "ic-base-types 0.9.0",
               "target": "ic_base_types"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
               "id": "log 0.4.20",
               "target": "log"
-            },
-            {
-              "id": "lru 0.11.1",
-              "target": "lru"
             },
             {
               "id": "rand 0.8.5",
@@ -9843,15 +9195,7 @@
               "target": "rand_seeder"
             },
             {
-              "id": "rayon 1.8.0",
-              "target": "rayon"
-            },
-            {
-              "id": "reqwest 0.11.23",
-              "target": "reqwest"
-            },
-            {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -9865,10 +9209,6 @@
             {
               "id": "tabular 0.2.0",
               "target": "tabular"
-            },
-            {
-              "id": "tokio 1.35.1",
-              "target": "tokio"
             }
           ],
           "selects": {}
@@ -10631,7 +9971,7 @@
               "target": "on_wire"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -10731,7 +10071,7 @@
               "target": "dfn_core"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -10858,13 +10198,13 @@
       },
       "license": null
     },
-    "dialoguer 0.10.4": {
+    "dialoguer 0.11.0": {
       "name": "dialoguer",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/dialoguer/0.10.4/download",
-          "sha256": "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+          "url": "https://crates.io/api/v1/crates/dialoguer/0.11.0/download",
+          "sha256": "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
         }
       },
       "targets": [
@@ -10908,14 +10248,18 @@
               "target": "tempfile"
             },
             {
+              "id": "thiserror 1.0.56",
+              "target": "thiserror"
+            },
+            {
               "id": "zeroize 1.7.0",
               "target": "zeroize"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.10.4"
+        "edition": "2021",
+        "version": "0.11.0"
       },
       "license": "MIT"
     },
@@ -11427,10 +10771,6 @@
         "deps": {
           "common": [
             {
-              "id": "actix-web 4.4.1",
-              "target": "actix_web"
-            },
-            {
               "id": "anyhow 1.0.79",
               "target": "anyhow"
             },
@@ -11439,11 +10779,7 @@
               "target": "candid"
             },
             {
-              "id": "chrono 0.4.31",
-              "target": "chrono"
-            },
-            {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
@@ -11459,7 +10795,7 @@
               "target": "cryptoki"
             },
             {
-              "id": "dialoguer 0.10.4",
+              "id": "dialoguer 0.11.0",
               "target": "dialoguer"
             },
             {
@@ -11487,10 +10823,6 @@
               "target": "futures"
             },
             {
-              "id": "ic-agent 0.27.0",
-              "target": "ic_agent"
-            },
-            {
               "id": "ic-base-types 0.9.0",
               "target": "ic_base_types"
             },
@@ -11507,27 +10839,11 @@
               "target": "ic_nns_governance"
             },
             {
-              "id": "ic-protobuf 0.9.0",
-              "target": "ic_protobuf"
-            },
-            {
-              "id": "ic-registry-keys 0.9.0",
-              "target": "ic_registry_keys"
-            },
-            {
-              "id": "ic-registry-nns-data-provider 0.9.0",
-              "target": "ic_registry_nns_data_provider"
-            },
-            {
-              "id": "ic-registry-transport 0.9.0",
-              "target": "ic_registry_transport"
-            },
-            {
               "id": "ic-sys 0.9.0",
               "target": "ic_sys"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -11543,10 +10859,6 @@
               "target": "pretty_env_logger"
             },
             {
-              "id": "prost 0.12.3",
-              "target": "prost"
-            },
-            {
               "id": "regex 1.10.2",
               "target": "regex"
             },
@@ -11555,7 +10867,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -11579,7 +10891,7 @@
               "target": "strum"
             },
             {
-              "id": "tabled 0.14.0",
+              "id": "tabled 0.15.0",
               "target": "tabled"
             },
             {
@@ -11616,10 +10928,6 @@
             {
               "id": "async-trait 0.1.77",
               "target": "async_trait"
-            },
-            {
-              "id": "strum_macros 0.25.3",
-              "target": "strum_macros"
             }
           ],
           "selects": {}
@@ -11662,36 +10970,6 @@
         "version": "1.0.16"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "easy-parallel 3.3.1": {
-      "name": "easy-parallel",
-      "version": "3.3.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/easy-parallel/3.3.1/download",
-          "sha256": "2afbb9b0aef60e4f0d2b18129b6c0dff035a6f7dbbd17c2f38c1432102ee223c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "easy_parallel",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "easy_parallel",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "3.3.1"
-      },
-      "license": "Apache-2.0 OR MIT"
     },
     "ecdsa 0.16.9": {
       "name": "ecdsa",
@@ -11819,7 +11097,7 @@
               "target": "rand_core"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -12150,92 +11428,6 @@
       },
       "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
     },
-    "enum-map 1.1.1": {
-      "name": "enum-map",
-      "version": "1.1.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/enum-map/1.1.1/download",
-          "sha256": "e893a7ba6116821058dec84a6fb14fb2a97cd8ce5fd0f85d5a4e760ecd7329d9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "enum_map",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "enum_map",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "enum-map-derive 0.6.0",
-              "target": "enum_map_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "1.1.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "enum-map-derive 0.6.0": {
-      "name": "enum-map-derive",
-      "version": "0.6.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/enum-map-derive/0.6.0/download",
-          "sha256": "84278eae0af6e34ff6c1db44c11634a694aafac559ff3080e4db4e4ac35907aa"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "enum_map_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "enum_map_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.75",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.6.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "enumflags2 0.7.8": {
       "name": "enumflags2",
       "version": "0.7.8",
@@ -12270,7 +11462,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -12467,7 +11659,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -12475,6 +11667,53 @@
         },
         "edition": "2021",
         "version": "0.3.31"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "erased-serde 0.4.2": {
+      "name": "erased-serde",
+      "version": "0.4.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/erased-serde/0.4.2/download",
+          "sha256": "55d05712b2d8d88102bc9868020c9e5c7a1f5527c452b9b97450a1d006140ba7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "erased_serde",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "erased_serde",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.195",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.2"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -12992,101 +12231,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "figment 0.10.13": {
-      "name": "figment",
-      "version": "0.10.13",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/figment/0.10.13/download",
-          "sha256": "7629b8c7bcd214a072c2c88b263b5bb3ceb54c34365d8c41c1665461aeae0993"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "figment",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "figment",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "env",
-            "parse-value",
-            "pear",
-            "serde_yaml",
-            "yaml"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "figment 0.10.13",
-              "target": "build_script_build"
-            },
-            {
-              "id": "pear 0.2.8",
-              "target": "pear"
-            },
-            {
-              "id": "serde 1.0.194",
-              "target": "serde"
-            },
-            {
-              "id": "serde_yaml 0.9.30",
-              "target": "serde_yaml"
-            },
-            {
-              "id": "uncased 0.9.9",
-              "target": "uncased"
-            }
-          ],
-          "selects": {
-            "cfg(any(target_pointer_width = \"8\", target_pointer_width = \"16\", target_pointer_width = \"32\"))": [
-              {
-                "id": "atomic 0.6.0",
-                "target": "atomic"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.10.13"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "fixedbitset 0.4.2": {
       "name": "fixedbitset",
       "version": "0.4.2",
@@ -13215,36 +12359,6 @@
         "version": "0.9.0"
       },
       "license": "MIT"
-    },
-    "float-ord 0.3.2": {
-      "name": "float-ord",
-      "version": "0.3.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/float-ord/0.3.2/download",
-          "sha256": "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "float_ord",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "float_ord",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.3.2"
-      },
-      "license": "MIT / Apache-2.0"
     },
     "fnv 1.0.7": {
       "name": "fnv",
@@ -14479,7 +13593,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -14573,7 +13687,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -14662,7 +13776,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -14738,7 +13852,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -15189,7 +14303,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.5",
+              "id": "base64 0.21.7",
               "target": "base64"
             },
             {
@@ -15405,7 +14519,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -15745,7 +14859,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -15935,7 +15049,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -16141,95 +15255,7 @@
             "tls12",
             "tokio-runtime"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "webpki-roots"
-            ],
-            "aarch64-apple-ios": [
-              "webpki-roots"
-            ],
-            "aarch64-apple-ios-sim": [
-              "webpki-roots"
-            ],
-            "aarch64-fuchsia": [
-              "webpki-roots"
-            ],
-            "aarch64-linux-android": [
-              "webpki-roots"
-            ],
-            "aarch64-pc-windows-msvc": [
-              "webpki-roots"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "webpki-roots"
-            ],
-            "arm-unknown-linux-gnueabi": [
-              "webpki-roots"
-            ],
-            "armv7-linux-androideabi": [
-              "webpki-roots"
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              "webpki-roots"
-            ],
-            "i686-apple-darwin": [
-              "webpki-roots"
-            ],
-            "i686-linux-android": [
-              "webpki-roots"
-            ],
-            "i686-pc-windows-msvc": [
-              "webpki-roots"
-            ],
-            "i686-unknown-freebsd": [
-              "webpki-roots"
-            ],
-            "i686-unknown-linux-gnu": [
-              "webpki-roots"
-            ],
-            "powerpc-unknown-linux-gnu": [
-              "webpki-roots"
-            ],
-            "riscv32imc-unknown-none-elf": [
-              "webpki-roots"
-            ],
-            "riscv64gc-unknown-none-elf": [
-              "webpki-roots"
-            ],
-            "s390x-unknown-linux-gnu": [
-              "webpki-roots"
-            ],
-            "thumbv7em-none-eabi": [
-              "webpki-roots"
-            ],
-            "thumbv8m.main-none-eabi": [
-              "webpki-roots"
-            ],
-            "x86_64-apple-darwin": [
-              "webpki-roots"
-            ],
-            "x86_64-apple-ios": [
-              "webpki-roots"
-            ],
-            "x86_64-fuchsia": [
-              "webpki-roots"
-            ],
-            "x86_64-linux-android": [
-              "webpki-roots"
-            ],
-            "x86_64-pc-windows-msvc": [
-              "webpki-roots"
-            ],
-            "x86_64-unknown-freebsd": [
-              "webpki-roots"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "webpki-roots"
-            ],
-            "x86_64-unknown-none": [
-              "webpki-roots"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -16264,10 +15290,6 @@
             {
               "id": "tokio-rustls 0.24.1",
               "target": "tokio_rustls"
-            },
-            {
-              "id": "webpki-roots 0.25.3",
-              "target": "webpki_roots"
             }
           ],
           "selects": {}
@@ -16685,165 +15707,6 @@
       },
       "license": null
     },
-    "ic-agent 0.27.0": {
-      "name": "ic-agent",
-      "version": "0.27.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ic-agent/0.27.0/download",
-          "sha256": "65c513a595191149b26e562c580616118216b66d8183fe15d87b00794893d2a9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_agent",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ic_agent",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "pem",
-            "reqwest"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "backoff 0.4.0",
-              "target": "backoff"
-            },
-            {
-              "id": "candid 0.9.11",
-              "target": "candid"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "http 0.2.11",
-              "target": "http"
-            },
-            {
-              "id": "http-body 0.4.6",
-              "target": "http_body"
-            },
-            {
-              "id": "ic-certification 0.27.0",
-              "target": "ic_certification"
-            },
-            {
-              "id": "ic-verify-bls-signature 0.1.0",
-              "target": "ic_verify_bls_signature"
-            },
-            {
-              "id": "k256 0.13.2",
-              "target": "k256"
-            },
-            {
-              "id": "leb128 0.2.5",
-              "target": "leb128"
-            },
-            {
-              "id": "pem 2.0.1",
-              "target": "pem"
-            },
-            {
-              "id": "pkcs8 0.10.2",
-              "target": "pkcs8"
-            },
-            {
-              "id": "rand 0.8.5",
-              "target": "rand"
-            },
-            {
-              "id": "reqwest 0.11.23",
-              "target": "reqwest"
-            },
-            {
-              "id": "ring 0.16.20",
-              "target": "ring"
-            },
-            {
-              "id": "sec1 0.7.3",
-              "target": "sec1"
-            },
-            {
-              "id": "serde 1.0.194",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.14",
-              "target": "serde_bytes"
-            },
-            {
-              "id": "serde_cbor 0.11.2",
-              "target": "serde_cbor"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            },
-            {
-              "id": "simple_asn1 0.6.2",
-              "target": "simple_asn1"
-            },
-            {
-              "id": "thiserror 1.0.56",
-              "target": "thiserror"
-            },
-            {
-              "id": "time 0.3.31",
-              "target": "time"
-            },
-            {
-              "id": "url 2.5.0",
-              "target": "url"
-            }
-          ],
-          "selects": {
-            "cfg(not(target_family = \"wasm\"))": [
-              {
-                "id": "rustls-webpki 0.101.7",
-                "target": "webpki"
-              },
-              {
-                "id": "tokio 1.35.1",
-                "target": "tokio"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "serde_repr 0.1.18",
-              "target": "serde_repr"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.27.0"
-      },
-      "license": "Apache-2.0"
-    },
     "ic-agent 0.30.2": {
       "name": "ic-agent",
       "version": "0.30.2",
@@ -16872,7 +15735,6 @@
         "crate_features": {
           "common": [
             "default",
-            "hyper",
             "pem",
             "reqwest"
           ],
@@ -16911,10 +15773,6 @@
             {
               "id": "http-body 0.4.6",
               "target": "http_body"
-            },
-            {
-              "id": "hyper 0.14.28",
-              "target": "hyper"
             },
             {
               "id": "ic-certification 1.3.0",
@@ -16965,7 +15823,7 @@
               "target": "sec1"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -16999,10 +15857,6 @@
           ],
           "selects": {
             "cfg(not(target_family = \"wasm\"))": [
-              {
-                "id": "hyper-rustls 0.24.2",
-                "target": "hyper_rustls"
-              },
               {
                 "id": "rustls-webpki 0.101.7",
                 "target": "webpki"
@@ -17194,7 +16048,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -17253,7 +16107,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -17315,7 +16169,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -17425,7 +16279,7 @@
               "target": "rustls"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -17578,7 +16432,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -17694,10 +16548,6 @@
               "target": "ic_ic00_types"
             },
             {
-              "id": "ic-identity-hsm 0.30.2",
-              "target": "ic_identity_hsm"
-            },
-            {
               "id": "ic-nns-common 0.9.0",
               "target": "ic_nns_common"
             },
@@ -17734,16 +16584,8 @@
               "target": "prost"
             },
             {
-              "id": "reqwest 0.11.23",
-              "target": "reqwest"
-            },
-            {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.111",
-              "target": "serde_json"
             },
             {
               "id": "sha2 0.10.8",
@@ -17804,7 +16646,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -17906,7 +16748,7 @@
               "target": "scoped_threadpool"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18023,7 +16865,7 @@
               "target": "ic0"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18087,7 +16929,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18146,7 +16988,7 @@
               "target": "ic0"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18162,65 +17004,6 @@
         },
         "edition": "2021",
         "version": "0.4.0"
-      },
-      "license": "Apache-2.0"
-    },
-    "ic-certification 0.27.0": {
-      "name": "ic-certification",
-      "version": "0.27.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ic-certification/0.27.0/download",
-          "sha256": "1120544357d4d2f7540dd5290b952c6305afe24c9620d423e2239560adca2535"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_certification",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ic_certification",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "serde",
-            "serde_bytes"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "serde 1.0.194",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.14",
-              "target": "serde_bytes"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.27.0"
       },
       "license": "Apache-2.0"
     },
@@ -18275,7 +17058,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18334,7 +17117,7 @@
               "target": "hex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18432,7 +17215,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18510,7 +17293,7 @@
               "target": "json5"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -18899,7 +17682,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -19122,7 +17905,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -19188,7 +17971,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -19332,7 +18115,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -19493,7 +18276,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -19588,7 +18371,7 @@
               "target": "phantom_newtype"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -19695,7 +18478,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -19737,7 +18520,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -19949,7 +18732,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -20007,7 +18790,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -20086,7 +18869,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -20376,7 +19159,7 @@
               "target": "ic_utils"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -20463,7 +19246,7 @@
               "target": "prometheus"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -20553,7 +19336,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -20660,7 +19443,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -20787,7 +19570,7 @@
               "target": "scopeguard"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -20940,7 +19723,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -21038,7 +19821,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -21048,65 +19831,6 @@
         "version": "0.1.0"
       },
       "license": null
-    },
-    "ic-identity-hsm 0.30.2": {
-      "name": "ic-identity-hsm",
-      "version": "0.30.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ic-identity-hsm/0.30.2/download",
-          "sha256": "bb5a52d46a3e011a0febff1ba9cb2382acf86d68a69a2aac2eb7ed6bef9a8e28"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_identity_hsm",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ic_identity_hsm",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "ic-agent 0.30.2",
-              "target": "ic_agent"
-            },
-            {
-              "id": "pkcs11 0.5.0",
-              "target": "pkcs11"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            },
-            {
-              "id": "simple_asn1 0.6.2",
-              "target": "simple_asn1"
-            },
-            {
-              "id": "thiserror 1.0.56",
-              "target": "thiserror"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.30.2"
-      },
-      "license": "Apache-2.0"
     },
     "ic-interfaces 0.9.0": {
       "name": "ic-interfaces",
@@ -21199,7 +19923,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -21274,7 +19998,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -21406,7 +20130,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -21469,7 +20193,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -21523,7 +20247,7 @@
               "target": "hex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -21581,7 +20305,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -21643,10 +20367,6 @@
               "target": "anyhow"
             },
             {
-              "id": "async-timer 0.7.4",
-              "target": "async_timer"
-            },
-            {
               "id": "backon 0.4.1",
               "target": "backon"
             },
@@ -21657,10 +20377,6 @@
             {
               "id": "chrono 0.4.31",
               "target": "chrono"
-            },
-            {
-              "id": "counter 0.5.7",
-              "target": "counter"
             },
             {
               "id": "csv 1.3.0",
@@ -21683,14 +20399,6 @@
               "target": "dotenv"
             },
             {
-              "id": "either 1.9.0",
-              "target": "either"
-            },
-            {
-              "id": "enum-map 1.1.1",
-              "target": "enum_map"
-            },
-            {
               "id": "env_logger 0.10.1",
               "target": "env_logger"
             },
@@ -21699,20 +20407,12 @@
               "target": "exitcode"
             },
             {
-              "id": "float-ord 0.3.2",
-              "target": "float_ord"
-            },
-            {
               "id": "fs2 0.4.3",
               "target": "fs2"
             },
             {
               "id": "futures 0.3.30",
               "target": "futures"
-            },
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
             },
             {
               "id": "futures-util 0.3.30",
@@ -21727,11 +20427,7 @@
               "target": "hyper"
             },
             {
-              "id": "hyper-tls 0.5.0",
-              "target": "hyper_tls"
-            },
-            {
-              "id": "ic-agent 0.27.0",
+              "id": "ic-agent 0.30.2",
               "target": "ic_agent"
             },
             {
@@ -21741,10 +20437,6 @@
             {
               "id": "ic-interfaces-registry 0.9.0",
               "target": "ic_interfaces_registry"
-            },
-            {
-              "id": "ic-nns-common 0.9.0",
-              "target": "ic_nns_common"
             },
             {
               "id": "ic-nns-constants 0.9.0",
@@ -21799,7 +20491,7 @@
               "target": "ic_types"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -21811,20 +20503,8 @@
               "target": "log"
             },
             {
-              "id": "phantom_newtype 0.9.0",
-              "target": "phantom_newtype"
-            },
-            {
               "id": "prometheus-http-query 0.4.2",
               "target": "prometheus_http_query"
-            },
-            {
-              "id": "prost 0.12.3",
-              "target": "prost"
-            },
-            {
-              "id": "rand 0.8.5",
-              "target": "rand"
             },
             {
               "id": "regex 1.10.2",
@@ -21839,11 +20519,7 @@
               "target": "reqwest"
             },
             {
-              "id": "reverse_geocoder 3.0.1",
-              "target": "reverse_geocoder"
-            },
-            {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -21865,10 +20541,6 @@
             {
               "id": "url 2.5.0",
               "target": "url"
-            },
-            {
-              "id": "urlencoding 2.1.3",
-              "target": "urlencoding"
             }
           ],
           "selects": {}
@@ -21896,10 +20568,6 @@
             {
               "id": "async-trait 0.1.77",
               "target": "async_trait"
-            },
-            {
-              "id": "derive_more 0.99.17",
-              "target": "derive_more"
             },
             {
               "id": "strum_macros 0.25.3",
@@ -21951,12 +20619,8 @@
               "target": "chrono"
             },
             {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
-            },
-            {
-              "id": "float-cmp 0.9.0",
-              "target": "float_cmp"
             },
             {
               "id": "ic-base-types 0.9.0",
@@ -21975,10 +20639,6 @@
               "target": "ic_types"
             },
             {
-              "id": "itertools 0.11.0",
-              "target": "itertools"
-            },
-            {
               "id": "registry-canister 0.9.0",
               "target": "registry_canister"
             },
@@ -21987,7 +20647,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -22193,7 +20853,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -22373,7 +21033,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -22611,7 +21271,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -22751,7 +21411,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -22885,7 +21545,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -23004,7 +21664,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -23285,7 +21945,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -23438,7 +22098,7 @@
               "target": "ic_nns_constants"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -23509,7 +22169,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -23823,7 +22483,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -24078,7 +22738,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -24186,7 +22846,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -24240,7 +22900,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -24290,7 +22950,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -24365,7 +23025,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -24539,7 +23199,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -24755,7 +23415,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -24916,7 +23576,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -25043,7 +23703,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -25229,7 +23889,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -25390,7 +24050,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -25554,7 +24214,7 @@
               "target": "leb128"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -25583,36 +24243,6 @@
           "selects": {}
         },
         "version": "0.30.2"
-      },
-      "license": "Apache-2.0"
-    },
-    "ic-types 0.7.0": {
-      "name": "ic-types",
-      "version": "0.7.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ic-types/0.7.0/download",
-          "sha256": "95af86c6e40ea8a850c64914024762a0b91a2a6d438b412d8f4a7fc010e72519"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_types",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ic_types",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.7.0"
       },
       "license": "Apache-2.0"
     },
@@ -25719,7 +24349,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -25822,7 +24452,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -25905,7 +24535,7 @@
               "target": "scoped_threadpool"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -26047,7 +24677,7 @@
               "target": "ic_utils"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -26090,7 +24720,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -26306,7 +24936,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -26381,7 +25011,7 @@
               "target": "icrc_ledger_types"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -26456,7 +25086,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -26796,36 +25426,6 @@
       },
       "license": "MIT"
     },
-    "inlinable_string 0.1.15": {
-      "name": "inlinable_string",
-      "version": "0.1.15",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/inlinable_string/0.1.15/download",
-          "sha256": "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "inlinable_string",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "inlinable_string",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.1.15"
-      },
-      "license": "Apache-2.0/MIT"
-    },
     "instant 0.1.12": {
       "name": "instant",
       "version": "0.1.12",
@@ -27064,7 +25664,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -27153,9 +25753,7 @@
         ],
         "crate_features": {
           "common": [
-            "default",
-            "use_alloc",
-            "use_std"
+            "use_alloc"
           ],
           "selects": {}
         },
@@ -27250,47 +25848,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "jobserver 0.1.27": {
-      "name": "jobserver",
-      "version": "0.1.27",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/jobserver/0.1.27/download",
-          "sha256": "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "jobserver",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "jobserver",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.151",
-                "target": "libc"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.1.27"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "js-sys 0.3.66": {
       "name": "js-sys",
       "version": "0.3.66",
@@ -27362,7 +25919,7 @@
               "target": "pest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -27590,45 +26147,6 @@
         },
         "edition": "2021",
         "version": "2.3.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "kiddo 0.2.5": {
-      "name": "kiddo",
-      "version": "0.2.5",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/kiddo/0.2.5/download",
-          "sha256": "06ced2e69cfc5f22f86ccc9ce4ecff9f19917f3083a4bac0f402bdab034d73f1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "kiddo",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "kiddo",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "num-traits 0.2.17",
-              "target": "num_traits"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.2.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -28608,7 +27126,7 @@
               "target": "anyhow"
             },
             {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
@@ -28624,7 +27142,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -28792,52 +27310,6 @@
         "version": "0.13.0"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "lru 0.11.1": {
-      "name": "lru",
-      "version": "0.11.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/lru/0.11.1/download",
-          "sha256": "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lru",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "lru",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "hashbrown"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "hashbrown 0.14.3",
-              "target": "hashbrown"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.11.1"
-      },
-      "license": "MIT"
     },
     "lzma-sys 0.1.20": {
       "name": "lzma-sys",
@@ -29778,11 +28250,11 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.13.1",
+              "id": "base64 0.21.7",
               "target": "base64"
             },
             {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
@@ -29794,7 +28266,7 @@
               "target": "crossbeam_channel"
             },
             {
-              "id": "erased-serde 0.3.31",
+              "id": "erased-serde 0.4.2",
               "target": "erased_serde"
             },
             {
@@ -29830,7 +28302,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -29882,7 +28354,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
@@ -29968,7 +28440,7 @@
         "deps": {
           "common": [
             {
-              "id": "erased-serde 0.3.31",
+              "id": "erased-serde 0.4.2",
               "target": "erased_serde"
             },
             {
@@ -29980,11 +28452,11 @@
               "target": "regex"
             },
             {
-              "id": "ring 0.16.20",
+              "id": "ring 0.17.7",
               "target": "ring"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -30314,7 +28786,7 @@
               "target": "anyhow"
             },
             {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
@@ -30471,36 +28943,12 @@
         "deps": {
           "common": [
             {
-              "id": "actix 0.13.1",
-              "target": "actix"
-            },
-            {
               "id": "actix-web 4.4.1",
               "target": "actix_web"
             },
             {
               "id": "anyhow 1.0.79",
               "target": "anyhow"
-            },
-            {
-              "id": "chrono 0.4.31",
-              "target": "chrono"
-            },
-            {
-              "id": "figment 0.10.13",
-              "target": "figment"
-            },
-            {
-              "id": "ic-interfaces-registry 0.9.0",
-              "target": "ic_interfaces_registry"
-            },
-            {
-              "id": "ic-registry-client-helpers 0.9.0",
-              "target": "ic_registry_client_helpers"
-            },
-            {
-              "id": "ic-registry-local-registry 0.9.0",
-              "target": "ic_registry_local_registry"
             },
             {
               "id": "ic-types 0.9.0",
@@ -30515,7 +28963,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -30826,7 +29274,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -30931,7 +29379,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -31598,7 +30046,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -32317,13 +30765,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "papergrid 0.10.0": {
+    "papergrid 0.11.0": {
       "name": "papergrid",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/papergrid/0.10.0/download",
-          "sha256": "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
+          "url": "https://crates.io/api/v1/crates/papergrid/0.11.0/download",
+          "sha256": "9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb"
         }
       },
       "targets": [
@@ -32366,7 +30814,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.0"
+        "version": "0.11.0"
       },
       "license": "MIT"
     },
@@ -32582,117 +31030,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "pear 0.2.8": {
-      "name": "pear",
-      "version": "0.2.8",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/pear/0.2.8/download",
-          "sha256": "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pear",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "pear",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "color",
-            "default",
-            "yansi"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "inlinable_string 0.1.15",
-              "target": "inlinable_string"
-            },
-            {
-              "id": "yansi 1.0.0-rc.1",
-              "target": "yansi"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "pear_codegen 0.2.8",
-              "target": "pear_codegen"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.2.8"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "pear_codegen 0.2.8": {
-      "name": "pear_codegen",
-      "version": "0.2.8",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/pear_codegen/0.2.8/download",
-          "sha256": "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "pear_codegen",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "pear_codegen",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.75",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "proc-macro2-diagnostics 0.10.1",
-              "target": "proc_macro2_diagnostics"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.48",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.2.8"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "pem 1.1.1": {
       "name": "pem",
       "version": "1.1.1",
@@ -32767,7 +31104,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.5",
+              "id": "base64 0.21.7",
               "target": "base64"
             }
           ],
@@ -33154,7 +31491,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -34646,92 +32983,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2-diagnostics 0.10.1": {
-      "name": "proc-macro2-diagnostics",
-      "version": "0.10.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2-diagnostics/0.10.1/download",
-          "sha256": "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "proc_macro2_diagnostics",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "proc_macro2_diagnostics",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "colors",
-            "default",
-            "yansi"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.75",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "proc-macro2-diagnostics 0.10.1",
-              "target": "build_script_build"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.48",
-              "target": "syn"
-            },
-            {
-              "id": "yansi 1.0.0-rc.1",
-              "target": "yansi"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.10.1"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "procfs 0.14.2": {
       "name": "procfs",
       "version": "0.14.2",
@@ -34983,20 +33234,16 @@
               "target": "anyhow"
             },
             {
-              "id": "base64 0.13.1",
+              "id": "base64 0.21.7",
               "target": "base64"
             },
             {
-              "id": "clap 3.2.25",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
               "id": "crossbeam 0.8.3",
               "target": "crossbeam"
-            },
-            {
-              "id": "crossbeam-channel 0.5.10",
-              "target": "crossbeam_channel"
             },
             {
               "id": "futures-util 0.3.30",
@@ -35035,7 +33282,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -35102,7 +33349,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -35167,7 +33414,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -36178,111 +34425,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "rayon 1.8.0": {
-      "name": "rayon",
-      "version": "1.8.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/rayon/1.8.0/download",
-          "sha256": "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rayon",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "rayon",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "either 1.9.0",
-              "target": "either"
-            },
-            {
-              "id": "rayon-core 1.12.0",
-              "target": "rayon_core"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.8.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "rayon-core 1.12.0": {
-      "name": "rayon-core",
-      "version": "1.12.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/rayon-core/1.12.0/download",
-          "sha256": "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rayon_core",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "rayon_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "crossbeam-deque 0.8.4",
-              "target": "crossbeam_deque"
-            },
-            {
-              "id": "crossbeam-utils 0.8.18",
-              "target": "crossbeam_utils"
-            },
-            {
-              "id": "rayon-core 1.12.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.12.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "links": "rayon-core"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "redox_syscall 0.4.1": {
       "name": "redox_syscall",
       "version": "0.4.1",
@@ -36863,7 +35005,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -36997,8 +35139,6 @@
             "hyper-rustls",
             "hyper-tls",
             "json",
-            "mime_guess",
-            "multipart",
             "native-tls-crate",
             "rustls",
             "rustls-pemfile",
@@ -37017,7 +35157,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.5",
+              "id": "base64 0.21.7",
               "target": "base64"
             },
             {
@@ -37037,11 +35177,7 @@
               "target": "http"
             },
             {
-              "id": "mime_guess 2.0.4",
-              "target": "mime_guess"
-            },
-            {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -37262,62 +35398,6 @@
         "version": "2.0.0"
       },
       "license": "MIT"
-    },
-    "reverse_geocoder 3.0.1": {
-      "name": "reverse_geocoder",
-      "version": "3.0.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/reverse_geocoder/3.0.1/download",
-          "sha256": "1c7cb9a3269abd8896c527042bd635f05531e18be7d5de1eb71c501027c51423"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "reverse_geocoder",
-            "crate_root": "src/reverse_geocoder.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "reverse_geocoder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "csv 1.3.0",
-              "target": "csv"
-            },
-            {
-              "id": "kiddo 0.2.5",
-              "target": "kiddo"
-            },
-            {
-              "id": "serde 1.0.194",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "serde_derive 1.0.194",
-              "target": "serde_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "3.0.1"
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "rfc6979 0.4.0": {
       "name": "rfc6979",
@@ -37750,7 +35830,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -38418,7 +36498,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.5",
+              "id": "base64 0.21.7",
               "target": "base64"
             }
           ],
@@ -38912,7 +36992,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -39092,7 +37172,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -39108,13 +37188,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.194": {
+    "serde 1.0.195": {
       "name": "serde",
-      "version": "1.0.194",
+      "version": "1.0.195",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.194/download",
-          "sha256": "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.195/download",
+          "sha256": "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
         }
       },
       "targets": [
@@ -39147,7 +37227,6 @@
             "alloc",
             "default",
             "derive",
-            "rc",
             "serde_derive",
             "std"
           ],
@@ -39156,7 +37235,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "build_script_build"
             }
           ],
@@ -39166,13 +37245,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.194",
+              "id": "serde_derive 1.0.195",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.194"
+        "version": "1.0.195"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -39216,7 +37295,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -39266,7 +37345,7 @@
               "target": "half"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -39277,13 +37356,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "serde_derive 1.0.194": {
+    "serde_derive 1.0.195": {
       "name": "serde_derive",
-      "version": "1.0.194",
+      "version": "1.0.195",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.194/download",
-          "sha256": "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.195/download",
+          "sha256": "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
         }
       },
       "targets": [
@@ -39326,7 +37405,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.194"
+        "version": "1.0.195"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -39383,7 +37462,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -39441,7 +37520,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -39535,7 +37614,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -39590,7 +37669,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -39637,7 +37716,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -39744,7 +37823,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -39799,7 +37878,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -39925,7 +38004,7 @@
               "target": "registry_canister"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -40535,7 +38614,7 @@
               "target": "futures"
             },
             {
-              "id": "ic-agent 0.27.0",
+              "id": "ic-agent 0.30.2",
               "target": "ic_agent"
             },
             {
@@ -40551,11 +38630,7 @@
               "target": "ic_nns_governance"
             },
             {
-              "id": "ic-types 0.7.0",
-              "target": "ic_types"
-            },
-            {
-              "id": "itertools 0.11.0",
+              "id": "itertools 0.12.0",
               "target": "itertools"
             },
             {
@@ -40565,10 +38640,6 @@
             {
               "id": "log 0.4.20",
               "target": "log"
-            },
-            {
-              "id": "prost 0.12.3",
-              "target": "prost"
             },
             {
               "id": "regex 1.10.2",
@@ -40587,7 +38658,7 @@
               "target": "retry"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -40599,10 +38670,6 @@
               "target": "serde_yaml"
             },
             {
-              "id": "strum 0.25.0",
-              "target": "strum"
-            },
-            {
               "id": "tokio 1.35.1",
               "target": "tokio"
             }
@@ -40610,15 +38677,6 @@
           "selects": {}
         },
         "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "strum_macros 0.25.3",
-              "target": "strum_macros"
-            }
-          ],
-          "selects": {}
-        },
         "version": "0.1.0"
       },
       "license": null
@@ -40808,7 +38866,7 @@
               "target": "erased_serde"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -41051,7 +39109,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.4.13",
+              "id": "clap 4.4.17",
               "target": "clap"
             },
             {
@@ -41075,10 +39133,6 @@
               "target": "ic_async_utils"
             },
             {
-              "id": "ic-types 0.9.0",
-              "target": "ic_types"
-            },
-            {
               "id": "regex 1.10.2",
               "target": "regex"
             },
@@ -41087,7 +39141,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -42336,13 +40390,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "tabled 0.14.0": {
+    "tabled 0.15.0": {
       "name": "tabled",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tabled/0.14.0/download",
-          "sha256": "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
+          "url": "https://crates.io/api/v1/crates/tabled/0.15.0/download",
+          "sha256": "4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e"
         }
       },
       "targets": [
@@ -42374,7 +40428,7 @@
         "deps": {
           "common": [
             {
-              "id": "papergrid 0.10.0",
+              "id": "papergrid 0.11.0",
               "target": "papergrid"
             },
             {
@@ -42388,23 +40442,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tabled_derive 0.6.0",
+              "id": "tabled_derive 0.7.0",
               "target": "tabled_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.14.0"
+        "version": "0.15.0"
       },
       "license": "MIT"
     },
-    "tabled_derive 0.6.0": {
+    "tabled_derive 0.7.0": {
       "name": "tabled_derive",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tabled_derive/0.6.0/download",
-          "sha256": "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+          "url": "https://crates.io/api/v1/crates/tabled_derive/0.7.0/download",
+          "sha256": "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
         }
       },
       "targets": [
@@ -42449,7 +40503,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.0"
+        "version": "0.7.0"
       },
       "license": "MIT"
     },
@@ -44152,7 +42206,7 @@
               "target": "axum"
             },
             {
-              "id": "base64 0.21.5",
+              "id": "base64 0.21.7",
               "target": "base64"
             },
             {
@@ -44836,7 +42890,7 @@
               "target": "leb128"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -45142,75 +43196,6 @@
         "version": "1.1.0"
       },
       "license": "MIT"
-    },
-    "uncased 0.9.9": {
-      "name": "uncased",
-      "version": "0.9.9",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/uncased/0.9.9/download",
-          "sha256": "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "uncased",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "uncased",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "uncased 0.9.9",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.9.9"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT OR Apache-2.0"
     },
     "unicase 2.7.0": {
       "name": "unicase",
@@ -45664,7 +43649,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -45674,36 +43659,6 @@
         "version": "2.5.0"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "urlencoding 2.1.3": {
-      "name": "urlencoding",
-      "version": "2.1.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/urlencoding/2.1.3/download",
-          "sha256": "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "urlencoding",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "urlencoding",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "2.1.3"
-      },
-      "license": "MIT"
     },
     "utf-8 0.7.6": {
       "name": "utf-8",
@@ -45844,7 +43799,7 @@
               "target": "getrandom"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             }
           ],
@@ -46161,7 +44116,7 @@
               "target": "scoped_tls"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -46902,7 +44857,6 @@
             "shlobj",
             "std",
             "sysinfoapi",
-            "threadpoolapiset",
             "winbase",
             "wincon",
             "winerror",
@@ -48806,7 +46760,7 @@
               "target": "assert_json_diff"
             },
             {
-              "id": "base64 0.21.5",
+              "id": "base64 0.21.7",
               "target": "base64"
             },
             {
@@ -48842,7 +46796,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -49252,44 +47206,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "yansi 1.0.0-rc.1": {
-      "name": "yansi",
-      "version": "1.0.0-rc.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/yansi/1.0.0-rc.1/download",
-          "sha256": "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "yansi",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "yansi",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.0.0-rc.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "zbus 3.14.1": {
       "name": "zbus",
       "version": "3.14.1",
@@ -49397,7 +47313,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -49567,7 +47483,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -49774,204 +47690,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "zstd 0.13.0": {
-      "name": "zstd",
-      "version": "0.13.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/zstd/0.13.0/download",
-          "sha256": "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "zstd",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "zstd",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "arrays",
-            "default",
-            "legacy",
-            "zdict_builder"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "zstd-safe 7.0.0",
-              "target": "zstd_safe"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.13.0"
-      },
-      "license": "MIT"
-    },
-    "zstd-safe 7.0.0": {
-      "name": "zstd-safe",
-      "version": "7.0.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/zstd-safe/7.0.0/download",
-          "sha256": "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "zstd_safe",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "zstd_safe",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "arrays",
-            "legacy",
-            "std",
-            "zdict_builder"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "zstd-safe 7.0.0",
-              "target": "build_script_build"
-            },
-            {
-              "id": "zstd-sys 2.0.9+zstd.1.5.5",
-              "target": "zstd_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "7.0.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "link_deps": {
-          "common": [
-            {
-              "id": "zstd-sys 2.0.9+zstd.1.5.5",
-              "target": "zstd_sys"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "zstd-sys 2.0.9+zstd.1.5.5": {
-      "name": "zstd-sys",
-      "version": "2.0.9+zstd.1.5.5",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/zstd-sys/2.0.9+zstd.1.5.5/download",
-          "sha256": "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "zstd_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "zstd_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "legacy",
-            "std",
-            "zdict_builder"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "zstd-sys 2.0.9+zstd.1.5.5",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.0.9+zstd.1.5.5"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cc 1.0.83",
-              "target": "cc"
-            },
-            {
-              "id": "pkg-config 0.3.28",
-              "target": "pkg_config"
-            }
-          ],
-          "selects": {}
-        },
-        "links": "zstd"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "zvariant 3.15.0": {
       "name": "zvariant",
       "version": "3.15.0",
@@ -50018,7 +47736,7 @@
               "target": "libc"
             },
             {
-              "id": "serde 1.0.194",
+              "id": "serde 1.0.195",
               "target": "serde"
             },
             {
@@ -50445,10 +48163,6 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-none"
     ],
-    "cfg(any(target_arch = \"wasm32\"))": [
-      "wasm32-unknown-unknown",
-      "wasm32-wasi"
-    ],
     "cfg(any(target_arch = \"x86\", target_arch = \"x86_64\", all(any(target_arch = \"aarch64\", target_arch = \"arm\"), any(target_os = \"android\", target_os = \"fuchsia\", target_os = \"linux\"))))": [
       "aarch64-fuchsia",
       "aarch64-linux-android",
@@ -50531,45 +48245,6 @@
       "x86_64-apple-darwin",
       "x86_64-apple-ios",
       "x86_64-unknown-freebsd"
-    ],
-    "cfg(any(target_os = \"macos\", target_os = \"ios\", unix))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-unknown-linux-gnu",
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "s390x-unknown-linux-gnu",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
-    ],
-    "cfg(any(target_pointer_width = \"8\", target_pointer_width = \"16\", target_pointer_width = \"32\"))": [
-      "arm-unknown-linux-gnueabi",
-      "armv7-linux-androideabi",
-      "armv7-unknown-linux-gnueabi",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
-      "powerpc-unknown-linux-gnu",
-      "riscv32imc-unknown-none-elf",
-      "thumbv7em-none-eabi",
-      "thumbv8m.main-none-eabi",
-      "wasm32-unknown-unknown",
-      "wasm32-wasi"
     ],
     "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
       "aarch64-apple-darwin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,6 @@
 version = 3
 
 [[package]]
-name = "actix"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba56612922b907719d4a01cf11c8d5b458e7d3dba946d0435f20f58d6795ed2"
-dependencies = [
- "actix-macros",
- "actix-rt",
- "actix_derive",
- "bitflags 2.4.1",
- "bytes",
- "crossbeam-channel",
- "futures-core",
- "futures-sink",
- "futures-task",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "actix-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,16 +30,14 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash 0.8.7",
- "base64 0.21.5",
+ "base64 0.21.7",
  "bitflags 2.4.1",
- "brotli",
  "bytes",
  "bytestring",
  "derive_more 0.99.17",
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
  "http",
  "httparse",
  "httpdate",
@@ -80,7 +53,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -174,7 +146,6 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
  "derive_more 0.99.17",
  "encoding_rs",
  "futures-core",
@@ -202,17 +173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
 dependencies = [
  "actix-router",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "actix_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -279,21 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -650,17 +595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
-name = "async-timer"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5fa6ed76cb2aa820707b4eb9ec46f42da9ce70b0eafab5e5e34942b38a44d5"
-dependencies = [
- "libc",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,15 +603,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "atomic"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -809,9 +734,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -985,27 +910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,12 +1033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
-name = "bytemuck"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,7 +1135,7 @@ name = "canister-log-fetcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.4.13",
+ "clap 4.4.17",
  "humantime",
  "log",
  "pretty_env_logger",
@@ -1276,7 +1174,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -1362,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.13"
+version = "4.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+checksum = "80932e03c33999b9235edb8655bc9df3204adc9887c2f95b50cb1deb9fd54253"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.7",
@@ -1381,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "d6c0db58c659eef1c73e444d298c27322a1b52f6927d2ad470c0c0f96fa7b8fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1522,8 +1419,8 @@ version = "0.1.0"
 dependencies = [
  "crossbeam",
  "crossbeam-channel",
- "erased-serde",
- "ic-types 0.9.0",
+ "erased-serde 0.4.2",
+ "ic-types",
  "ic-utils 0.9.0",
  "regex",
  "serde",
@@ -1571,17 +1468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,15 +1482,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "counter"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1837,7 +1714,7 @@ dependencies = [
  "ic-nns-common",
  "ic-nns-constants",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-xrc-types",
  "icp-ledger",
  "icrc-ledger-types",
@@ -1848,7 +1725,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "sha2 0.9.9",
- "yansi 0.5.1",
+ "yansi",
 ]
 
 [[package]]
@@ -1954,27 +1831,20 @@ dependencies = [
  "ahash 0.8.7",
  "anyhow",
  "async-trait",
- "chrono",
  "colored",
- "easy-parallel",
- "futures-util",
  "ic-base-types",
  "ic-management-types",
  "include_dir",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "log",
- "lru",
  "rand 0.8.5",
  "rand_seeder",
- "rayon",
  "regex",
- "reqwest",
  "serde",
  "serde_json",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tabular",
- "tokio",
 ]
 
 [[package]]
@@ -2165,13 +2035,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
  "shell-words",
  "tempfile",
+ "thiserror",
  "zeroize",
 ]
 
@@ -2277,12 +2148,10 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 name = "dre"
 version = "0.1.0"
 dependencies = [
- "actix-web",
  "anyhow",
  "async-trait",
  "candid",
- "chrono",
- "clap 4.4.13",
+ "clap 4.4.17",
  "clap-num",
  "colored",
  "cryptoki",
@@ -2293,7 +2162,6 @@ dependencies = [
  "edit",
  "flate2",
  "futures",
- "ic-agent 0.27.0",
  "ic-base-types",
  "ic-canister-client",
  "ic-canisters",
@@ -2301,16 +2169,11 @@ dependencies = [
  "ic-management-types",
  "ic-nns-constants",
  "ic-nns-governance",
- "ic-protobuf",
- "ic-registry-keys",
- "ic-registry-nns-data-provider",
- "ic-registry-transport",
  "ic-sys",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "keyring",
  "log",
  "pretty_env_logger",
- "prost",
  "regex",
  "reqwest",
  "serde",
@@ -2319,7 +2182,6 @@ dependencies = [
  "socket2 0.5.5",
  "spinners",
  "strum 0.25.0",
- "strum_macros 0.25.3",
  "tabled",
  "tabular",
  "tempfile",
@@ -2333,12 +2195,6 @@ name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
-
-[[package]]
-name = "easy-parallel"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afbb9b0aef60e4f0d2b18129b6c0dff035a6f7dbbd17c2f38c1432102ee223c"
 
 [[package]]
 name = "ecdsa"
@@ -2430,26 +2286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-map"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e893a7ba6116821058dec84a6fb14fb2a97cd8ce5fd0f85d5a4e760ecd7329d9"
-dependencies = [
- "enum-map-derive",
-]
-
-[[package]]
-name = "enum-map-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84278eae0af6e34ff6c1db44c11634a694aafac559ff3080e4db4e4ac35907aa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2330,15 @@ name = "erased-serde"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d05712b2d8d88102bc9868020c9e5c7a1f5527c452b9b97450a1d006140ba7"
 dependencies = [
  "serde",
 ]
@@ -2601,20 +2446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "figment"
-version = "0.10.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7629b8c7bcd214a072c2c88b263b5bb3ceb54c34365d8c41c1665461aeae0993"
-dependencies = [
- "atomic",
- "pear",
- "serde",
- "serde_yaml 0.9.30",
- "uncased",
- "version_check",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,12 +2469,6 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "float-ord"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "fnv"
@@ -3031,7 +2856,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "bytes",
  "headers-core",
  "http",
@@ -3233,7 +3058,6 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3313,41 +3137,6 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c513a595191149b26e562c580616118216b66d8183fe15d87b00794893d2a9"
-dependencies = [
- "backoff",
- "candid",
- "futures-util",
- "hex",
- "http",
- "http-body",
- "ic-certification 0.27.0",
- "ic-verify-bls-signature",
- "k256",
- "leb128",
- "pem 2.0.1",
- "pkcs8",
- "rand 0.8.5",
- "reqwest",
- "ring 0.16.20",
- "rustls-webpki",
- "sec1",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "serde_repr",
- "sha2 0.10.8",
- "simple_asn1",
- "thiserror",
- "time",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "ic-agent"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "263d5c7b295ba69eac0692e6f6b35a01ca323889d10612c0f8c8fd223b0bfec5"
@@ -3360,8 +3149,6 @@ dependencies = [
  "hex",
  "http",
  "http-body",
- "hyper",
- "hyper-rustls",
  "ic-certification 1.3.0",
  "ic-transport-types",
  "ic-verify-bls-signature",
@@ -3399,7 +3186,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hyper",
- "ic-types 0.9.0",
+ "ic-types",
  "slog",
  "tokio",
  "tonic",
@@ -3468,7 +3255,7 @@ dependencies = [
  "ic-crypto-utils-threshold-sig-der",
  "ic-ic00-types",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "itertools 0.12.0",
  "prost",
  "rustls",
@@ -3492,7 +3279,7 @@ dependencies = [
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
  "ic-crypto-utils-basic-sig",
- "ic-types 0.9.0",
+ "ic-types",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "simple_asn1",
@@ -3523,12 +3310,11 @@ dependencies = [
  "backoff",
  "candid",
  "hex",
- "ic-agent 0.30.2",
+ "ic-agent",
  "ic-base-types",
  "ic-canister-client",
  "ic-canister-client-sender",
  "ic-ic00-types",
- "ic-identity-hsm",
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-governance",
@@ -3538,9 +3324,7 @@ dependencies = [
  "ic-utils 0.30.2",
  "pkcs11",
  "prost",
- "reqwest",
  "serde",
- "serde_json",
  "sha2 0.10.8",
  "simple_asn1",
  "thiserror",
@@ -3571,7 +3355,7 @@ dependencies = [
  "ic-registry-routing-table",
  "ic-registry-subnet-type",
  "ic-replicated-state",
- "ic-types 0.9.0",
+ "ic-types",
  "itertools 0.12.0",
  "leb128",
  "phantom_newtype",
@@ -3644,22 +3428,10 @@ dependencies = [
  "ic-crypto-tree-hash",
  "ic-crypto-utils-threshold-sig",
  "ic-crypto-utils-threshold-sig-der",
- "ic-types 0.9.0",
+ "ic-types",
  "serde",
  "serde_cbor",
  "tree-deserializer",
-]
-
-[[package]]
-name = "ic-certification"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1120544357d4d2f7540dd5290b952c6305afe24c9620d423e2239560adca2535"
-dependencies = [
- "hex",
- "serde",
- "serde_bytes",
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3704,7 +3476,7 @@ dependencies = [
  "ic-protobuf",
  "ic-registry-subnet-type",
  "ic-sys",
- "ic-types 0.9.0",
+ "ic-types",
  "json5",
  "serde",
  "slog",
@@ -3752,7 +3524,7 @@ name = "ic-crypto-interfaces-sig-verification"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b0915931003b7eca#4b3b2ce76c4bde0c1c60fb80b0915931003b7eca"
 dependencies = [
- "ic-types 0.9.0",
+ "ic-types",
 ]
 
 [[package]]
@@ -3761,7 +3533,7 @@ version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b0915931003b7eca#4b3b2ce76c4bde0c1c60fb80b0915931003b7eca"
 dependencies = [
  "hex",
- "ic-types 0.9.0",
+ "ic-types",
  "simple_asn1",
  "zeroize",
 ]
@@ -3780,7 +3552,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3827,7 +3599,7 @@ dependencies = [
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3841,7 +3613,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b091
 dependencies = [
  "hex",
  "ic-crypto-sha2",
- "ic-types 0.9.0",
+ "ic-types",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3870,7 +3642,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
- "ic-types 0.9.0",
+ "ic-types",
  "lazy_static",
  "parking_lot",
  "rand 0.8.5",
@@ -3904,7 +3676,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
- "ic-types 0.9.0",
+ "ic-types",
  "k256",
  "lazy_static",
  "p256",
@@ -3951,7 +3723,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-tls-cert-validation",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "serde",
 ]
 
@@ -3979,7 +3751,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b091
 dependencies = [
  "hex",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
 ]
 
 [[package]]
@@ -4002,7 +3774,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-test-utils-reproducible-rng",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "serde",
  "x509-parser 0.14.0",
 ]
@@ -4015,7 +3787,7 @@ dependencies = [
  "async-trait",
  "ic-crypto-sha2",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "serde",
  "tokio",
  "tokio-rustls",
@@ -4058,7 +3830,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b091
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
- "ic-types 0.9.0",
+ "ic-types",
  "serde_cbor",
 ]
 
@@ -4070,7 +3842,7 @@ dependencies = [
  "base64 0.13.1",
  "ic-crypto-internal-threshold-sig-bls12381",
  "ic-crypto-internal-types",
- "ic-types 0.9.0",
+ "ic-types",
 ]
 
 [[package]]
@@ -4082,7 +3854,7 @@ dependencies = [
  "ic-crypto-internal-threshold-sig-bls12381",
  "ic-crypto-internal-threshold-sig-bls12381-der",
  "ic-crypto-internal-types",
- "ic-types 0.9.0",
+ "ic-types",
 ]
 
 [[package]]
@@ -4107,7 +3879,7 @@ dependencies = [
  "ic-crypto-tls-interfaces",
  "ic-interfaces-registry",
  "ic-metrics",
- "ic-types 0.9.0",
+ "ic-types",
  "prometheus",
  "serde",
  "slog",
@@ -4224,20 +3996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-identity-hsm"
-version = "0.30.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5a52d46a3e011a0febff1ba9cb2382acf86d68a69a2aac2eb7ed6bef9a8e28"
-dependencies = [
- "hex",
- "ic-agent 0.30.2",
- "pkcs11",
- "sha2 0.10.8",
- "simple_asn1",
- "thiserror",
-]
-
-[[package]]
 name = "ic-interfaces"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b0915931003b7eca#4b3b2ce76c4bde0c1c60fb80b0915931003b7eca"
@@ -4254,7 +4012,7 @@ dependencies = [
  "ic-registry-provisional-whitelist",
  "ic-registry-subnet-type",
  "ic-sys",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-utils 0.9.0",
  "ic-wasm-types",
  "prost",
@@ -4270,7 +4028,7 @@ name = "ic-interfaces-registry"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b0915931003b7eca#4b3b2ce76c4bde0c1c60fb80b0915931003b7eca"
 dependencies = [
- "ic-types 0.9.0",
+ "ic-types",
  "prost",
  "serde",
 ]
@@ -4281,7 +4039,7 @@ version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b0915931003b7eca#4b3b2ce76c4bde0c1c60fb80b0915931003b7eca"
 dependencies = [
  "ic-crypto-tree-hash",
- "ic-types 0.9.0",
+ "ic-types",
  "phantom_newtype",
  "thiserror",
 ]
@@ -4352,37 +4110,28 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-recursion",
- "async-timer",
  "async-trait",
  "backon",
  "candid",
  "chrono",
- "counter",
  "csv",
  "custom_error",
  "decentralization",
  "derive_builder 0.12.0",
- "derive_more 0.99.17",
  "dirs",
  "dotenv",
- "either",
- "enum-map",
  "env_logger",
  "exitcode",
- "float-ord",
  "fs2",
  "futures",
- "futures-core",
  "futures-util",
  "gitlab",
  "hyper",
- "hyper-tls",
- "ic-agent 0.27.0",
+ "ic-agent",
  "ic-base-types",
  "ic-canisters",
  "ic-interfaces-registry",
  "ic-management-types",
- "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-governance",
  "ic-protobuf",
@@ -4395,18 +4144,14 @@ dependencies = [
  "ic-registry-local-store",
  "ic-registry-nns-data-provider",
  "ic-registry-subnet-type",
- "ic-types 0.9.0",
- "itertools 0.11.0",
+ "ic-types",
+ "itertools 0.12.0",
  "lazy_static",
  "log",
- "phantom_newtype",
  "prometheus-http-query 0.4.2",
- "prost",
- "rand 0.8.5",
  "regex",
  "registry-canister",
  "reqwest",
- "reverse_geocoder",
  "serde",
  "serde_json",
  "serde_yaml 0.9.30",
@@ -4414,7 +4159,6 @@ dependencies = [
  "strum_macros 0.25.3",
  "tokio",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -4425,13 +4169,11 @@ dependencies = [
  "anyhow",
  "candid",
  "chrono",
- "clap 4.4.13",
- "float-cmp",
+ "clap 4.4.17",
  "ic-base-types",
  "ic-nns-governance",
  "ic-registry-subnet-type",
- "ic-types 0.9.0",
- "itertools 0.11.0",
+ "ic-types",
  "registry-canister",
  "reqwest",
  "serde",
@@ -4533,7 +4275,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b091
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
- "ic-types 0.9.0",
+ "ic-types",
  "lazy_static",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4637,7 +4379,7 @@ dependencies = [
  "ic-registry-keys",
  "ic-registry-transport",
  "ic-stable-structures",
- "ic-types 0.9.0",
+ "ic-types",
  "lazy_static",
  "num-traits",
  "on_wire",
@@ -4695,7 +4437,7 @@ dependencies = [
  "ic-sns-swap",
  "ic-sns-wasm",
  "ic-stable-structures",
- "ic-types 0.9.0",
+ "ic-types",
  "icp-ledger",
  "itertools 0.12.0",
  "lazy_static",
@@ -4743,7 +4485,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b091
 dependencies = [
  "bincode",
  "candid",
- "erased-serde",
+ "erased-serde 0.3.31",
  "maplit",
  "prost",
  "serde",
@@ -4762,7 +4504,7 @@ dependencies = [
  "ic-registry-client-helpers",
  "ic-registry-common-proto",
  "ic-registry-keys",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-utils 0.9.0",
  "prometheus",
 ]
@@ -4773,7 +4515,7 @@ version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b0915931003b7eca#4b3b2ce76c4bde0c1c60fb80b0915931003b7eca"
 dependencies = [
  "ic-interfaces-registry",
- "ic-types 0.9.0",
+ "ic-types",
 ]
 
 [[package]]
@@ -4790,7 +4532,7 @@ dependencies = [
  "ic-registry-provisional-whitelist",
  "ic-registry-routing-table",
  "ic-registry-subnet-features",
- "ic-types 0.9.0",
+ "ic-types",
  "serde_cbor",
  "thiserror",
 ]
@@ -4811,7 +4553,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-ic00-types",
- "ic-types 0.9.0",
+ "ic-types",
  "serde",
 ]
 
@@ -4827,7 +4569,7 @@ dependencies = [
  "ic-registry-local-store",
  "ic-registry-nns-data-provider",
  "ic-registry-transport",
- "ic-types 0.9.0",
+ "ic-types",
  "thiserror",
  "tokio",
  "url",
@@ -4840,7 +4582,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=4b3b2ce76c4bde0c1c60fb80b091
 dependencies = [
  "ic-interfaces-registry",
  "ic-registry-common-proto",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-utils 0.9.0",
  "prost",
 ]
@@ -4862,7 +4604,7 @@ dependencies = [
  "ic-interfaces-registry",
  "ic-nns-constants",
  "ic-registry-transport",
- "ic-types 0.9.0",
+ "ic-types",
  "prost",
  "rand 0.8.5",
  "serde",
@@ -4952,7 +4694,7 @@ dependencies = [
  "ic-registry-subnet-features",
  "ic-registry-subnet-type",
  "ic-sys",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-utils 0.9.0",
  "ic-wasm-types",
  "itertools 0.12.0",
@@ -5138,7 +4880,7 @@ dependencies = [
  "ic-sns-governance",
  "ic-sns-init",
  "ic-sns-root",
- "ic-types 0.9.0",
+ "ic-types",
  "icrc-ledger-types",
  "maplit",
  "prost",
@@ -5182,12 +4924,6 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror",
 ]
-
-[[package]]
-name = "ic-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af86c6e40ea8a850c64914024762a0b91a2a6d438b412d8f4a7fc010e72519"
 
 [[package]]
 name = "ic-types"
@@ -5250,7 +4986,7 @@ checksum = "fbd6fac62c95df9f963c8a941431d86308c864ba1e9001da75843d79a355fb68"
 dependencies = [
  "async-trait",
  "candid",
- "ic-agent 0.30.2",
+ "ic-agent",
  "once_cell",
  "semver",
  "serde",
@@ -5281,7 +5017,7 @@ dependencies = [
  "ic-crypto-sha2",
  "ic-protobuf",
  "ic-sys",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-utils 0.9.0",
  "serde",
 ]
@@ -5436,12 +5172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5522,15 +5252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5576,15 +5297,6 @@ dependencies = [
  "secret-service",
  "security-framework",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "kiddo"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ced2e69cfc5f22f86ccc9ce4ecff9f19917f3083a4bac0f402bdab034d73f1"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -5755,7 +5467,7 @@ name = "log-fetcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.4.13",
+ "clap 4.4.17",
  "log",
  "pretty_env_logger",
  "reqwest",
@@ -5795,15 +5507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
 dependencies = [
  "logos-codegen",
-]
-
-[[package]]
-name = "lru"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
-dependencies = [
- "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -5969,17 +5672,17 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 name = "multiservice-discovery"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.1",
- "clap 4.4.13",
+ "base64 0.21.7",
+ "clap 4.4.17",
  "crossbeam",
  "crossbeam-channel",
- "erased-serde",
+ "erased-serde 0.4.2",
  "futures-util",
  "humantime",
  "ic-async-utils",
  "ic-crypto-utils-threshold-sig-der",
  "ic-registry-client",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-utils 0.9.0",
  "multiservice-discovery-shared",
  "regex",
@@ -5998,13 +5701,13 @@ dependencies = [
 name = "multiservice-discovery-downloader"
 version = "0.1.0"
 dependencies = [
- "clap 4.4.13",
+ "clap 4.4.17",
  "crossbeam",
  "crossbeam-channel",
  "futures-util",
  "humantime",
  "ic-async-utils",
- "ic-types 0.9.0",
+ "ic-types",
  "multiservice-discovery-shared",
  "regex",
  "reqwest",
@@ -6020,10 +5723,10 @@ dependencies = [
 name = "multiservice-discovery-shared"
 version = "0.1.0"
 dependencies = [
- "erased-serde",
- "ic-types 0.9.0",
+ "erased-serde 0.4.2",
+ "ic-types",
  "regex",
- "ring 0.16.20",
+ "ring 0.17.7",
  "serde",
  "serde_json",
  "service-discovery",
@@ -6082,12 +5785,12 @@ name = "node-status-updater"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.4.13",
+ "clap 4.4.17",
  "crossbeam",
  "crossbeam-channel",
  "futures-util",
  "humantime",
- "ic-agent 0.30.2",
+ "ic-agent",
  "ic-async-utils",
  "ic-metrics",
  "obs-canister-clients",
@@ -6120,18 +5823,12 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 name = "np-notifications"
 version = "0.1.0"
 dependencies = [
- "actix",
  "actix-web",
  "anyhow",
- "chrono",
- "figment",
  "httptest",
- "ic-interfaces-registry",
  "ic-management-backend",
  "ic-management-types",
- "ic-registry-client-helpers",
- "ic-registry-local-registry",
- "ic-types 0.9.0",
+ "ic-types",
  "pretty_assertions",
  "rand 0.8.5",
  "reqwest",
@@ -6317,7 +6014,7 @@ name = "obs-canister-clients"
 version = "0.1.0"
 dependencies = [
  "candid",
- "ic-agent 0.30.2",
+ "ic-agent",
  "rand 0.8.5",
  "serde",
  "slog",
@@ -6445,9 +6142,9 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
+checksum = "9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb"
 dependencies = [
  "bytecount",
  "fnv",
@@ -6490,29 +6187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "pear"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi 1.0.0-rc.1",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6527,7 +6201,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -6791,7 +6465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
- "yansi 0.5.1",
+ "yansi",
 ]
 
 [[package]]
@@ -6893,19 +6567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "version_check",
- "yansi 1.0.0-rc.1",
-]
-
-[[package]]
 name = "procfs"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6954,11 +6615,10 @@ name = "prometheus-config-updater"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
- "clap 3.2.25",
+ "base64 0.21.7",
+ "clap 4.4.17",
  "config-writer-common",
  "crossbeam",
- "crossbeam-channel",
  "futures-util",
  "humantime",
  "ic-async-utils",
@@ -6966,7 +6626,7 @@ dependencies = [
  "ic-crypto-utils-threshold-sig-der",
  "ic-http-endpoints-metrics",
  "ic-metrics",
- "ic-types 0.9.0",
+ "ic-types",
  "regex",
  "serde",
  "serde_json",
@@ -7196,26 +6856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
 
 [[package]]
-name = "rayon"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7317,7 +6957,7 @@ dependencies = [
  "ic-registry-subnet-features",
  "ic-registry-subnet-type",
  "ic-registry-transport",
- "ic-types 0.9.0",
+ "ic-types",
  "ipnet",
  "lazy_static",
  "leb128",
@@ -7343,7 +6983,7 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -7358,7 +6998,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -7396,18 +7035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
 dependencies = [
  "rand 0.8.5",
-]
-
-[[package]]
-name = "reverse_geocoder"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7cb9a3269abd8896c527042bd635f05531e18be7d5de1eb71c501027c51423"
-dependencies = [
- "csv",
- "kiddo",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -7599,7 +7226,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -7734,9 +7361,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -7762,9 +7389,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7895,7 +7522,7 @@ dependencies = [
  "ic-registry-local-store",
  "ic-registry-local-store-artifacts",
  "ic-registry-nns-data-provider",
- "ic-types 0.9.0",
+ "ic-types",
  "ic-utils 0.9.0",
  "itertools 0.12.0",
  "prometheus",
@@ -8021,15 +7648,13 @@ dependencies = [
  "dotenv",
  "env_logger",
  "futures",
- "ic-agent 0.27.0",
+ "ic-agent",
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-governance",
- "ic-types 0.7.0",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "lazy_static",
  "log",
- "prost",
  "regex",
  "registry-canister",
  "reqwest",
@@ -8037,8 +7662,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.30",
- "strum 0.25.0",
- "strum_macros 0.25.3",
  "tokio",
 ]
 
@@ -8048,7 +7671,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
- "erased-serde",
+ "erased-serde 0.3.31",
 ]
 
 [[package]]
@@ -8069,7 +7692,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
 dependencies = [
- "erased-serde",
+ "erased-serde 0.3.31",
  "serde",
  "serde_json",
  "slog",
@@ -8119,19 +7742,17 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 name = "sns-downloader"
 version = "0.1.0"
 dependencies = [
- "clap 4.4.13",
+ "clap 4.4.17",
  "crossbeam",
  "crossbeam-channel",
  "futures-util",
  "humantime",
  "ic-async-utils",
- "ic-types 0.9.0",
  "multiservice-discovery-shared",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
- "service-discovery",
  "slog",
  "slog-async",
  "slog-term",
@@ -8361,9 +7982,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
+checksum = "4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e"
 dependencies = [
  "papergrid",
  "tabled_derive",
@@ -8372,9 +7993,9 @@ dependencies = [
 
 [[package]]
 name = "tabled_derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+checksum = "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -8717,7 +8338,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.5",
+ "base64 0.21.7",
  "bytes",
  "h2",
  "http",
@@ -8908,15 +8529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uncased"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9002,12 +8614,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -9491,7 +9097,7 @@ checksum = "13a3a53eaf34f390dd30d7b1b078287dd05df2aa2e21a589ccb80f5c7253c2e9"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64 0.21.5",
+ "base64 0.21.7",
  "deadpool",
  "futures",
  "futures-timer",
@@ -9588,12 +9194,6 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "yansi"
-version = "1.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zbus"
@@ -9699,34 +9299,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,150 @@ authors = ["IC Decentralized Reliability Engineering (DRE) Team"]
 description = "Tooling for managing the Internet Computer"
 documentation = "https://github.com/dfinity/dre/"
 
+[workspace.dependencies]
+actix = "0.13.1"
+actix-web = { version = "4.2.1", default-features = false, features = [
+    "compress-gzip",
+    "macros",
+] }
+actix-rt = "2.2.0"
+ahash = "0.8.3"
+anyhow = "1.0.79"
+assert_matches = "1.4.0"
+async-recursion = "1.0.5"
+async-timer = "0.7.4"
+async-trait = "0.1.53"
+backoff = { version = "0.4.0", features = ["tokio"] }
+backon = "0.4.1"
+candid = "0.9.11"
+chrono = { version = "0.4.31", features = ["serde"] }
+clap-num = "1.0.0"
+clap = { version = "4.4.17", features = [
+    "derive",
+    "env",
+    "usage",
+    "color",
+    "help",
+    "error-context",
+    "suggestions",
+    "wrap_help",
+    "string",
+    "cargo",
+] }
+colored = "2.0.0"
+counter = "0.5.2"
+crossbeam = "0.8.0"
+crossbeam-channel = "0.5.5"
+cryptoki = "0.3.1"
+csv = "1.1.6"
+custom_error = "1.9.2"
+decentralization = { path = "rs/decentralization" }
+derive_builder = "0.12.0"
+derive_more = "0.99.16"
+dialoguer = "0.11.0"
+dirs = "5.0.1"
+dotenv = "0.15.0"
+base64 = "0.21.7"
+easy-parallel = "3.1.0"
+edit = "0.1.4"
+either = "1.6.1"
+enum-map = "1.1.1"
+env_logger = "0.10.0"
+erased-serde = "0.4.2"
+exitcode = "1.1.2"
+flate2 = "1.0.22"
+float-ord = "0.3.2"
+fs2 = "0.4.3"
+futures = "0.3.21"
+futures-core = "0.3.16"
+futures-util = "0.3.21"
+gitlab = "0.1603.0"
+hex = "0.4.3"
+humantime = "2.1.0"
+hyper = { version = "0.14.11", features = ["http2", "stream"] }
+hyper-tls = "0.5.0"
+ic-agent = "0.30.2"
+ic-async-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-base-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-canister-client = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-canister-client-sender = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-canisters = { path = "rs/ic-canisters" }
+ic-config = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-crypto-utils-threshold-sig-der = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-http-endpoints-metrics = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-identity-hsm = "0.30.2"
+ic-interfaces-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-management-backend = { path = "rs/ic-management-backend" }
+ic-management-types = { path = "rs/ic-management-types" }
+ic-metrics = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-nns-common = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-protobuf = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-client = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-client-fake = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-client-helpers = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-common-proto = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-keys = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-local-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-local-store = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-local-store-artifacts = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-nns-data-provider = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-subnet-type = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-registry-transport = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-sys = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+ic-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+include_dir = "0.7.3"
+itertools = "0.12.0"
+keyring = "2.0.2"
+lazy_static = "1.4.0"
+log = "0.4.20"
+lru = "0.12.1"
+phantom_newtype = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+pkcs11 = "0.5.0"
+pretty_env_logger = "0.5.0"
+prometheus-http-query = "0.4.0"
+prometheus = { version = "0.13.3", features = ["process"] }
+prost = "0.12.1"
+rand = { version = "0.8.5", features = ["std_rng"] }
+rand_seeder = "0.2.3"
+rayon = "1.8.0"
+regex = "1.10.2"
+registry-canister = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+reqwest = { version = "0.11", features = ["json"] }
+retry = "2.0.0"
+reverse_geocoder = "4.0.0"
+ring = "0.17.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0.195"
+serde_json = "1.0.111"
+serde_yaml = "0.9.30"
+sha2 = "0.10.6"
+simple_asn1 = "0.6.0"
+slog-async = { version = "2.8.0", features = ["nested-values"] }
+slog-term = "2.9.0"
+slog = { version = "2.7.0", features = [
+    "max_level_trace",
+    "nested-values",
+    "release_max_level_debug",
+    "release_max_level_trace",
+] }
+socket2 = "0.5.5"
+spinners = "4.1.1"
+strum = { version = "0.25.0", features = ["derive"] }
+strum_macros = "0.25.3"
+tabled = "0.15.0"
+tabular = "0.2"
+tempfile = "3.8.0"
+thiserror = "1.0.40"
+tokio = { version = "1.2.0", features = ["full"] }
+url = "2.5.0"
+urlencoding = "2.1.0"
+warp = "0.3"
+
+
 [profile.release]
 # Add debug information to the release build (does NOT reduce the level of optimization!)
 # Makes flamegraphs and backtraces more readable.

--- a/canisters/Cargo.lock
+++ b/canisters/Cargo.lock
@@ -511,7 +511,6 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ic-cdk",
- "ic-cdk-macros",
  "serde",
 ]
 

--- a/canisters/node_status_canister/src/node_status_canister_backend/Cargo.toml
+++ b/canisters/node_status_canister/src/node_status_canister_backend/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.8.4"
 ic-cdk = "0.7.4"
-ic-cdk-macros = "0.6.10"
+# ic-cdk-macros = "0.6.10"
 serde = "1"

--- a/canisters/node_status_canister/src/node_status_canister_backend/Cargo.toml
+++ b/canisters/node_status_canister/src/node_status_canister_backend/Cargo.toml
@@ -11,5 +11,4 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.8.4"
 ic-cdk = "0.7.4"
-# ic-cdk-macros = "0.6.10"
 serde = "1"

--- a/rs/canister-log-fetcher/Cargo.toml
+++ b/rs/canister-log-fetcher/Cargo.toml
@@ -6,24 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.2.7", features = [
-    "derive",
-    "env",
-    "usage",
-    "color",
-    "help",
-    "error-context",
-    "suggestions",
-    "wrap_help",
-    "string",
-    "cargo",
-] }
-reqwest = { version = "0.11", features = ["json"] }
-url = "2.3.1"
-log = "0.4.14"
-pretty_env_logger = "0.5.0"
-tokio = { version = "1.14.0", features = ["full"] }
-anyhow = "1.0.44"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.108" 
-humantime = "2.1.0"
+clap = { workspace = true }
+reqwest = { workspace = true }
+url = { workspace = true }
+log = { workspace = true }
+pretty_env_logger = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+humantime = { workspace = true }

--- a/rs/canister-log-fetcher/src/main.rs
+++ b/rs/canister-log-fetcher/src/main.rs
@@ -15,6 +15,7 @@ use crate::entry::Entry;
 
 mod entry;
 
+#[allow(clippy::iter_skip_zero)]
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let args = Cli::parse();

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -10,67 +10,44 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.130", features = ["derive"] }
-chrono = "0.4.31"
-clap = { version = "4.2.7", features = [
-    "derive",
-    "env",
-    "usage",
-    "color",
-    "help",
-    "error-context",
-    "suggestions",
-    "wrap_help",
-    "string",
-    "cargo",
-] }
-reqwest = { version = "0.11", features = ["json"] }
-serde_json = "1.0.68"
-anyhow = "1.0.44"
-futures = "0.3.21"
-colored = "2.0.0"
-log = "0.4.14"
-pretty_env_logger = "0.5.0"
-regex = "1.5.4"
-ic-base-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-canister-client = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-sys = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-nns-data-provider = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-keys = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-transport = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-protobuf = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-canisters = { path = "../ic-canisters" }
-prost = "0.12.1"
-tokio = { version = "1.14.0", features = ["full"] }
-strum = { version = "0.25.0", features = ["derive"] }
-strum_macros = "0.25.1"
-flate2 = "1.0.22"
-dirs = "5.0.1"
-decentralization = { path = "../decentralization" }
-ic-management-types = { path = "../ic-management-types" }
-ic-management-backend = { path = "../ic-management-backend" }
-dialoguer = "0.10.0"
-itertools = "0.11.0"
-async-trait = "0.1.53"
-keyring = "2.0.2"
-cryptoki = "0.3.1"
-candid = "0.9.5"
-url = "2.3.1"
-clap-num = "1.0.0"
-sha2 = "0.10.6"
-edit = "0.1.4"
-tabular = "0.2"
-ic-agent = "0.27.0"
-actix-web = { version = "4.2.1", default-features = false, features = [
-    "compress-gzip",
-    "macros",
-] }
-dotenv = "0.15.0"
-socket2 = "0.5.4"
-spinners = "4.1.0"
-tabled = "0.14.0"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+candid = { workspace = true }
+clap = { workspace = true }
+clap-num = { workspace = true }
+colored = { workspace = true }
+cryptoki = { workspace = true }
+decentralization = { workspace = true }
+dialoguer = { workspace = true }
+dirs = { workspace = true }
+dotenv = { workspace = true }
+edit = { workspace = true }
+flate2 = { workspace = true }
+futures = { workspace = true }
+ic-base-types = { workspace = true }
+ic-canister-client = { workspace = true }
+ic-canisters = { workspace = true }
+ic-management-backend = { workspace = true }
+ic-management-types = { workspace = true }
+ic-nns-constants = { workspace = true }
+ic-nns-governance = { workspace = true }
+ic-sys = { workspace = true }
+itertools = { workspace = true }
+keyring = { workspace = true }
+log = { workspace = true }
+pretty_env_logger = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+socket2 = { workspace = true }
+spinners = { workspace = true }
+strum = { workspace = true }
+tabled = { workspace = true }
+tabular = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -389,7 +389,7 @@ impl Cli {
     }
 
     pub fn get_update_cmd_args(update_version: &UpdateVersion) -> Vec<String> {
-        vec![
+        [
             [
                 vec![
                     format!("--{}-version-to-elect", update_version.release_artifact),
@@ -402,7 +402,7 @@ impl Cli {
             ]
             .concat(),
             match update_version.versions_to_retire.clone() {
-                Some(versions) => vec![
+                Some(versions) => [
                     vec![format!("--{}-versions-to-unelect", update_version.release_artifact)],
                     versions,
                 ]

--- a/rs/cli/src/ic_admin.rs
+++ b/rs/cli/src/ic_admin.rs
@@ -588,7 +588,7 @@ impl ProposeCommand {
                 subnet_id,
                 node_ids_add: nodes_ids_add,
                 node_ids_remove: nodes_ids_remove,
-            } => vec![
+            } => [
                 vec!["--subnet-id".to_string(), subnet_id.to_string()],
                 if !nodes_ids_add.is_empty() {
                     [
@@ -614,7 +614,7 @@ impl ProposeCommand {
                 vec![subnet.to_string(), version.clone()]
             }
             Self::Raw { command: _, args } => args.clone(),
-            Self::UpdateNodesHostosVersion { nodes, version } => vec![
+            Self::UpdateNodesHostosVersion { nodes, version } => [
                 nodes.iter().map(|n| n.to_string()).collect::<Vec<_>>(),
                 vec!["--hostos-version-id".to_string(), version.to_string()],
             ]

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -250,7 +250,7 @@ impl Runner {
             })
             .fold(BTreeMap::new(), |mut acc, (node_id, subnet, dc)| {
                 acc.entry(dc.unwrap_or_default().name)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push((node_id, subnet));
                 acc
             })
@@ -285,9 +285,9 @@ impl Runner {
                 let mut summary = "## List of nodes\n".to_string();
                 let mut builder_dc = Builder::default();
                 let nodes_by_dc = self.nodes_by_dc(nodes_to_update.clone()).await;
-                builder_dc.set_header(["dc", "node_id", "subnet"]);
+                builder_dc.push_record(["dc", "node_id", "subnet"]);
                 nodes_by_dc.into_iter().for_each(|(dc, nodes_with_sub)| {
-                    let _builder = builder_dc.push_record([
+                    builder_dc.push_record([
                         dc,
                         nodes_with_sub.iter().map(|(p, _)| p.to_string()).join("\n"),
                         nodes_with_sub
@@ -305,7 +305,7 @@ impl Runner {
                 if let Some(subnets_affected) = maybe_subnets_affected {
                     summary.push_str("## Updated nodes per subnet\n");
                     let mut builder_subnets = Builder::default();
-                    builder_subnets.set_header([
+                    builder_subnets.push_record([
                         "subnet_id",
                         "updated_nodes",
                         "count",
@@ -349,7 +349,7 @@ impl Runner {
                         })
                         .sorted_by(|a, b| a[3].cmp(&b[3]))
                         .for_each(|row| {
-                            let _builder = builder_subnets.push_record(row);
+                            builder_subnets.push_record(row);
                         });
 
                     let mut table_subnets = builder_subnets.build();

--- a/rs/decentralization/Cargo.toml
+++ b/rs/decentralization/Cargo.toml
@@ -9,33 +9,23 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-base-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-serde = { version = "1.0", features = ["rc"] }
-serde_json = { version = "1.0" }
-async-trait = "0.1.52"
-actix-web = { version = "4.2.1", default-features = false, features = [
-  "compress-gzip",
-  "macros",
-] }
-colored = "2.0.0"
-reqwest = { version = "0.11.9", features = ["json"] }
-itertools = "0.11.0"
-chrono = "0.4.31"
-tokio = { version = "1.2.0", features = ["full"] }
-ic-management-types = { path = "../ic-management-types" }
-futures-util = "0.3.21"
-strum = "0.25.0"
-strum_macros = "0.25.1"
-anyhow = "1.0.44"
-log = "0.4.14"
-tabular = "0.2"
-rayon = "1.5.1"
-easy-parallel = "3.1.0"
-lru = "0.11.0"
-rand = { version = "0.8.5", features = ["std_rng"] }
-rand_seeder = "0.2.3"
-ahash = "0.8.3"
+actix-web = { workspace = true }
+ahash = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+colored = { workspace = true }
+ic-base-types = { workspace = true }
+ic-management-types = { workspace = true }
+itertools = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+rand_seeder = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tabular = { workspace = true }
 
 [dev-dependencies]
-include_dir = "0.7.2"
-regex = "1.5.4"
+include_dir = { workspace = true }
+regex = { workspace = true }

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -78,52 +78,49 @@ impl From<&ic_management_types::Node> for Node {
     fn from(n: &ic_management_types::Node) -> Self {
         Self {
             id: n.principal,
-            features: nakamoto::NodeFeatures::from_iter(
-                [
-                    (
-                        NodeFeature::City,
-                        n.operator
-                            .datacenter
-                            .as_ref()
-                            .map(|d| d.city.clone())
-                            .unwrap_or_else(|| "unknown".to_string()),
-                    ),
-                    (
-                        NodeFeature::Country,
-                        n.operator
-                            .datacenter
-                            .as_ref()
-                            .map(|d| d.country.clone())
-                            .unwrap_or_else(|| "unknown".to_string()),
-                    ),
-                    (
-                        NodeFeature::Continent,
-                        n.operator
-                            .datacenter
-                            .as_ref()
-                            .map(|d| d.continent.clone())
-                            .unwrap_or_else(|| "unknown".to_string()),
-                    ),
-                    (
-                        NodeFeature::DataCenterOwner,
-                        n.operator
-                            .datacenter
-                            .as_ref()
-                            .map(|d| d.owner.name.clone())
-                            .unwrap_or_else(|| "unknown".to_string()),
-                    ),
-                    (
-                        NodeFeature::DataCenter,
-                        n.operator
-                            .datacenter
-                            .as_ref()
-                            .map(|d| d.name.clone())
-                            .unwrap_or_else(|| "unknown".to_string()),
-                    ),
-                    (NodeFeature::NodeProvider, n.operator.provider.principal.to_string()),
-                ]
-                .into_iter(),
-            ),
+            features: nakamoto::NodeFeatures::from_iter([
+                (
+                    NodeFeature::City,
+                    n.operator
+                        .datacenter
+                        .as_ref()
+                        .map(|d| d.city.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ),
+                (
+                    NodeFeature::Country,
+                    n.operator
+                        .datacenter
+                        .as_ref()
+                        .map(|d| d.country.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ),
+                (
+                    NodeFeature::Continent,
+                    n.operator
+                        .datacenter
+                        .as_ref()
+                        .map(|d| d.continent.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ),
+                (
+                    NodeFeature::DataCenterOwner,
+                    n.operator
+                        .datacenter
+                        .as_ref()
+                        .map(|d| d.owner.name.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ),
+                (
+                    NodeFeature::DataCenter,
+                    n.operator
+                        .datacenter
+                        .as_ref()
+                        .map(|d| d.name.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ),
+                (NodeFeature::NodeProvider, n.operator.provider.principal.to_string()),
+            ]),
             dfinity_owned: n.dfinity_owned.unwrap_or_default(),
             decentralized: n.decentralized,
         }

--- a/rs/ic-canisters/Cargo.toml
+++ b/rs/ic-canisters/Cargo.toml
@@ -7,29 +7,26 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-ic-nns-constants = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-url = "2.2.2"
-ic-agent = "0.30.2"
-anyhow = "1.0.44"
-candid = "0.9.5"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
-ic-canister-client = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-sys = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-common = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-canister-client-sender = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-reqwest = "0.11.22"
-backoff = { version = "0.4.0", features = ["tokio"] }
-ic-base-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-ic00-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+anyhow = { workspace = true }
+backoff = { workspace = true }
+candid = { workspace = true }
+hex = { workspace = true }
+ic-agent = { workspace = true }
+ic-base-types = { workspace = true }
+ic-canister-client = { workspace = true }
+ic-canister-client-sender = { workspace = true }
+ic-ic00-types = { workspace = true }
+ic-nns-common = { workspace = true }
+ic-nns-constants = { workspace = true }
+ic-nns-governance = { workspace = true }
+ic-protobuf = { workspace = true }
+ic-registry-transport = { workspace = true }
+ic-sys = { workspace = true }
 ic-utils = "0.30.2"
-ic-identity-hsm = "0.30.2"
-ic-protobuf = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-transport = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-prost = "0.12.3"
-pkcs11 = "0.5.0"
-simple_asn1 = "0.6.0"
-hex = "0.4.3"
-sha2 = "0.10.6"
-thiserror = "1.0.40"
+pkcs11 = { workspace = true }
+prost = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+simple_asn1 = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }

--- a/rs/ic-management-backend/Cargo.toml
+++ b/rs/ic-management-backend/Cargo.toml
@@ -7,79 +7,62 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-tokio = { version = "1.2.0", features = ["full"] }
-serde_json = "1.0.66"
-serde = { version = "1.0.127", features = ["rc"] }
-hyper = { version = "0.14.11", features = ["http2", "stream"] }
-url = "2.2.2"
-float-ord = "0.3.2"
-hyper-tls = "0.5.0"
-chrono = { version = "0.4.31", features = ["serde"] }
-urlencoding = "2.1.0"
-futures-core = "0.3.16"
-futures-util = "0.3.16"
-derive_more = "0.99.16"
-actix-web = { version = "4.2.1", default-features = false, features = [
-    "compress-gzip",
-    "macros",
-] }
-ic-base-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-keys = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-anyhow = "1.0.43"
-futures = "0.3.16"
-serde_yaml = "0.9.11"
-reqwest = { version = "0.11.4", features = ["json"] }
-async-trait = "0.1.52"
-async-recursion = "1.0.5"
-enum-map = "1.1.1"
-either = "1.6.1"
-ic-interfaces-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-protobuf = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-nns-data-provider = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-local-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-local-store = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-common-proto = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-subnet-type = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-prost = "0.12.1"
-ic-management-types = { path = "../ic-management-types" }
-ic-canisters = { path = "../ic-canisters" }
-registry-canister = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-strum = "0.25.0"
-strum_macros = "0.25.1"
-itertools = "0.11.0"
-log = "0.4.14"
-env_logger = "0.10.0"
-reverse_geocoder = "3.0.1"
-csv = "1.1.6"
-candid = "0.9.5"
-ic-nns-governance = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-common = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-agent = "0.27.0"
-gitlab = "0.1603.0"
-dotenv = "0.15.0"
-derive_builder = "0.12.0"
-lazy_static = "1.4.0"
-regex = "1.5.4"
-async-timer = "0.7.4"
-counter = "0.5.2"
-rand = "0.8.4"
-phantom_newtype = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+actix-web = { workspace = true }
+anyhow = { workspace = true }
+async-recursion = { workspace = true }
+async-trait = { workspace = true }
+backon = { workspace = true }
+candid = { workspace = true }
+chrono = { workspace = true }
+csv = { workspace = true }
+custom_error = { workspace = true }
 decentralization = { path = "../decentralization" }
-prometheus-http-query = "0.4.0"
-ic-registry-client = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-client-fake = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-client-helpers = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-dirs = "5.0.1"
-backon = "0.4.1"
-exitcode = "1.1.2"
-fs2 = "0.4.3"
-custom_error = "1.9.2"
+derive_builder = { workspace = true }
+dirs = { workspace = true }
+dotenv = { workspace = true }
+env_logger = { workspace = true }
+exitcode = { workspace = true }
+fs2 = { workspace = true }
+futures = { workspace = true }
+futures-util = { workspace = true }
+gitlab = { workspace = true }
+hyper = { workspace = true }
+ic-agent = { workspace = true }
+ic-base-types = { workspace = true }
+ic-canisters = { path = "../ic-canisters" }
+ic-interfaces-registry = { workspace = true }
+ic-management-types = { path = "../ic-management-types" }
+ic-nns-constants = { workspace = true }
+ic-nns-governance = { workspace = true }
+ic-protobuf = { workspace = true }
+ic-registry-client = { workspace = true }
+ic-registry-client-fake = { workspace = true }
+ic-registry-client-helpers = { workspace = true }
+ic-registry-common-proto = { workspace = true }
+ic-registry-keys = { workspace = true }
+ic-registry-local-registry = { workspace = true }
+ic-registry-local-store = { workspace = true }
+ic-registry-nns-data-provider = { workspace = true }
+ic-registry-subnet-type = { workspace = true }
+ic-types = { workspace = true }
+itertools = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+prometheus-http-query = { workspace = true }
+regex = { workspace = true }
+registry-canister = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-assert_matches = "1.4.0"
-actix-rt = "2.2.0"
+assert_matches = { workspace = true }
+actix-rt = { workspace = true }
 
 
 [[bin]]

--- a/rs/ic-management-backend/src/hostos_rollout.rs
+++ b/rs/ic-management-backend/src/hostos_rollout.rs
@@ -60,7 +60,7 @@ impl HostosRollout {
                 (NodeGroup::new(assignment, owner), node)
             })
             .fold(BTreeMap::new(), |mut acc, (node_group, node)| {
-                acc.entry(node_group).or_insert_with(Vec::new).push(node);
+                acc.entry(node_group).or_default().push(node);
                 acc
             });
 
@@ -132,10 +132,13 @@ impl HostosRollout {
                     node,
                 )
             })
-            .fold(BTreeMap::new(), |mut acc, (status, node)| {
-                acc.entry(status).or_insert_with(Vec::new).push(node);
-                acc
-            });
+            .fold(
+                BTreeMap::new(),
+                |mut acc: BTreeMap<Status, Vec<Node>>, (status, node)| {
+                    acc.entry(status).or_default().push(node);
+                    acc
+                },
+            );
 
         nodes_by_status
             .iter()
@@ -152,9 +155,9 @@ impl HostosRollout {
                 let nodes = subnet
                     .nodes
                     .iter()
-                    .cloned()
-                    .filter(|n| candidate_nodes.iter().any(|node| node.principal == n.principal))
+                    .filter(|&n| candidate_nodes.iter().any(|node| node.principal == n.principal))
                     .take(nodes_to_take)
+                    .cloned()
                     .collect::<Vec<_>>();
                 let actual_percent = nodes.len() as f32 / subnet_size as f32 * 100.0;
 

--- a/rs/ic-management-backend/src/proposal.rs
+++ b/rs/ic-management-backend/src/proposal.rs
@@ -4,6 +4,7 @@ use backon::Retryable;
 use candid::{Decode, Encode};
 
 use futures_util::future::try_join_all;
+use ic_agent::agent::http_transport::reqwest_transport::ReqwestHttpReplicaV2Transport;
 use ic_agent::Agent;
 use ic_management_types::{NnsFunctionProposal, TopologyChangePayload, TopologyChangeProposal};
 use ic_management_types::{
@@ -76,10 +77,7 @@ pub struct SubnetUpdateProposal {
 impl ProposalAgent {
     pub fn new(url: String) -> Self {
         let agent = Agent::builder()
-            .with_transport(
-                ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(url)
-                    .expect("failed to create transport"),
-            )
+            .with_transport(ReqwestHttpReplicaV2Transport::create(url).expect("failed to create transport"))
             .build()
             .expect("failed to build the agent");
         Self { agent }

--- a/rs/ic-management-backend/src/registry.rs
+++ b/rs/ic-management-backend/src/registry.rs
@@ -397,7 +397,7 @@ impl RegistryState {
                 }
             });
 
-            for (blessed_versions, ArtifactReleases { artifact, releases }) in vec![
+            for (blessed_versions, ArtifactReleases { artifact, releases }) in [
                 (blessed_replica_versions, &mut self.replica_releases),
                 (elected_hostos_versions, &mut self.hostos_releases),
             ] {

--- a/rs/ic-management-types/Cargo.toml
+++ b/rs/ic-management-types/Cargo.toml
@@ -7,27 +7,22 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-actix-web = { version = "4.2.1", default-features = false, features = [
-    "compress-gzip",
-    "macros",
-] }
-chrono = { version = "0.4.31", features = ["serde"] }
-float-cmp = "0.9.0"
-ic-base-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-subnet-type = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-registry-canister = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-itertools = "0.11.0"
-reqwest = { version = "0.11.9", features = ["json"] }
-serde = "1.0.127"
-serde_json = "1.0.66"
-strum = "0.25.0"
-strum_macros = "0.25.1"
-url = "2.2.2"
-anyhow = "1.0.43"
-candid = "0.9.5"
-clap = { version = "4.4.10", features = ["derive"] }
+actix-web = { workspace = true }
+chrono = { workspace = true }
+ic-base-types = { workspace = true }
+ic-nns-governance = { workspace = true }
+ic-registry-subnet-type = { workspace = true }
+ic-types = { workspace = true }
+registry-canister = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+url = { workspace = true }
+anyhow = { workspace = true }
+candid = { workspace = true }
+clap = { workspace = true }
 
 [lib]
 path = "src/lib.rs"

--- a/rs/ic-observability/config-writer-common/Cargo.toml
+++ b/rs/ic-observability/config-writer-common/Cargo.toml
@@ -6,22 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-regex = "1.7.0"
+regex = { workspace = true }
 service-discovery = { path = "../service-discovery" }
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-slog = { version = "2.7.0", features = [
-  "max_level_trace",
-  "nested-values",
-  "release_max_level_debug",
-  "release_max_level_trace",
-] }
-slog-async = { version = "2.5", features = ["nested-values"] }
-slog-term = "2.6.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0.107", features = ["std"] }
-ic-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-erased-serde = "0.3.23"
-serde_derive = "1.0.150"
-crossbeam = "0.8.0"
-crossbeam-channel = "0.5.5"
-url = { version = "2.1.1", features = ["serde"] }
+ic-types = { workspace = true }
+slog = { workspace = true }
+slog-async = { workspace = true }
+slog-term = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ic-utils = { workspace = true }
+erased-serde = { workspace = true }
+serde_derive = { workspace = true }
+crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
+url = { workspace = true }

--- a/rs/ic-observability/multiservice-discovery-downloader/Cargo.toml
+++ b/rs/ic-observability/multiservice-discovery-downloader/Cargo.toml
@@ -6,30 +6,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-multiservice-discovery-shared ={ path = "../multiservice-discovery-shared" }
-tokio = { version = "1.35.1", features = ["full"] }
-url = "2.2.2"
-slog = { version = "2.7.0", features = [
-  "max_level_trace",
-  "nested-values",
-  "release_max_level_debug",
-  "release_max_level_trace",
-] }
-slog-async = { version = "2.5", features = ["nested-values"] }
-slog-term = "2.6.0"
-clap = { version = "4.3.0", features = ["derive"] }
-humantime = "2.0"
-ic-async-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-futures-util = "0.3.5"
-reqwest = { version = "0.11.22", default-features = false, features = [
-  "blocking",
-  "json",
-  "multipart",
-  "rustls-tls-webpki-roots",
-  "stream",
-] }
-crossbeam = "0.8.0"
-crossbeam-channel = "0.5.5"
+clap = { workspace = true }
+crossbeam-channel = { workspace = true }
+crossbeam = { workspace = true }
+futures-util = { workspace = true }
+humantime = { workspace = true }
+ic-async-utils = { workspace = true }
+ic-types = { workspace = true }
+multiservice-discovery-shared = { path = "../multiservice-discovery-shared" }
+regex = { workspace = true }
+reqwest = { workspace = true }
 service-discovery = { path = "../service-discovery" }
-regex = "1.7.0"
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+slog = { workspace = true }
+slog-async = { workspace = true }
+slog-term = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }

--- a/rs/ic-observability/multiservice-discovery-shared/Cargo.toml
+++ b/rs/ic-observability/multiservice-discovery-shared/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 service-discovery = { path = "../service-discovery" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0.107", features = ["std"] }
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-erased-serde = "0.3.23"
-regex = "1.7.0"
-ring = "0.16"
+serde = { workspace = true }
+serde_json = { workspace = true }
+ic-types = { workspace = true }
+erased-serde = { workspace = true }
+regex = { workspace = true }
+ring = { workspace = true }

--- a/rs/ic-observability/multiservice-discovery/Cargo.toml
+++ b/rs/ic-observability/multiservice-discovery/Cargo.toml
@@ -6,31 +6,26 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.35.1", features = ["full"] }
-url = "2.2.2"
+base64 = { workspace = true }
+clap = { workspace = true }
+crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
+erased-serde = { workspace = true }
+futures-util = { workspace = true }
+humantime = { workspace = true }
+ic-async-utils = { workspace = true }
+ic-crypto-utils-threshold-sig-der = { workspace = true }
+ic-registry-client = { workspace = true }
+ic-types = { workspace = true }
+ic-utils = { workspace = true }
+multiservice-discovery-shared = { path = "../multiservice-discovery-shared" }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 service-discovery = { path = "../service-discovery" }
-slog = { version = "2.7.0", features = [
-  "max_level_trace",
-  "nested-values",
-  "release_max_level_debug",
-  "release_max_level_trace",
-] }
-slog-async = { version = "2.5", features = ["nested-values"] }
-slog-term = "2.6.0"
-ic-registry-client = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-async-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-futures-util = "0.3.5"
-clap = { version = "4.3.0", features = ["derive"] }
-crossbeam = "0.8.0"
-crossbeam-channel = "0.5.5"
-humantime = "2.0"
-warp = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0.107", features = ["std"] }
-ic-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-erased-serde = "0.3.23"
-regex = "1.7.0"
-ic-types ={ git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-multiservice-discovery-shared = {path = "../multiservice-discovery-shared"}
-ic-crypto-utils-threshold-sig-der = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-base64 = "0.13.1"
+slog = { workspace = true }
+slog-async = { workspace = true }
+slog-term = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+warp = { workspace = true }

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/add_definition_handler.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/add_definition_handler.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose as b64, Engine as _};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -26,7 +27,7 @@ pub struct AddDefinitionBinding {
 pub async fn add_definition(definition: DefinitionDto, binding: AddDefinitionBinding) -> WebResult<impl Reply> {
     let public_key = match definition.public_key {
         Some(pk) => {
-            let decoded = base64::decode(pk).unwrap();
+            let decoded = b64::STANDARD.decode(pk).unwrap();
 
             match parse_threshold_sig_key_from_der(&decoded) {
                 Ok(key) => Some(key),

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/dto.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/dto.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose as b64, Engine as _};
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,7 @@ impl From<&Definition> for DefinitionDto {
         Self {
             name: value.name.clone(),
             nns_urls: value.nns_urls.clone(),
-            public_key: value.public_key.map(|pk| base64::encode(pk.into_bytes())),
+            public_key: value.public_key.map(|pk| b64::STANDARD.encode(pk.into_bytes())),
         }
     }
 }

--- a/rs/ic-observability/node-status-updater/Cargo.toml
+++ b/rs/ic-observability/node-status-updater/Cargo.toml
@@ -6,30 +6,25 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-service-discovery ={ path = "../service-discovery" }
-clap = { version = "4.3.0", features = ["derive"] }
-tokio = { version = "1.35.1", features = ["full"] }
-anyhow = "1.0.75"
-slog = { version = "2.7.0", features = [
-  "max_level_trace",
-  "nested-values",
-  "release_max_level_debug",
-  "release_max_level_trace",
-] }
-slog-async = { version = "2.5", features = ["nested-values"] }
-slog-term = "2.6.0"
-humantime = "2.0"
-url = "2.2.2"
-ic-async-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-futures-util = "0.3.5"
-ic-metrics = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-crossbeam = "0.8.0"
-crossbeam-channel = "0.5.5"
-ic-agent = { version = "0.30.2", features = ["hyper"] }
+anyhow = { workspace = true }
+clap = { workspace = true }
+crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
+futures-util = { workspace = true }
+humantime = { workspace = true }
+ic-agent = { workspace = true }
+ic-async-utils = { workspace = true }
+ic-metrics = { workspace = true }
 obs-canister-clients = { path = "../obs-canister-clients" }
 prometheus-http-query = { version = "0.6.6", default_features = false, features = [
   "rustls-tls-webpki-roots",
 ] }
+service-discovery = { path = "../service-discovery" }
+slog = { workspace = true }
+slog-async = { workspace = true }
+slog-term = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [[bin]]
 name = "node-status-updater"

--- a/rs/ic-observability/obs-canister-clients/Cargo.toml
+++ b/rs/ic-observability/obs-canister-clients/Cargo.toml
@@ -6,14 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-agent = { version = "0.30.2", features = ["hyper"] }
-candid = { version = "0.9.10", features = ["parser"] }
-serde = { version = "1.0", features = ["derive"] }
-rand = "0.8"
-url = "2.2.2"
-slog = { version = "2.7.0", features = [
-  "max_level_trace",
-  "nested-values",
-  "release_max_level_debug",
-  "release_max_level_trace",
-] }
+ic-agent = { workspace = true }
+candid = { workspace = true }
+serde = { workspace = true }
+rand = { workspace = true }
+url = { workspace = true }
+slog = { workspace = true }

--- a/rs/ic-observability/prometheus-config-updater/Cargo.toml
+++ b/rs/ic-observability/prometheus-config-updater/Cargo.toml
@@ -4,31 +4,25 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.31"
-clap = { version = "3.2.25", features = ["derive"] }
-crossbeam = "0.8.0"
-crossbeam-channel = "0.5.5"
-futures-util = "0.3.5"
-humantime = "2.0"
-ic-async-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-metrics = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-crypto-utils-threshold-sig-der = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-base64 = { version = "0.13.1" }
-regex = "1.7.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0.107", features = ["std"] }
-service-discovery = { path = "../service-discovery" }
-slog = { version = "2.7.0", features = [
-  "max_level_trace",
-  "nested-values",
-  "release_max_level_debug",
-  "release_max_level_trace",
-] }
-slog-async = { version = "2.5", features = ["nested-values"] }
-slog-term = "2.6.0"
-tokio = { version = "1.35.1", features = ["full"] }
-url = { version = "2.1.1", features = ["serde"] }
+anyhow = { workspace = true }
+base64 = { workspace = true }
+clap = { workspace = true }
 config-writer-common = { path = "../config-writer-common" }
-ic-config = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-http-endpoints-metrics = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
+crossbeam = { workspace = true }
+futures-util = { workspace = true }
+humantime = { workspace = true }
+ic-async-utils = { workspace = true }
+ic-config = { workspace = true }
+ic-crypto-utils-threshold-sig-der = { workspace = true }
+ic-http-endpoints-metrics = { workspace = true }
+ic-metrics = { workspace = true }
+ic-types = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+service-discovery = { path = "../service-discovery" }
+slog = { workspace = true }
+slog-async = { workspace = true }
+slog-term = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }

--- a/rs/ic-observability/service-discovery/Cargo.toml
+++ b/rs/ic-observability/service-discovery/Cargo.toml
@@ -6,40 +6,35 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-interfaces-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-protobuf = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-local-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-client = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-client-helpers = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-nns-data-provider = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-local-store = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-local-store-artifacts = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-thiserror = "1.0"
-ic-metrics = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-prometheus = { version = "0.13.3", features = ["process"] }
-hyper = { version = "0.14.18", features = ["full"] }
-anyhow = "1.0.31"
-slog = { version = "2.7.0", features = [
-  "max_level_trace",
-  "nested-values",
-  "release_max_level_debug",
-  "release_max_level_trace",
-] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0.107", features = ["std"] }
-ic-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-keys = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-tokio = { version = "1.35.1", features = ["full"] }
-crossbeam = "0.8.0"
-crossbeam-channel = "0.5.5"
-tempfile = "3.1.0"
-url = "2.2.2"
-ic-registry-client-fake = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-registry-canister = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-common-proto = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-futures = "0.3.28"
-regex = "1.7.0"
+anyhow = { workspace = true }
+crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
+futures = { workspace = true }
+hyper = { workspace = true }
+ic-interfaces-registry = { workspace = true }
+ic-metrics = { workspace = true }
+ic-protobuf = { workspace = true }
+ic-registry-client = { workspace = true }
+ic-registry-client-fake = { workspace = true }
+ic-registry-client-helpers = { workspace = true }
+ic-registry-common-proto = { workspace = true }
+ic-registry-keys = { workspace = true }
+ic-registry-local-registry = { workspace = true }
+ic-registry-local-store = { workspace = true }
+ic-registry-local-store-artifacts = { workspace = true }
+ic-registry-nns-data-provider = { workspace = true }
+ic-types = { workspace = true }
+ic-utils = { workspace = true }
+prometheus = { workspace = true }
+regex = { workspace = true }
+registry-canister = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+slog = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-itertools = "0.12.0"
+itertools = { workspace = true }

--- a/rs/ic-observability/sns-downloader/Cargo.toml
+++ b/rs/ic-observability/sns-downloader/Cargo.toml
@@ -6,27 +6,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { workspace = true }
+crossbeam = { workspace = true }
+crossbeam-channel = { workspace = true }
+futures-util = { workspace = true }
+humantime = { workspace = true }
+ic-async-utils = { workspace = true }
 multiservice-discovery-shared = { path = "../multiservice-discovery-shared" }
-tokio = { version = "1.35.1", features = ["full"] }
-url = "2.2.2"
-slog = { version = "2.5.2", features = ["nested-values"] }
-slog-async = { version = "2.5", features = ["nested-values"] }
-slog-term = "2.6.0"
-clap = { version = "4.3.0", features = ["derive"] }
-humantime = "2.0"
-ic-async-utils = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-futures-util = "0.3.5"
-reqwest = { version = "0.11.22", default-features = false, features = [
-  "blocking",
-  "json",
-  "multipart",
-  "rustls-tls-webpki-roots",
-  "stream",
-] }
-crossbeam = "0.8.0"
-crossbeam-channel = "0.5.5"
-service-discovery = { path = "../service-discovery" }
-regex = "1.7.0"
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0.107", features = ["std"] }
+regex = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+slog = { workspace = true }
+slog-async = { workspace = true }
+slog-term = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }

--- a/rs/log-fetcher/Cargo.toml
+++ b/rs/log-fetcher/Cargo.toml
@@ -9,23 +9,12 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.2.7", features = [
-    "derive",
-    "env",
-    "usage",
-    "color",
-    "help",
-    "error-context",
-    "suggestions",
-    "wrap_help",
-    "string",
-    "cargo",
-] }
-reqwest = { version = "0.11", features = ["json"] }
-url = "2.3.1"
-log = "0.4.14"
-pretty_env_logger = "0.5.0"
-tokio = { version = "1.14.0", features = ["full"] }
-anyhow = "1.0.44"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.108"
+clap = { workspace = true }
+reqwest = { workspace = true }
+url = { workspace = true }
+log = { workspace = true }
+pretty_env_logger = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/rs/np-notifications/Cargo.toml
+++ b/rs/np-notifications/Cargo.toml
@@ -9,31 +9,25 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "4.3.1"
-ic-management-types = { path = "../ic-management-types" }
+actix-web = { workspace = true }
+anyhow = { workspace = true }
 ic-management-backend = { path = "../ic-management-backend" }
-ic-types = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-local-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-tokio = { version = "1.29.1", features = ["full"] }
+ic-management-types = { path = "../ic-management-types" }
+ic-types = { workspace = true }
+rand = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
 tokio-util = "0.7.8"
-actix = "0.13.0"
-url = "2.4.0"
-reqwest = { version = "0.11.18", features = ["blocking"] }
-serde_json = "1.0.102"
-serde = "1.0.171"
-chrono = "0.4.31"
-figment = { version = "0.10.10", features = ["env", "yaml"] }
-ic-interfaces-registry = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-registry-client-helpers = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-serde_yaml = "0.9.25"
-rand = "0.8.5"
 tracing = { version = "0.1.37", features = ["log"] }
-tracing-subscriber = "0.3.17"
 tracing-log = { version = "0.2.0", features = ["log-tracer"] }
-anyhow = "1.0.75"
+tracing-subscriber = "0.3.17"
+url = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.8.0"
+tempfile = { workspace = true }
 pretty_assertions = "1.4.0"
 httptest = "0.15.4"
 # Default features disabled because it would require env_logger, and we are not using it

--- a/rs/slack-notifications/Cargo.toml
+++ b/rs/slack-notifications/Cargo.toml
@@ -9,27 +9,23 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-nns-governance = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-common = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-registry-canister = { git = "https://github.com/dfinity/ic.git", rev = "4b3b2ce76c4bde0c1c60fb80b0915931003b7eca" }
-tokio = { version = "1.2.0", features = ["full"] }
-ic-agent = "0.27.0"
-ic-types = "0.7.0"
-candid = "0.9.5"
-anyhow = "1.0.44"
-reqwest = { version = "0.11.4", features = ["json"] }
-serde = "1.0.130"
-serde_yaml = "0.9.11"
-serde_json = "1.0.68"
-dotenv = "0.15.0"
-prost = "0.12.1"
-strum = "0.25.0"
-strum_macros = "0.25.1"
-retry = "2.0.0"
-itertools = "0.11.0"
-regex = "1.5.4"
-lazy_static = "1.4.0"
-log = "0.4.14"
-env_logger = "0.10.0"
-futures = "0.3.16"
+anyhow = { workspace = true }
+candid = { workspace = true }
+dotenv = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+ic-agent = { workspace = true }
+ic-nns-common = { workspace = true }
+ic-nns-constants = { workspace = true }
+ic-nns-governance = { workspace = true }
+itertools = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+regex = { workspace = true }
+registry-canister = { workspace = true }
+reqwest = { workspace = true }
+retry = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }

--- a/rs/slack-notifications/src/main.rs
+++ b/rs/slack-notifications/src/main.rs
@@ -2,6 +2,7 @@ use ic_nns_governance::pb::v1::{ListProposalInfo, ListProposalInfoResponse, Prop
 
 use anyhow::Result;
 use candid::Decode;
+use ic_agent::agent::http_transport::reqwest_transport::ReqwestHttpReplicaV2Transport;
 use ic_agent::Agent;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -93,8 +94,7 @@ impl ProposalPoller {
     fn new() -> Self {
         let agent = Agent::builder()
             .with_transport(
-                ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create("https://ic0.app")
-                    .expect("failed to create transport"),
+                ReqwestHttpReplicaV2Transport::create("https://ic0.app").expect("failed to create transport"),
             )
             .build()
             .expect("failed to build the agent");


### PR DESCRIPTION
This should slightly improve CI time since there will be less of a need to recompile multiple versions of the same crate