### PR TITLE
feat(ci): Automatically push containers if branch name starts with "container"

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -54,6 +54,6 @@ jobs:
           files: |
             release/*
       - name: Push images to GitHub Container Registry
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/container') }}
         run:
           bazel query --noshow_progress 'kind("oci_push", ...)' | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}


### PR DESCRIPTION
This pull request adds a new job to the CI pipeline that automatically pushes containers to the GitHub Container Registry if the branch name starts with "container". 

This can streamline the container development and deployment process.