### PR TITLE
feat(ci): Create a PR on nightly CI runs instead of directly pushing to main

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -2,17 +2,16 @@ name: Bazel
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
   merge_group:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '30 1 * * *'
+    - cron: "30 1 * * *"
 jobs:
   bazel:
     runs-on: ubuntu-22.04
     steps:
-
       ########################################
       # Setup
       ########################################
@@ -22,7 +21,7 @@ jobs:
           # this might remove tools that are actually needed,
           # when set to "true" but frees about 6 GB
           tool-cache: true
-          large-packages: false  # this is slow
+          large-packages: false # this is slow
       - uses: actions/checkout@v4
       - uses: bazelbuild/setup-bazelisk@v2
 
@@ -64,10 +63,11 @@ jobs:
           poetry update
           ./bin/poetry-export.sh
           CARGO_BAZEL_REPIN=true bazel query //...
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Create Pull Request
         if: "${{github.event.schedule == '30 1 * * *' && github.ref == 'refs/heads/main'}}"
+        uses: peter-evans/create-pull-request@v5
         with:
-          commit_message: Update dependencies
+          commit-message: Update dependencies
 
       ########################################
       # Build and test
@@ -119,8 +119,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push images to GitHub Container Registry
         if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
-        run:
-          bazel query --noshow_progress 'kind("oci_push", ...)' | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}
+        run: bazel query --noshow_progress 'kind("oci_push", ...)' | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}
 
       ########################################
       # Update k8s deployments
@@ -130,38 +129,38 @@ jobs:
         env:
           GITLAB_API_TOKEN: ${{ secrets.GITLAB_API_TOKEN }}
         run: |
-            set -eExou pipefail
+          set -eExou pipefail
 
-            cd .git
+          cd .git
 
-            # checkout branch
-            git clone "https://gitlab-ci-token:${GITLAB_API_TOKEN}@gitlab.com/dfinity-lab/private/k8s/k8s.git"
+          # checkout branch
+          git clone "https://gitlab-ci-token:${GITLAB_API_TOKEN}@gitlab.com/dfinity-lab/private/k8s/k8s.git"
 
-            cd k8s
-            git config user.email "idx@dfinity.org"
-            git config user.name "IDX Automation"
-            git checkout -b "update-image-tag-${GITHUB_SHA}"
+          cd k8s
+          git config user.email "idx@dfinity.org"
+          git config user.name "IDX Automation"
+          git checkout -b "update-image-tag-${GITHUB_SHA}"
 
-            # Update the internal dashboard image refs
-            # this regex matches the first group (ie the image name) and uses \1
-            # called a back-reference to insert the first group matched, the second
-            # part is to match the 40 characters hash that we replace with the $GITHUB_SHA
-            sed -i "s~\(\([[:alpha:]]\|-\)\+\):[[:alnum:]]\{40\}~\1:${GITHUB_SHA}~g" bases/apps/mainnet-dashboard/statefulset-slack.yaml bases/apps/mainnet-dashboard/backend/base/deployment.yaml bases/apps/mainnet-dashboard/frontend/deployment.yaml
+          # Update the internal dashboard image refs
+          # this regex matches the first group (ie the image name) and uses \1
+          # called a back-reference to insert the first group matched, the second
+          # part is to match the 40 characters hash that we replace with the $GITHUB_SHA
+          sed -i "s~\(\([[:alpha:]]\|-\)\+\):[[:alnum:]]\{40\}~\1:${GITHUB_SHA}~g" bases/apps/mainnet-dashboard/statefulset-slack.yaml bases/apps/mainnet-dashboard/backend/base/deployment.yaml bases/apps/mainnet-dashboard/frontend/deployment.yaml
 
-            # commit changes if there are any
-            git add .
-            if git diff --cached --quiet; then
-                echo "No changes to commit."
-                exit 0
-            fi
+          # commit changes if there are any
+          git add .
+          if git diff --cached --quiet; then
+              echo "No changes to commit."
+              exit 0
+          fi
 
-            # Push changes and create a new merge request
-            git commit -m "Updating container base image refs"
-            git push \
-                -o merge_request.create \
-                -o merge_request.title="[nomrbot] - Updating container image refs mainnet-dashboard [$GITHUB_SHA]" \
-                -o merge_request.description="Changes to the release repository - [here](https://github.com/dfinity/dre/commit/$GITHUB_SHA)" \
-                --force --set-upstream origin "update-image-tag-${GITHUB_SHA}"
+          # Push changes and create a new merge request
+          git commit -m "Updating container base image refs"
+          git push \
+              -o merge_request.create \
+              -o merge_request.title="[nomrbot] - Updating container image refs mainnet-dashboard [$GITHUB_SHA]" \
+              -o merge_request.description="Changes to the release repository - [here](https://github.com/dfinity/dre/commit/$GITHUB_SHA)" \
+              --force --set-upstream origin "update-image-tag-${GITHUB_SHA}"
 
       ########################################
       # Optimize bazel cache by hard-linking duplicate files


### PR DESCRIPTION
The CI job does not have the necessary privileges to push to main at the moment, and this might not be a great idea anyway. Example failed run: https://github.com/dfinity/dre/actions/runs/7648727685/job/20842002552

