### PR TITLE
fix(docs): Update the links for running the trustworthy metrics notebook online

### DIFF
--- a/docs/trustworthy-metrics/TrustworthyMetricsAnalytics.ipynb
+++ b/docs/trustworthy-metrics/TrustworthyMetricsAnalytics.ipynb
@@ -11,15 +11,15 @@
     "import numpy as np\n",
     "import pathlib\n",
     "import json\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import requests\n",
+    "import pathlib"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "dbbc6db6-faf4-4690-9a38-055a84c48ee9",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "# Load data"
    ]
@@ -31,6 +31,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "data_json = pathlib.Path(\"data.json\")\n",
+    "if not data_json.exists():\n",
+    "    contents = requests.get(\"https://github.com/dfinity/dre/raw/main/docs/trustworthy-metrics/data.json\").text\n",
+    "    data_json.write_text(contents)\n",
     "data = json.load(pathlib.Path(\"data.json\").open())\n",
     "data_flat = []\n",
     "for subnet_id, subnet_data in data.items():\n",
@@ -500,7 +504,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b4ab4655a4948aabe03a0739823edb0",
+       "model_id": "50a9615b28454f75a8da7c8c5763e2da",
        "version_major": 2,
        "version_minor": 0
       },

--- a/docs/trustworthy-metrics/trustworthy-metrics.md
+++ b/docs/trustworthy-metrics/trustworthy-metrics.md
@@ -73,7 +73,7 @@ If you used a purely new identity (which is advised since the tool can then para
     
 2. replace `<key-params>` in the command with something like: `--private-key-pem identity.pem`
 
-If you used an HSM then replace `<key-params>` with: `-hsm-slot 0 --hsm-key-id 0 --hsm-pin $(cat <pin-file>)`. Note that the HSM is less parallel than the key file due to hardware limits, so getting metrics with an HSM will be a bit slower.
+If you used an HSM then replace `<key-params>` with: `--hsm-slot 0 --hsm-key-id 0 --hsm-pin $(cat <pin-file>)`. Note that the HSM is less parallel than the key file due to hardware limits, so getting metrics with an HSM will be a bit slower.
 
 Even if created the wallet canister with an HSM you can still add another file-based controller to the wallet canister:
 
@@ -103,8 +103,9 @@ dre --private-key-pem identity.pem trustworthy-metrics nanx4-baaaa-aaaap-qb4sq-c
 
 Or with an HSM:
 ```bash
-dre --private-key-pem identity.pem trustworthy-metrics nanx4-baaaa-aaaap-qb4sq-cai 0 > data.json
+dre --hsm-slot 0 --hsm-key-id 0 --hsm-pin "<pin>" trustworthy-metrics nanx4-baaaa-aaaap-qb4sq-cai 0 > data.json
 ```
 
 You can check some examples of the analytics possible with the IC Mainnet data in the following [Jupyter Notebook](./TrustworthyMetricsAnalytics.ipynb)
-If you don't have Jupyter notebooks locally, you can use [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dfinity/dre/main?labpath=docs%2Ftrustworthy-metrics%2FTrustworthyMetricsAnalytics.ipynb) to run it online.
+
+If you don't have Jupyter notebooks locally, you can use [Google Colaboratory](https://colab.research.google.com/github/dfinity/dre/blob/main/docs/trustworthy-metrics/TrustworthyMetricsAnalytics.ipynb) or [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dfinity/dre/main?labpath=docs%2Ftrustworthy-metrics%2FTrustworthyMetricsAnalytics.ipynb) to run it online for free.


### PR DESCRIPTION
- Add a google colaboratory link
- Download data.json from the internet if not present locally (required by google colab)