### PR TITLE
fix(bazel): Update build configuration and version information

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --workspace_status_command=$(pwd)/bazel/workspace_status.sh
+build --workspace_status_command=$(pwd)/bazel/workspace_status.sh --stamp
 
 # Use local disk cache by default
 build --disk_cache=~/.cache/bazel/local_cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,15 +21,6 @@ jobs:
       ########################################
       # Build and test
       ########################################
-      - name: Set GIT_HASH variable
-        run: |
-          set -eExou pipefail
-          # Set GIT_HASH variable based on the type of GitHub reference
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            echo "GIT_HASH=$GITHUB_REF_NAME" >> "$GITHUB_ENV"  # Embed tag name as GIT_HASH
-          else
-            echo "GIT_HASH=$GITHUB_SHA" >> "$GITHUB_ENV"  # Embed commit SHA as GIT_HASH
-          fi
       - run: bazel build ...
         name: Building
       - run: bazel test ...

--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 echo "BUILD_TIME \"$(TZ=UTC date --rfc-3339=seconds)\""
 
 GIT_REV=$(git tag --points-at HEAD)
-if [[ -z "${GITREV:-}" ]]; then GIT_REV=$(git rev-parse HEAD); fi
+if [[ -z "${GITREV:-}" ]]; then GIT_REV=$(git describe --always --dirty); fi
 
 echo "GIT_REV ${GIT_REV:-unset}"
 

--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -2,8 +2,12 @@
 
 set -euo pipefail
 
-if [[ ! -z "${CI_COMMIT_SHA+x}" ]]; then
-    echo GIT_HASH "${CI_COMMIT_SHA}"
-else
-    echo GIT_HASH $(git rev-parse HEAD)
-fi
+echo "BUILD_TIME \"$(TZ=UTC date --rfc-3339=seconds)\""
+
+GIT_REV=$(git tag --points-at HEAD)
+if [[ -z "${GITREV:-}" ]]; then GIT_REV=$(git rev-parse HEAD); fi
+
+echo "GIT_REV ${GIT_REV:-unset}"
+
+RELEASE_VERSION=$(grep ^version Cargo.toml | cut -d\" -f2)
+echo "RELEASE_VERSION ${RELEASE_VERSION:-unset}"

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -1,13 +1,11 @@
 load("@crate_index_dre//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
-load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 DEPS = [
     "//rs/ic-canisters",
     "//rs/decentralization",
     "//rs/ic-management-types",
     "//rs/ic-management-backend:ic-management-backend-lib",
-    ":build_script",
 ]
 
 rust_binary(
@@ -18,7 +16,6 @@ rust_binary(
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
-    stamp = 1,
     deps = all_crate_deps(
         normal = True,
     ) + DEPS,
@@ -45,9 +42,3 @@ genrule(
     cmd = "echo \"CARGO_PKG_VERSION=$$(awk '$$1 == \"RELEASE_VERSION\" {print $$2}' bazel-out/volatile-status.txt)-$$(awk '$$1 == \"GIT_REV\" {print $$2}' bazel-out/volatile-status.txt)\" > $@",
     stamp = True,
 )
-
-cargo_build_script(
-    name = "build_script",
-    srcs = ["build.rs"],
-)
-

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -14,6 +14,7 @@ rust_binary(
     name = "dre",
     srcs = glob(["src/**/*.rs"]),
     aliases = aliases(),
+    rustc_env_files = [":generate_rustc_env_file"],
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
@@ -38,13 +39,15 @@ rust_test(
     ) + DEPS,
 )
 
+genrule(
+    name = "generate_rustc_env_file",
+    outs = ["rustc_env_file"],
+    cmd = "echo \"CARGO_PKG_VERSION=$$(awk '$$1 == \"RELEASE_VERSION\" {print $$2}' bazel-out/volatile-status.txt)-$$(awk '$$1 == \"GIT_REV\" {print $$2}' bazel-out/volatile-status.txt)\" > $@",
+    stamp = True,
+)
+
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
 )
-# rustc_env_files... has been disabled
-# the correct way to pass this variable into build.rs
-# is to either let build.rs use git to determine the
-# correct git hash (the default) or set the variable
-# GIT_HASH in the bazel build process, and pass additional
-# argument --action_env=GIT_HASH.
+

--- a/rs/cli/build.rs
+++ b/rs/cli/build.rs
@@ -1,10 +1,18 @@
-// build.rs
-
+// Construct a useful and specific version string for the CLI
 use std::process::Command;
+
 fn main() {
     // taken from https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
     let git_rev = option_env!("GIT_REV").map(String::from).unwrap_or_else(|| {
-        String::from_utf8(Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap().stdout).unwrap()
+        String::from_utf8(
+            // https://stackoverflow.com/questions/21017300/git-command-to-get-head-sha1-with-dirty-suffix-if-workspace-is-not-clean
+            Command::new("git")
+                .args(["describe", "--always", "--dirty"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
     });
     if !git_rev.is_empty() {
         println!(

--- a/rs/cli/build.rs
+++ b/rs/cli/build.rs
@@ -3,8 +3,15 @@
 use std::process::Command;
 fn main() {
     // taken from https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
-    let git_hash = option_env!("GIT_HASH").map(String::from).unwrap_or_else(|| {
+    let git_rev = option_env!("GIT_REV").map(String::from).unwrap_or_else(|| {
         String::from_utf8(Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap().stdout).unwrap()
     });
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    if !git_rev.is_empty() {
+        println!(
+            "cargo:rustc-env=CARGO_PKG_VERSION={}",
+            option_env!("CARGO_PKG_VERSION")
+                .map(|v| format!("{}-{}", v, git_rev))
+                .unwrap_or_default()
+        );
+    }
 }

--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -8,7 +8,7 @@ use crate::detect_neuron::{detect_hsm_auth, detect_neuron, Auth, Neuron};
 
 // For more info about the version setup, look at https://docs.rs/clap/latest/clap/struct.Command.html#method.version
 #[derive(Parser, Clone)]
-#[clap(about, version = env!("GIT_HASH"), author)]
+#[clap(about, version = env!("CARGO_PKG_VERSION"), author)]
 pub struct Opts {
     #[clap(long, env = "HSM_PIN", global = true)]
     pub(crate) hsm_pin: Option<String>,

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -28,7 +28,7 @@ const STAGING_NEURON_ID: u64 = 49;
 async fn main() -> Result<(), anyhow::Error> {
     dotenv().ok();
     init_logger();
-    info!("Running version {}", env!("GIT_HASH"));
+    info!("Running version {}", env!("CARGO_PKG_VERSION"));
 
     let mut cli_opts = cli::Opts::parse();
     let mut cmd = cli::Opts::command();


### PR DESCRIPTION
Before the change, with bazel builds:
```
./bazel-bin/rs/cli/dre --version
 INFO  dre > Running version 
dre 
```

After the change:
```
$ bazel run //rs/cli:dre -- --version
[...]
 INFO  dre > Running version 0.2.0-5aaa4fa-dirty
dre 0.2.0-5aaa4fa-dirty
```

The version is picked up automatically from `Cargo.toml` and git. Build is done as usual.

Bazel changes based on https://github.com/bazelbuild/rules_rust/blob/fe610dab73c3c61560a547bc661177dd5115fed7/examples/version_stamping/BUILD.bazel#L15