### PR TITLE
feat(ci): Enable grouping of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,36 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "07:15"
+      timezone: "Etc/UTC"
+    groups:
+      # Group name will be used in PR titles and branch names
+      cargo-dependencies:
+        patterns:
+          - "*" # match all dependencies; risk: this may open a very large PR!
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "07:15"
+      timezone: "Etc/UTC"
+    groups:
+      # Group name will be used in PR titles and branch names
+      python-dependencies:
+        patterns:
+          - "*" # match all dependencies; risk: this may open a very large PR!
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+      day: "monday"
+      time: "07:15"
+      timezone: "Etc/UTC"
+    groups:
+      # Group name will be used in PR titles and branch names
+      github-actions-dependencies:
+        patterns:
+          - "*" # match all dependencies; risk: this may open a very large PR!


### PR DESCRIPTION
This pull request enables grouping of dependabot PRs by package ecosystem. It adds a schedule for checking updates to cargo dependencies, python dependencies, and GitHub Actions dependencies. The schedule is set to run every Monday at 07:15 UTC. This change aims to improve the organization and management of dependabot PRs.