### PR TITLE
Return only host/port.

### DIFF
--- a/rs/ic-observability/multiservice-discovery-shared/src/builders/prometheus_config_structure.rs
+++ b/rs/ic-observability/multiservice-discovery-shared/src/builders/prometheus_config_structure.rs
@@ -46,7 +46,7 @@ pub fn map_target_group(target_groups: Vec<TargetDto>) -> Vec<PrometheusStaticCo
             let mut ret = vec![];
             for job in &tg.jobs {
                 ret.push(PrometheusStaticConfig {
-                    targets: tg.targets.iter().map(|sa| job.url(*sa, false)).collect(),
+                    targets: tg.targets.iter().map(|sa| job.host_port(*sa, false)).collect(),
                     labels: {
                         BTreeMap::from([
                             (IC_NAME.into(), tg.ic_name.clone()),

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/export_prometheus_config_handler.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/export_prometheus_config_handler.rs
@@ -25,7 +25,12 @@ pub fn serialize_definitions_to_prometheus_config(
     let boundary_nodes_targets = boundary_nodes_from_definitions(&definitions, &filters)
         .iter()
         .map(|(definition_name, bn)| PrometheusStaticConfig {
-            targets: bn.targets.clone().iter().map(|g| bn.job_type.url(*g, true)).collect(),
+            targets: bn
+                .targets
+                .clone()
+                .iter()
+                .map(|g| bn.job_type.host_port(*g, true))
+                .collect(),
             labels: {
                 BTreeMap::from([
                     ("ic", definition_name.clone()),

--- a/rs/ic-observability/service-discovery/src/job_types.rs
+++ b/rs/ic-observability/service-discovery/src/job_types.rs
@@ -96,6 +96,9 @@ impl JobType {
             self.endpoint().trim_start_matches('/'),
         )
     }
+    pub fn host_port(&self, s: SocketAddr, is_boundary_node: bool) -> String {
+        format!("{}", self.sockaddr(s, is_boundary_node),)
+    }
 }
 
 /// This is duplicated in impl Job.


### PR DESCRIPTION
We were returning http:// or https:// along with the address, as well as a /path at the end. This is not supported by Prometheus and therefore this PR removes it.  With this, Prometheus correctly loads the targets, at the cost of the client needing to hard code the scheme and the path in the SD config.

**Note: this breaks compatibility.  If any part of our stack is currently relying on this broken format, we will have to figure out a way to safely roll this out.**

Prometheus cannot natively cope with protocol and path in the address.  This can be worked around using relabeling rules:

```
  - # Strip the scheme from the multiservice-discovery-generated address.
    source_labels:
    - __address__
    target_label: __address__
    regex: (.*)://(.*)
    replacement: ${2}
    action: replace
  - # Strip the metrics path from the multiservice-discovery-generated address.
    source_labels:
    - __address__
    target_label: __address__
    regex: (.*?)/(.*)
    replacement: ${1}
    action: replace
```

(I tested the above locally.)

The problem with this PR removing the protocol and the path in the returned address is that, without this information in the target, we cannot configure a single discovery service in our IC Metrics stack.  We would have to configure multiple ones (one per target), and drop the targets we don't want using rewrite rules.  Alternatively, we could use regexes to *fish out* the protocol and the path, and rewrite the __scheme__ and __path__ magic variables during relabeling.  This seems exceedingly hacky, but I'm not seeing anything outside these two solutions.

This is what I am currently doing in IC-O-Stack, as we have a fixed list of target URLs we scrape.

If we are OK with going full rewrite using regexes and relabeling rules, then this PR is not needed.

--------

https://github.com/dfinity/dre/pull/315 is required below this PR.