### PR TITLE
fix(ci): Use a GitHub PAT when creating PR automatically

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           commit-message: "chore: Update dependencies"
           branch: bot-update-deps
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
 
       - name: "🪓 Tear down runner"
         uses: ./.github/workflows/manage-runner-post


### PR DESCRIPTION
Using `GITHUB_TOKEN` results in the workflow not being triggered, as per https://github.com/orgs/community/discussions/25602