### PR TITLE
Fix multiservice-discovery test to run with Cargo and Bazel

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ec753ecb06335b978717a4f454580c78e4088f9255e77c92f1482b6dd3487532",
+  "checksum": "50059ed743d8139dafd6e4b27ef55253af52088328687ea060a031b67d599b07",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -27157,29 +27157,23 @@
         ],
         "crate_features": {
           "common": [
+            "elf",
+            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "std"
             ],
             "arm-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "std"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "std"
             ],
             "i686-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "std"
             ],
             "powerpc-unknown-linux-gnu": [
@@ -27189,8 +27183,6 @@
               "std"
             ],
             "x86_64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "std"
             ]
           }

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "50059ed743d8139dafd6e4b27ef55253af52088328687ea060a031b67d599b07",
+  "checksum": "2e3669d8fedffc2506c83062bc95f388e47024b0487866af5d65ad4e26756be3",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -27157,23 +27157,29 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "std"
             ],
             "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "std"
             ],
             "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
               "std"
             ],
             "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "std"
             ],
             "powerpc-unknown-linux-gnu": [
@@ -27183,6 +27189,8 @@
               "std"
             ],
             "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
               "std"
             ]
           }

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "fdd95fd9da734e10bce28317e6c1ca023d7a38e61e439eba2df424fc47224d40",
+  "checksum": "ec753ecb06335b978717a4f454580c78e4088f9255e77c92f1482b6dd3487532",
   "crates": {
     "actix-codec 0.5.1": {
       "name": "actix-codec",
@@ -12371,6 +12371,64 @@
         },
         "edition": "2021",
         "version": "0.13.0"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "filetime 0.2.23": {
+      "name": "filetime",
+      "version": "0.2.23",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/filetime/0.2.23/download",
+          "sha256": "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "filetime",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "filetime",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"redox\")": [
+              {
+                "id": "redox_syscall 0.4.1",
+                "target": "syscall"
+              }
+            ],
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.152",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.52.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.2.23"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -27099,13 +27157,43 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "elf",
+              "errno",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "elf",
+              "errno",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "elf",
+              "errno",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "elf",
+              "errno",
+              "std"
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.4.13"
@@ -28536,8 +28624,20 @@
               "target": "assert_cmd"
             },
             {
+              "id": "dirs 5.0.1",
+              "target": "dirs"
+            },
+            {
+              "id": "flate2 1.0.28",
+              "target": "flate2"
+            },
+            {
               "id": "reqwest 0.11.23",
               "target": "reqwest"
+            },
+            {
+              "id": "tar 0.4.40",
+              "target": "tar"
             },
             {
               "id": "tempfile 3.9.0",
@@ -40873,6 +40973,63 @@
       },
       "license": "MIT"
     },
+    "tar 0.4.40": {
+      "name": "tar",
+      "version": "0.4.40",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tar/0.4.40/download",
+          "sha256": "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tar",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "tar",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "xattr"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "filetime 0.2.23",
+              "target": "filetime"
+            }
+          ],
+          "selects": {
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.152",
+                "target": "libc"
+              },
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.4.40"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "tempfile 3.9.0": {
       "name": "tempfile",
       "version": "3.9.0",
