### PR TITLE
Simplify the definition management code in multiservice-discovery.

### DIFF
--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -43,7 +43,7 @@ impl Definition {
     ) -> Self {
         let global_registry_path = std::fs::canonicalize(global_registry_path).expect("Invalid global registry path");
         // The path needs to be sanitized otherwise any file in the environment can be overwritten,
-        let sanitized_name = name.replace(".", "_").replace("/", "_");
+        let sanitized_name = name.replace(['.', '/'], "_");
         let registry_path = global_registry_path.join(sanitized_name);
         if std::fs::metadata(&registry_path).is_err() {
             std::fs::create_dir_all(registry_path.clone()).unwrap();

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/add_definition_handler.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/add_definition_handler.rs
@@ -59,7 +59,7 @@ async fn _add_definition(
     Ok(())
 }
 
-pub async fn add_definition(definition: DefinitionDto, binding: AddDefinitionBinding) -> WebResult<impl Reply> {
+pub(crate) async fn add_definition(definition: DefinitionDto, binding: AddDefinitionBinding) -> WebResult<impl Reply> {
     let log = binding.log.clone();
     let dname = definition.name.clone();
     match _add_definition(definition, binding).await {

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/dto.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/dto.rs
@@ -1,8 +1,16 @@
 use base64::{engine::general_purpose as b64, Engine as _};
-use std::collections::{BTreeMap, BTreeSet};
+use ic_crypto_utils_threshold_sig_der::parse_threshold_sig_key_from_der;
+use ic_registry_client::client::ThresholdSigPublicKey;
+use service_discovery::registry_sync::nns_reachable;
 
 use serde::{Deserialize, Serialize};
+use slog::Logger;
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt::{Display, Error as FmtError, Formatter};
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
 use url::Url;
 
 use crate::definition::Definition;
@@ -12,6 +20,70 @@ pub struct DefinitionDto {
     pub nns_urls: Vec<Url>,
     pub name: String,
     pub public_key: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) enum BadDtoError {
+    InvalidPublicKey(String, std::io::Error),
+    AlreadyExists(String),
+    NNSUnreachable(String),
+}
+
+impl Error for BadDtoError {}
+
+impl Display for BadDtoError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        match self {
+            Self::InvalidPublicKey(name, e) => {
+                write!(f, "public key of definition {} is invalid: {}", name, e)
+            }
+            Self::AlreadyExists(name) => write!(f, "definition {} already exists", name),
+            Self::NNSUnreachable(name) => {
+                write!(f, "cannot reach any of the NNS nodes specified in definition {}", name)
+            }
+        }
+    }
+}
+
+impl DefinitionDto {
+    pub(crate) async fn try_into_definition(
+        self,
+        log: Logger,
+        registry_path: PathBuf,
+        poll_interval: Duration,
+        registry_query_timeout: Duration,
+    ) -> Result<Definition, BadDtoError> {
+        if !nns_reachable(self.nns_urls.clone()).await {
+            return Err(BadDtoError::NNSUnreachable(self.name));
+        }
+
+        let (stop_signal_sender, stop_signal_rcv) = crossbeam::channel::bounded::<()>(0);
+        Ok(Definition::new(
+            self.nns_urls.clone(),
+            registry_path,
+            self.name.clone(),
+            log,
+            self.decode_public_key()?,
+            poll_interval,
+            stop_signal_rcv,
+            registry_query_timeout,
+            stop_signal_sender,
+        ))
+    }
+
+    fn decode_public_key(self) -> Result<Option<ThresholdSigPublicKey>, BadDtoError> {
+        match self.public_key {
+            Some(pk) => {
+                let decoded = b64::STANDARD.decode(pk).unwrap();
+
+                match parse_threshold_sig_key_from_der(&decoded) {
+                    Ok(key) => Ok(Some(key)),
+                    Err(e) => Err(BadDtoError::InvalidPublicKey(self.name, e)),
+                }
+            }
+            None => Ok(None),
+        }
+    }
 }
 
 impl From<&Definition> for DefinitionDto {

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/replace_definitions_handler.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/replace_definitions_handler.rs
@@ -105,7 +105,7 @@ async fn _replace_definitions(
     Ok(())
 }
 
-pub async fn replace_definitions(
+pub(crate) async fn replace_definitions(
     definitions: Vec<DefinitionDto>,
     binding: ReplaceDefinitionsBinding,
 ) -> WebResult<impl Reply> {


### PR DESCRIPTION
I did not get to do this earlier because we had crunch, but now that I have a little bit more time, I have invested it into cleaning up this code to remove duplication and make the two management operations more symmetrical.

There is another cleanup I have in mind which is to marry the thread join handle into the definition so that we don't have to carry two separate `Vec[]`s (one for definitions and one for their join handles), which is nasty and can induce bugs later.  That will have to wait until at least tomorrow, though.

Functionality is equivalent and has not changed.