### PR TITLE
fix(ci): Cloning k8s repo to a suitable directory

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -84,6 +84,8 @@ jobs:
         run: |
             set -eExou pipefail
 
+            cd .git
+
             # checkout branch
             git clone "https://gitlab-ci-token:${GITLAB_API_TOKEN}@gitlab.com/dfinity-lab/private/k8s/k8s.git"
 


### PR DESCRIPTION
Should fix https://github.com/dfinity/dre/actions/runs/7626415516/job/20772752035
> Run set -eExou pipefail
> + git clone ***gitlab.com/dfinity-lab/private/k8s/k8s.git
fatal: destination path 'k8s' already exists and is not an empty directory.
Error: Process completed with exit code 128.