@@ -47338,6 +47495,65 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "xattr 1.3.1": {
+      "name": "xattr",
+      "version": "1.3.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/xattr/1.3.1/download",
+          "sha256": "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "xattr",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "xattr",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "unsupported"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "rustix 0.38.30",
+              "target": "rustix"
+            }
+          ],
+          "selects": {
+            "cfg(any(target_os = \"freebsd\", target_os = \"netbsd\"))": [
+              {
+                "id": "libc 0.2.152",
+                "target": "libc"
+              }
+            ],
+            "cfg(target_os = \"linux\")": [
+              {
+                "id": "linux-raw-sys 0.4.13",
+                "target": "linux_raw_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "1.3.1"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "xdg-home 1.0.0": {
       "name": "xdg-home",
       "version": "1.0.0",
@@ -48485,6 +48701,10 @@
       "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"illumos\", target_os = \"netbsd\", target_os = \"openbsd\", target_os = \"solaris\"))": [
+      "i686-unknown-freebsd",
+      "x86_64-unknown-freebsd"
+    ],
+    "cfg(any(target_os = \"freebsd\", target_os = \"netbsd\"))": [
       "i686-unknown-freebsd",
       "x86_64-unknown-freebsd"
     ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5711,7 +5723,9 @@ dependencies = [
  "clap 4.4.18",
  "crossbeam",
  "crossbeam-channel",
+ "dirs",
  "erased-serde 0.4.2",
+ "flate2",
  "futures-util",
  "humantime",
  "ic-async-utils",
@@ -5728,6 +5742,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
+ "tar",
  "tempfile",
  "tokio",
  "url",
@@ -8073,6 +8088,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9215,6 +9241,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.30",
 ]
 
 [[package]]

--- a/bazel-dre-1
+++ b/bazel-dre-1
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_pietro.di.marco/b166ba5137d2b5b80ccec0055091def4/execroot/dre

--- a/rs/ic-observability/multiservice-discovery/Cargo.toml
+++ b/rs/ic-observability/multiservice-discovery/Cargo.toml
@@ -35,3 +35,6 @@ tempfile = { workspace = true }
 reqwest = { version = "0.11", features = ["blocking"] }
 assert_cmd = "2.0.13"
 anyhow = "1.0.79"
+flate2 = "1.0.28"
+tar = "0.4.40"
+dirs = "5.0.1"

--- a/rs/ic-observability/multiservice-discovery/README.md
+++ b/rs/ic-observability/multiservice-discovery/README.md
@@ -12,6 +12,31 @@ networks on the fly.
 Containers built by the DRE repository CI are published to [GHCR](https://ghcr.io/dfinity/dre/).
 They are only built from PRs stemming from branches named `container-*`.
 
+## Test
+
+We are performing these checks to ensure that the multiservice-discovery fetches all the necessary targets
+before deploying it in production.
+If less or erroneus targets end up in production, we risk compromising the observability stack leading
+to incomplete or erroneus observability data.
+If the mainnet registry gets updated or if the logic for target discovery is modified,
+this assertions should be updated accordingly.
+One can run the multiservice-discovery from local and manually update the targets after inspection:
+
+```bash
+mkdir /tmp/mainnet-registry
+cargo run --package multiservice-discovery -- --targets-dir /tmp/mainnet-registry
+curl -L -v http://localhost:8000/prom/targets > targets.json
+
+# Check number of targets:
+jq -r '[.[] | .targets[]] | length' targets.json
+
+# List unique jobs:
+jq -r '.[].labels.job' targets.json | sort -u
+
+# List unique subnets:
+jq -r '.[].labels.ic_subnet'  targets.json | sort -u
+```
+
 ## API spec
 
 ### `GET` /
@@ -73,11 +98,10 @@ Use content type `application/json` and submit a body like this:
 
 **NOTE**: The `name` field should be unique within the instance of the service discovery.
 
-
 ### `PUT` /
 
 Replaces all known IC networks for scraping by the multiservice discovery with a new
-list of IC networks.  The content type is `application/json` with a content like:
+list of IC networks. The content type is `application/json` with a content like:
 
 ```JSON
 [
@@ -123,7 +147,7 @@ Used for retrieving a list of nodes available from all the scraping targets of t
 ```JSON
 [
     {
-        "node_id": "o4j7n-2j2vj-xutgj-4n4it-xfnqw-o6gdr-zpumz-aaogx-znicu-bezl3-jqe", 
+        "node_id": "o4j7n-2j2vj-xutgj-4n4it-xfnqw-o6gdr-zpumz-aaogx-znicu-bezl3-jqe",
         "ic_name": "benchmarkxsmall01", // This entry is linked to the scraping target named benchmarkxsmall01
         "targets": [
             "[2a00:fb01:400:42:5000:aeff:fee0:fc5f]:9090"
@@ -155,7 +179,7 @@ Used for adding boundary nodes to a certain scraping target. Since they are not 
 
 ```JSON
 {
-    "name": "bnp-00" 
+    "name": "bnp-00"
     "ic_name": "benchmarkxsmall01",
     "custom_labels": {
         "example": "value"

--- a/rs/ic-observability/multiservice-discovery/tests/tests.rs
+++ b/rs/ic-observability/multiservice-discovery/tests/tests.rs
@@ -105,7 +105,7 @@ mod tests {
                     acc
                 });
 
-        assert_eq!(targets.len(), 7364);
+        assert_eq!(targets.len(), 7274);
 
         assert_eq!(
             labels_set.get(IC_NAME).unwrap().iter().collect::<Vec<_>>(),

--- a/rs/ic-observability/multiservice-discovery/tests/tests.rs
+++ b/rs/ic-observability/multiservice-discovery/tests/tests.rs
@@ -23,7 +23,7 @@ mod tests {
 
     const REGISTRY_MAINNET_URL: &str = "https://github.com/dfinity/dre/raw/ic-registry-mainnet/rs/ic-observability/multiservice-discovery/tests/test_data/mercury.tar.gz";
 
-    async fn fetch_targets() -> anyhow::Result<BTreeSet<PrometheusStaticConfig>> {
+    async fn fetch_targets() -> anyhow::Result<Vec<PrometheusStaticConfig>> {
         let timeout_duration = Duration::from_secs(300);
         let start_time = std::time::Instant::now();
 
@@ -34,7 +34,7 @@ mod tests {
             if let Ok(response) = reqwest::get("http://localhost:8000/prom/targets").await {
                 if response.status().is_success() {
                     let text = response.text().await?;
-                    let targets: BTreeSet<PrometheusStaticConfig> = serde_json::from_str(&text).unwrap();
+                    let targets: Vec<PrometheusStaticConfig> = serde_json::from_str(&text).unwrap();
                     return Ok(targets);
                 }
             }
@@ -105,7 +105,7 @@ mod tests {
                     acc
                 });
 
-        assert_eq!(targets.len(), 7359);
+        assert_eq!(targets.len(), 7364);
 
         assert_eq!(
             labels_set.get(IC_NAME).unwrap().iter().collect::<Vec<_>>(),


### PR DESCRIPTION
- Add the possibility to run the test with `cargo test`
- Fix Bazel test retrying the connection to sd-service in case of failure
- Add docs how to update the test in case of failure