### PR TITLE
Refactor metrics to simplify updating the values

### DIFF
--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -488,7 +488,6 @@ impl DefinitionsSupervisor {
                     let fs_def: Vec<FSDefinition> = existing
                         .values()
                         .cloned()
-                        .into_iter()
                         .map(|running_def| running_def.definition.into())
                         .collect::<Vec<_>>();
 

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -255,7 +255,9 @@ impl RunningDefinition {
 
         // FIXME: sync_local_registry() needs to update the metrics just
         // as poll_loop() does.  Otherwise an initially hung or failed
-        // sync_local_registry() is going to give false results.
+        // sync_local_registry() is not going to be trackable via metrics.
+        // Right now, the callee simply says metrics sync successful once
+        // this function returns.
         let r = sync_local_registry(
             self.definition.log.clone(),
             self.definition.registry_path.join("targets"),

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -459,6 +459,11 @@ impl DefinitionsSupervisor {
         }
     }
 
+    // FIXME: if the file is corrupted, that may be a partial write from another
+    // MSD sharing the same directory.  Retry the error.
+    // FIXME: definitions should be reloaded if the file is changed.
+    // FIXME: if the definitions loaded are the same as the currently-loaded
+    // definitions, no action should be taken on this MSD.
     pub(crate) async fn load_or_create_defs(
         &self,
         networks_state_file: PathBuf,
@@ -477,6 +482,9 @@ impl DefinitionsSupervisor {
         Ok(())
     }
 
+    // FIXME: if the file contents on disk are the same as the contents about to
+    // be persisted, then the file should not be overwritten because it was
+    // already updated by another MSD sharing the same directory.
     pub(crate) async fn persist_defs(&self, networks_state_file: PathBuf) -> Result<(), Box<dyn Error>> {
         let existing = self.definitions.lock().await;
         retry::retry(retry::delay::Exponential::from_millis(10).take(5), || {

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -295,9 +295,9 @@ impl RunningDefinition {
                     self.definition.log,
                     "Failed to load new scraping targets for {} @ interval {:?}: {:?}", self.definition.name, tick, e
                 );
-                self.metrics.observe_load(self.name(), true)
-            } else {
                 self.metrics.observe_load(self.name(), false)
+            } else {
+                self.metrics.observe_load(self.name(), true)
             }
             debug!(self.definition.log, "Update registries for {}", self.definition.name);
             if let Err(e) = self.definition.ic_discovery.update_registries().await {
@@ -305,9 +305,9 @@ impl RunningDefinition {
                     self.definition.log,
                     "Failed to sync registry for {} @ interval {:?}: {:?}", self.definition.name, tick, e
                 );
-                self.metrics.observe_sync(self.name(), true)
-            } else {
                 self.metrics.observe_sync(self.name(), false)
+            } else {
+                self.metrics.observe_sync(self.name(), true)
             }
 
             tick = crossbeam::select! {

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -322,21 +322,6 @@ impl RunningDefinition {
         }
     }
 
-    pub(crate) async fn add_boundary_node(&mut self, target: BoundaryNode) -> Result<(), BoundaryNodeAlreadyExists> {
-        // Lock modifications to this object while mods are happening.
-        match self.ender.lock().await.as_ref() {
-            Some(_) => {
-                if let Some(bn) = self.definition.boundary_nodes.iter().find(|bn| bn.name == target.name) {
-                    return Err(BoundaryNodeAlreadyExists { name: bn.name.clone() });
-                };
-
-                self.definition.boundary_nodes.push(target);
-                Ok(())
-            }
-            _ => Ok(()), // Ended.  Do nothing.
-        }
-    }
-
     // Syncs the registry and keeps running, syncing as new
     // registry versions come in.
     async fn run(&mut self) {
@@ -360,6 +345,21 @@ impl RunningDefinition {
         // because another definition may be started in its name,
         // so it is racy to delete the folder it will be using.
         // So we no longer delete storage here.
+    }
+
+    pub(crate) async fn add_boundary_node(&mut self, target: BoundaryNode) -> Result<(), BoundaryNodeAlreadyExists> {
+        // Lock modifications to this object while mods are happening.
+        match self.ender.lock().await.as_ref() {
+            Some(_) => {
+                if let Some(bn) = self.definition.boundary_nodes.iter().find(|bn| bn.name == target.name) {
+                    return Err(BoundaryNodeAlreadyExists { name: bn.name.clone() });
+                };
+
+                self.definition.boundary_nodes.push(target);
+                Ok(())
+            }
+            _ => Ok(()), // Ended.  Do nothing.
+        }
     }
 
     pub fn name(&self) -> String {

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -295,9 +295,9 @@ impl RunningDefinition {
                     self.definition.log,
                     "Failed to load new scraping targets for {} @ interval {:?}: {:?}", self.definition.name, tick, e
                 );
-                self.metrics.observe_load(self.name(), false)
-            } else {
                 self.metrics.observe_load(self.name(), true)
+            } else {
+                self.metrics.observe_load(self.name(), false)
             }
             debug!(self.definition.log, "Update registries for {}", self.definition.name);
             if let Err(e) = self.definition.ic_discovery.update_registries().await {
@@ -305,7 +305,7 @@ impl RunningDefinition {
                     self.definition.log,
                     "Failed to sync registry for {} @ interval {:?}: {:?}", self.definition.name, tick, e
                 );
-                self.metrics.observe_sync(self.name(), false)
+                self.metrics.observe_sync(self.name(), true)
             } else {
                 self.metrics.observe_sync(self.name(), false)
             }

--- a/rs/ic-observability/multiservice-discovery/src/main.rs
+++ b/rs/ic-observability/multiservice-discovery/src/main.rs
@@ -118,6 +118,8 @@ fn main() {
         server_stop.send(()).unwrap();
 
         // Persist definitions to disk before ending the supervisor.
+        // FIXME: persistence should happen when the definitions structure
+        // changes, not just on end.  E.g. when a public key is updated.
         if let Some(networks_state_file) = cli_args.networks_state_file.clone() {
             rt.block_on(supervisor.persist_defs(networks_state_file)).unwrap();
         }

--- a/rs/ic-observability/multiservice-discovery/src/metrics.rs
+++ b/rs/ic-observability/multiservice-discovery/src/metrics.rs
@@ -1,20 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
-use opentelemetry::{
-    global,
-    metrics::{CallbackRegistration, ObservableGauge},
-    KeyValue,
-};
-use slog::{error, info, Logger};
-use tokio::sync::Mutex;
+use opentelemetry::{global, KeyValue};
+use std::sync::Mutex;
 
 const NETWORK: &str = "network";
 const AXUM_APP: &str = "axum-app";
-const LOAD: &str = "load";
-const SYNC: &str = "sync";
-
-type StatusCallbacks = Arc<Mutex<HashMap<String, Vec<Box<dyn CallbackRegistration>>>>>;
-type ValueCallbacks = Arc<Mutex<HashMap<String, Vec<NamedCallbackWithValue<i64>>>>>;
 
 #[derive(Clone)]
 pub struct MSDMetrics {
@@ -35,274 +25,164 @@ impl MSDMetrics {
     }
 }
 
+struct LatestValues {
+    load_new_targets_error: u64,
+    sync_registry_error: u64,
+    definitions_load_successful: u64,
+    definitions_sync_successful: u64,
+}
+
+impl LatestValues {
+    fn new() -> Self {
+        Self {
+            load_new_targets_error: 0,
+            sync_registry_error: 0,
+            definitions_load_successful: 0,
+            definitions_sync_successful: 0,
+        }
+    }
+}
+
+type LatestValuesByNetwork = HashMap<String, LatestValues>;
+
 #[derive(Clone)]
 pub struct RunningDefinitionsMetrics {
-    pub load_new_targets_error: ObservableGauge<i64>,
-    pub definitions_load_successful: ObservableGauge<i64>,
-
-    pub sync_registry_error: ObservableGauge<i64>,
-    pub definitions_sync_successful: ObservableGauge<i64>,
-
-    definition_status_callbacks: StatusCallbacks,
-    definition_value_callbacks: ValueCallbacks,
+    latest_values: Arc<Mutex<LatestValuesByNetwork>>,
 }
 
 impl RunningDefinitionsMetrics {
     pub fn new() -> Self {
         let meter = global::meter(AXUM_APP);
         let load_new_targets_error = meter
-            .i64_observable_gauge("msd.definitions.load.errors")
+            .u64_observable_gauge("msd.definitions.load.errors")
             .with_description("Total number of errors while loading new targets per definition")
             .init();
 
         let sync_registry_error = meter
-            .i64_observable_gauge("msd.definitions.sync.errors")
+            .u64_observable_gauge("msd.definitions.sync.errors")
             .with_description("Total number of errors while syncing the registry per definition")
             .init();
 
         let definitions_load_successful = meter
-            .i64_observable_gauge("msd.definitions.load.successful")
+            .u64_observable_gauge("msd.definitions.load.successful")
             .with_description("Status of last load of the registry per definition")
             .init();
 
         let definitions_sync_successful = meter
-            .i64_observable_gauge("msd.definitions.sync.successful")
+            .u64_observable_gauge("msd.definitions.sync.successful")
             .with_description("Status of last sync of the registry with NNS of definition")
             .init();
 
+        let latest_values_arc = Arc::new(Mutex::new(LatestValuesByNetwork::new()));
+
+        let s = latest_values_arc.clone();
+        meter
+            .register_callback(&[load_new_targets_error.as_any()], move |observer| {
+                // We blocking-lock because this is not async code, and this code
+                // does not need to be async, since it just needs to read local data.
+                // C.f. https://docs.rs/tokio/1.24.2/tokio/sync/struct.Mutex.html#method.blocking_lock
+                let l = s.lock().unwrap();
+                for (network, seen_value) in l.iter() {
+                    observer.observe_u64(
+                        &load_new_targets_error,
+                        seen_value.load_new_targets_error,
+                        &[KeyValue::new(NETWORK, network.clone())],
+                    )
+                }
+            })
+            .unwrap();
+
+        let s = latest_values_arc.clone();
+        meter
+            .register_callback(&[sync_registry_error.as_any()], move |observer| {
+                let l = s.lock().unwrap();
+                for (network, seen_value) in l.iter() {
+                    observer.observe_u64(
+                        &sync_registry_error,
+                        seen_value.sync_registry_error,
+                        &[KeyValue::new(NETWORK, network.clone())],
+                    )
+                }
+            })
+            .unwrap();
+
+        let s = latest_values_arc.clone();
+        meter
+            .register_callback(&[definitions_load_successful.as_any()], move |observer| {
+                let l = s.lock().unwrap();
+                for (network, seen_value) in l.iter() {
+                    observer.observe_u64(
+                        &definitions_load_successful,
+                        seen_value.definitions_load_successful,
+                        &[KeyValue::new(NETWORK, network.clone())],
+                    )
+                }
+            })
+            .unwrap();
+
+        let s = latest_values_arc.clone();
+        meter
+            .register_callback(&[definitions_sync_successful.as_any()], move |observer| {
+                let l = s.lock().unwrap();
+                for (network, seen_value) in l.iter() {
+                    observer.observe_u64(
+                        &definitions_sync_successful,
+                        seen_value.definitions_sync_successful,
+                        &[KeyValue::new(NETWORK, network.clone())],
+                    )
+                }
+            })
+            .unwrap();
+
         Self {
-            load_new_targets_error,
-            definitions_load_successful,
-            sync_registry_error,
-            definitions_sync_successful,
-            definition_status_callbacks: Arc::new(Mutex::new(HashMap::new())),
-            definition_value_callbacks: Arc::new(Mutex::new(HashMap::new())),
+            latest_values: latest_values_arc,
         }
     }
 
-    pub async fn inc_load_errors(&self, network: String, logger: Logger) {
-        Self::inc_counter(
-            network,
-            logger,
-            &self.definition_value_callbacks,
-            &self.load_new_targets_error,
-            LOAD.to_string(),
-        )
-        .await
+    pub fn inc_load_errors(&self, network: String) {
+        let mut s = self.latest_values.lock().unwrap();
+        s.entry(network)
+            .and_modify(|latest_values| latest_values.load_new_targets_error += 1)
+            .or_insert(LatestValues::new());
     }
 
-    pub async fn inc_sync_errors(&self, network: String, logger: Logger) {
-        Self::inc_counter(
-            network,
-            logger,
-            &self.definition_value_callbacks,
-            &self.sync_registry_error,
-            SYNC.to_string(),
-        )
-        .await
+    pub fn inc_sync_errors(&self, network: String) {
+        let mut s = self.latest_values.lock().unwrap();
+        s.entry(network)
+            .and_modify(|latest_values| latest_values.sync_registry_error += 1)
+            .or_insert(LatestValues::new());
     }
 
-    pub async fn set_successful_sync(&mut self, network: String, logger: Logger) {
-        Self::set_status(
-            network,
-            logger,
-            1,
-            &self.definitions_sync_successful,
-            &self.definition_status_callbacks,
-        )
-        .await
+    pub fn set_successful_sync(&mut self, network: String) {
+        let mut s = self.latest_values.lock().unwrap();
+        s.entry(network)
+            .and_modify(|latest_values| latest_values.definitions_sync_successful = 1)
+            .or_insert(LatestValues::new());
     }
 
-    pub async fn set_failed_sync(&mut self, network: String, logger: Logger) {
-        Self::set_status(
-            network,
-            logger,
-            0,
-            &self.definitions_sync_successful,
-            &self.definition_status_callbacks,
-        )
-        .await
+    pub fn set_failed_sync(&mut self, network: String) {
+        let mut s = self.latest_values.lock().unwrap();
+        s.entry(network)
+            .and_modify(|latest_values| latest_values.definitions_sync_successful = 0)
+            .or_insert(LatestValues::new());
     }
 
-    pub async fn set_successful_load(&mut self, network: String, logger: Logger) {
-        Self::set_status(
-            network,
-            logger,
-            1,
-            &self.definitions_load_successful,
-            &self.definition_status_callbacks,
-        )
-        .await
+    pub fn set_successful_load(&mut self, network: String) {
+        let mut s = self.latest_values.lock().unwrap();
+        s.entry(network)
+            .and_modify(|latest_values| latest_values.definitions_load_successful = 1)
+            .or_insert(LatestValues::new());
     }
 
-    pub async fn set_failed_load(&mut self, network: String, logger: Logger) {
-        Self::set_status(
-            network,
-            logger,
-            0,
-            &self.definitions_load_successful,
-            &self.definition_status_callbacks,
-        )
-        .await
+    pub fn set_failed_load(&mut self, network: String) {
+        let mut s = self.latest_values.lock().unwrap();
+        s.entry(network)
+            .and_modify(|latest_values| latest_values.definitions_load_successful = 0)
+            .or_insert(LatestValues::new());
     }
 
-    async fn set_status(
-        network: String,
-        logger: Logger,
-        status: i64,
-        gague: &ObservableGauge<i64>,
-        callbacks: &StatusCallbacks,
-    ) {
-        let meter = global::meter(AXUM_APP);
-        let network_clone = network.clone();
-        let local_clone = gague.clone();
-
-        match meter.register_callback(&[local_clone.as_any()], move |observer| {
-            observer.observe_i64(&local_clone, status, &[KeyValue::new(NETWORK, network.clone())])
-        }) {
-            Ok(callback) => {
-                info!(logger, "Registering callback for '{}'", &network_clone);
-                let mut locked = callbacks.lock().await;
-
-                if let Some(definition) = locked.get_mut(&network_clone) {
-                    definition.push(callback)
-                } else {
-                    locked.insert(network_clone, vec![callback]);
-                }
-            }
-            Err(e) => error!(
-                logger,
-                "Couldn't register callback for network '{}': {:?}", network_clone, e
-            ),
-        }
+    pub fn set_ended(&mut self, network: String) {
+        let mut s = self.latest_values.lock().unwrap();
+        s.remove(&network);
     }
-
-    pub async fn unregister_callback(&self, network: String, logger: Logger) {
-        self.unregister_unnamed_callback(network.clone(), logger.clone()).await;
-        self.unregister_named_callback(network, logger).await
-    }
-
-    async fn unregister_named_callback(&self, network: String, logger: Logger) {
-        let mut locked = self.definition_value_callbacks.lock().await;
-
-        if let Some(callbacks) = locked.remove(&network) {
-            for mut nc in callbacks {
-                if let Err(e) = nc.callback.unregister() {
-                    error!(
-                        logger,
-                        "Couldn't unregister callback for network '{}': {:?}", network, e
-                    )
-                }
-            }
-        }
-    }
-
-    async fn unregister_unnamed_callback(&self, network: String, logger: Logger) {
-        let mut locked = self.definition_status_callbacks.lock().await;
-
-        if let Some(callbacks) = locked.remove(&network) {
-            for mut callback in callbacks {
-                if let Err(e) = callback.unregister() {
-                    error!(
-                        logger,
-                        "Couldn't unregister callback for network '{}': {:?}", network, e
-                    )
-                }
-            }
-        } else {
-            error!(
-                logger,
-                "Couldn't unregister callbacks for network '{}': key not found", &network
-            )
-        }
-    }
-
-    async fn inc_counter(
-        network: String,
-        logger: Logger,
-        callbacks: &ValueCallbacks,
-        counter: &ObservableGauge<i64>,
-        metric_name: String,
-    ) {
-        let mut locked = callbacks.lock().await;
-        let network_clone = network.clone();
-        let meter = global::meter(AXUM_APP);
-        let local_clone = counter.clone();
-
-        match locked.get_mut(&network) {
-            Some(callbacks) => match callbacks.iter_mut().find(|nc| nc.name == metric_name) {
-                Some(nc) => {
-                    info!(logger, "Updating the named callback for network '{}'", network.clone());
-                    if let Err(e) = nc.callback.unregister() {
-                        error!(logger, "Couldn't unregister metric for network '{}': {:?}", network, e);
-                        return;
-                    }
-
-                    nc.value += 1;
-                    let cloned = nc.value;
-
-                    match meter.register_callback(&[local_clone.as_any()], move |observer| {
-                        observer.observe_i64(&local_clone, cloned, &[KeyValue::new(NETWORK, network.clone())])
-                    }) {
-                        Ok(callback) => nc.callback = callback,
-                        Err(e) => {
-                            error!(
-                                logger,
-                                "Couldn't register counter for network '{}': {:?}", network_clone, e
-                            )
-                        }
-                    }
-                }
-                None => {
-                    match meter.register_callback(&[local_clone.as_any()], move |observer| {
-                        observer.observe_i64(&local_clone, 1, &[KeyValue::new(NETWORK, network.clone())])
-                    }) {
-                        Ok(callback) => {
-                            let named = NamedCallbackWithValue {
-                                value: 1_i64,
-                                callback,
-                                name: metric_name,
-                            };
-
-                            callbacks.push(named)
-                        }
-                        Err(e) => {
-                            error!(
-                                logger,
-                                "Couldn't register counter for network '{}': {:?}", network_clone, e
-                            )
-                        }
-                    }
-                }
-            },
-            None => {
-                match meter.register_callback(&[local_clone.as_any()], move |observer| {
-                    observer.observe_i64(&local_clone, 1, &[KeyValue::new(NETWORK, network.clone())])
-                }) {
-                    Ok(callback) => {
-                        info!(logger, "Registering new counter for '{}'", network_clone);
-                        let named = NamedCallbackWithValue {
-                            value: 1_i64,
-                            callback,
-                            name: metric_name,
-                        };
-
-                        locked.insert(network_clone, vec![named]);
-                    }
-                    Err(e) => {
-                        error!(
-                            logger,
-                            "Couldn't register counter for network '{}': {:?}", network_clone, e
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-struct NamedCallbackWithValue<T> {
-    callback: Box<dyn CallbackRegistration>,
-    value: T,
-    name: String,
 }

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/delete_definition_handler.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/delete_definition_handler.rs
@@ -9,14 +9,7 @@ pub(super) async fn delete_definition(
     State(binding): State<Server>,
 ) -> Result<String, (StatusCode, String)> {
     match binding.supervisor.stop(vec![name.clone()]).await {
-        Ok(_) => {
-            binding
-                .metrics
-                .running_definition_metrics
-                .unregister_callback(name.clone(), binding.log)
-                .await;
-            Ok(format!("Deleted definition {}", name))
-        }
+        Ok(_) => Ok(format!("Deleted definition {}", name)),
         Err(e) => match e.errors.into_iter().next().unwrap() {
             StopDefinitionError::DoesNotExist(e) => {
                 not_found(binding.log, format!("Definition with name '{}' doesn't exist", name), e)

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/mod.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/mod.rs
@@ -64,7 +64,7 @@ pub(crate) struct Server {
     poll_interval: Duration,
     registry_query_timeout: Duration,
     registry_path: PathBuf,
-    pub metrics: MSDMetrics,
+    metrics: MSDMetrics,
 }
 
 impl Server {


### PR DESCRIPTION
Use a private data structure to track per-network metrics, then use that data structure as data source for the metrics callbacks.  The once-added callbacks can then serve the metrics for registered definitions.

In addition to that, when a definition ends, we deregister it from the per- network metrics data structure, so we stop serving metrics about it.

We are no longer using Tokio mutexes since this would require async closures for the callbacks, and async closures are unstable.  std::sync::Mutex works perfectly OK for this use and, in fact, Tokio documentation states that standard mutexes can work fine with Tokio code, and should be preferred in most cases.

https://docs.rs/tokio/1.24.2/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use indicates we should use the standard mutex when we are not going to hold the lock across await points.  Since that is exactly what we are doing (there are no awaits involved in the set() and get() code for the data structure being locked), then we can simply use the simple blocking mutex, which is what we have done here.