### PR TITLE
Add CLI arg to skip the update of the local registry

### DIFF
--- a/.github/workflows/msd-diff.yaml
+++ b/.github/workflows/msd-diff.yaml
@@ -34,11 +34,9 @@ jobs:
         run: |
           set -exuo pipefail
           REGISTRY_DIR_MAIN="$HOME/tmp/main-registry"
-          REGISTRY_DIR_BRANCH="$HOME/tmp/branch-registry"
           TARGETS_DIR_MAIN="$HOME/main-targets"
           TARGETS_DIR_BRANCH="$HOME/branch-targets"
           mkdir -p "$REGISTRY_DIR_MAIN" \
-                  "$REGISTRY_DIR_BRANCH" \
                   "$TARGETS_DIR_MAIN" \
                   "$TARGETS_DIR_BRANCH"
           chmod +x multiservice-discovery
@@ -48,7 +46,8 @@ jobs:
               --render-prom-targets-to-stdout > "$TARGETS_DIR_MAIN/targets.json"
           # Run multiservice-discovery for branch targets with bazel
           bazel run //rs/ic-observability/multiservice-discovery -- \
-              --targets-dir "$REGISTRY_DIR_BRANCH" \
+              --targets-dir "$REGISTRY_DIR_MAIN" \
+              --skip-update-local-registry \
               --render-prom-targets-to-stdout > "$TARGETS_DIR_BRANCH/targets.json"
           echo "targets_main=$TARGETS_DIR_MAIN" >> $GITHUB_OUTPUT
           echo "targets_branch=$TARGETS_DIR_BRANCH" >> $GITHUB_OUTPUT

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -143,8 +143,21 @@ impl TestDefinition {
     }
 
     /// Syncs the registry update the in-memory cache then stops.
-    pub async fn sync_and_stop(&self) {
-        let _ = self.running_def.initial_registry_sync().await;
+    pub async fn sync_and_stop(&self, skip_update_local_registry: bool) {
+        let _ = if skip_update_local_registry {
+            sync_local_registry(
+                self.running_def.definition.log.clone(),
+                self.running_def.definition.registry_path.join("targets"),
+                self.running_def.definition.nns_urls.clone(),
+                true,
+                self.running_def.definition.public_key,
+                &self.running_def.stop_signal,
+            )
+            .await.unwrap();
+        } else {
+            self.running_def.initial_registry_sync().await.unwrap();
+        };
+        
         // if self.initial_registry_sync().await.is_err() {
         // FIXME: Error has been logged, but ideally, it should be handled.
         // E.g. telemetry should collect this.

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -146,6 +146,12 @@ impl TestDefinition {
     /// Syncs the registry update the in-memory cache then stops.
     pub async fn sync_and_stop(&self, skip_update_local_registry: bool) {
         if let Err(e) = if skip_update_local_registry {
+            // The function, when invoked with use_current_version=true, prioritizes utilizing the 
+            // local registry and omits the synchronization step. If however the local registry is found to be empty,
+            // perhaps as a consequence of a prior execution error or a buggy version, the function will then proceed 
+            // to synchronize the registry. 
+            // This mechanism ensures clarity in handling scenarios where a comparison between two MSD versions starts 
+            // from a baseline of an empty registry due to issues in earlier runs.
             sync_local_registry(
                 self.running_def.definition.log.clone(),
                 self.running_def.definition.registry_path.join("targets"),

--- a/rs/ic-observability/multiservice-discovery/src/main.rs
+++ b/rs/ic-observability/multiservice-discovery/src/main.rs
@@ -212,7 +212,7 @@ the Prometheus targets of mainnet as a JSON structure on stdout.
         default_value = "false",
         action,
         help = r#"
-Used for testing: Weather to skip the update of the local mainnet registry.
+Used for testing: Whether to skip the update of the local mainnet registry.
 "#
     )]
     skip_update_local_registry: bool,

--- a/rs/ic-observability/multiservice-discovery/src/main.rs
+++ b/rs/ic-observability/multiservice-discovery/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
         ) -> Option<RunningDefinition> {
             let def = get_mainnet_definition(cli_args, log.clone());
             let mut test_def = TestDefinition::new(def, RunningDefinitionsMetrics::new());
-            let sync_fut = test_def.sync_and_stop();
+            let sync_fut = test_def.sync_and_stop(cli_args.skip_update_local_registry);
             tokio::select! {
                 _ = sync_fut => {
                     info!(log, "Synchronization done");
@@ -206,6 +206,16 @@ the Prometheus targets of mainnet as a JSON structure on stdout.
 "#
     )]
     render_prom_targets_to_stdout: bool,
+
+    #[clap(
+        long = "skip-update-local-registry",
+        default_value = "false",
+        action,
+        help = r#"
+Used for testing: Weather to skip the update of the local mainnet registry.
+"#
+    )]
+    skip_update_local_registry: bool,
 
     #[clap(
         long = "networks-state-file",


### PR DESCRIPTION
* Used for MSD test: Add arg `--skip-update-local-registry` to avoid syncing the local registry with remote registry canister (which cause flaky test)