### PR TITLE
feat(cli): implementing completions

### DIFF
--- a/.github/workflows/prepare-release/action.yaml
+++ b/.github/workflows/prepare-release/action.yaml
@@ -16,7 +16,7 @@ runs:
         # query the location of the bazel "dre" binary and copy it to the "release" directory
         mkdir -p release
         cp --dereference bazel-out/k8-opt/bin/rs/cli/dre release/dre
-        cp -r bazel-out/k8-opt/bin/rs/cli/build_script.out_dir/completions release
+        tar -cf release/completions.tar -C bazel-out/k8-opt/bin/rs/cli/build_script.out_dir completions
     - name: "🆕 📢 Prepare release"
       # v0.1.15
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/prepare-release/action.yaml
+++ b/.github/workflows/prepare-release/action.yaml
@@ -16,6 +16,16 @@ runs:
         # query the location of the bazel "dre" binary and copy it to the "release" directory
         mkdir -p release
         cp --dereference bazel-out/k8-opt/bin/rs/cli/dre release/dre
+    - name: "💲 Generate completion scripts"
+      shell: bash
+      run: |
+        set -eExuo pipefail
+        
+        # Run any command to generate completions
+        release/dre --help
+
+        completions=${XDG_DATA_HOME:-$HOME/.local/share}/completions
+        cp -r $completions release
     - name: "🆕 📢 Prepare release"
       # v0.1.15
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/prepare-release/action.yaml
+++ b/.github/workflows/prepare-release/action.yaml
@@ -16,16 +16,7 @@ runs:
         # query the location of the bazel "dre" binary and copy it to the "release" directory
         mkdir -p release
         cp --dereference bazel-out/k8-opt/bin/rs/cli/dre release/dre
-    - name: "💲 Generate completion scripts"
-      shell: bash
-      run: |
-        set -eExuo pipefail
-        
-        # Run any command to generate completions
-        release/dre --help
-
-        completions=${XDG_DATA_HOME:-$HOME/.local/share}/completions
-        cp -r $completions release
+        cp -r bazel-out/k8-opt/bin/rs/cli/build_script.out_dir/completions release/completions
     - name: "🆕 📢 Prepare release"
       # v0.1.15
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/prepare-release/action.yaml
+++ b/.github/workflows/prepare-release/action.yaml
@@ -16,7 +16,7 @@ runs:
         # query the location of the bazel "dre" binary and copy it to the "release" directory
         mkdir -p release
         cp --dereference bazel-out/k8-opt/bin/rs/cli/dre release/dre
-        cp -r bazel-out/k8-opt/bin/rs/cli/build_script.out_dir/completions release/completions
+        cp -r bazel-out/k8-opt/bin/rs/cli/build_script.out_dir/completions release
     - name: "🆕 📢 Prepare release"
       # v0.1.15
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b6737f3f6bdb970486578a3c4c615afe6fd16e0bf32c3930b649d568c6be06c5",
+  "checksum": "54c60347f247a5806c210bfb382c8b6e7095468864b1282b9b656202370f032c",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -7004,6 +7004,51 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "clap_complete 4.5.2": {
+      "name": "clap_complete",
+      "version": "4.5.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/clap_complete/4.5.2/download",
+          "sha256": "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "clap_complete",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "clap_complete",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "clap 4.5.4",
+              "target": "clap"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "4.5.2"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "clap_derive 3.2.25": {
       "name": "clap_derive",
       "version": "3.2.25",
@@ -11520,6 +11565,10 @@
               "target": "clap_num"
             },
             {
+              "id": "clap_complete 4.5.2",
+              "target": "clap_complete"
+            },
+            {
               "id": "colored 2.1.0",
               "target": "colored"
             },
@@ -11546,6 +11595,10 @@
             {
               "id": "edit 0.1.5",
               "target": "edit"
+            },
+            {
+              "id": "file_diff 1.0.0",
+              "target": "file_diff"
             },
             {
               "id": "flate2 1.0.28",
@@ -13231,6 +13284,36 @@
         "version": "0.13.0"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "file_diff 1.0.0": {
+      "name": "file_diff",
+      "version": "1.0.0",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/file_diff/1.0.0/download",
+          "sha256": "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "file_diff",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "file_diff",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "1.0.0"
+      },
+      "license": "BSD-3-Clause"
     },
     "filetime 0.2.23": {
       "name": "filetime",

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "54c60347f247a5806c210bfb382c8b6e7095468864b1282b9b656202370f032c",
+  "checksum": "609adbd55213e511bf8a56e610f0951465973518256678db9c4af1ca7fb1587d",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -11533,8 +11533,8 @@
         },
         {
           "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
+            "crate_name": "build_script_build_script_",
+            "crate_root": "src/build_script_.rs",
             "srcs": [
               "**/*.rs"
             ]
@@ -11565,10 +11565,6 @@
               "target": "clap_num"
             },
             {
-              "id": "clap_complete 4.5.2",
-              "target": "clap_complete"
-            },
-            {
               "id": "colored 2.1.0",
               "target": "colored"
             },
@@ -11590,15 +11586,11 @@
             },
             {
               "id": "dre 0.3.2",
-              "target": "build_script_build"
+              "target": "build_script_build_script_"
             },
             {
               "id": "edit 0.1.5",
               "target": "edit"
-            },
-            {
-              "id": "file_diff 1.0.0",
-              "target": "file_diff"
             },
             {
               "id": "flate2 1.0.28",
@@ -11759,7 +11751,32 @@
       "build_script_attrs": {
         "data_glob": [
           "**"
-        ]
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "clap 4.5.4",
+              "target": "clap"
+            },
+            {
+              "id": "clap-num 1.1.1",
+              "target": "clap_num"
+            },
+            {
+              "id": "clap_complete 4.5.2",
+              "target": "clap_complete"
+            },
+            {
+              "id": "ic-base-types 0.9.0",
+              "target": "ic_base_types"
+            },
+            {
+              "id": "url 2.5.0",
+              "target": "url"
+            }
+          ],
+          "selects": {}
+        }
       },
       "license": null
     },
@@ -13284,36 +13301,6 @@
         "version": "0.13.0"
       },
       "license": "MIT/Apache-2.0"
-    },
-    "file_diff 1.0.0": {
-      "name": "file_diff",
-      "version": "1.0.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/file_diff/1.0.0/download",
-          "sha256": "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "file_diff",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "file_diff",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "1.0.0"
-      },
-      "license": "BSD-3-Clause"
     },
     "filetime 0.2.23": {
       "name": "filetime",
@@ -16903,6 +16890,8 @@
         ],
         "crate_features": {
           "common": [
+            "client",
+            "client-legacy",
             "default",
             "http1",
             "http2",
@@ -16910,124 +16899,7 @@
             "server-auto",
             "tokio"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "client",
-              "client-legacy"
-            ],
-            "aarch64-apple-ios": [
-              "client",
-              "client-legacy"
-            ],
-            "aarch64-apple-ios-sim": [
-              "client",
-              "client-legacy"
-            ],
-            "aarch64-fuchsia": [
-              "client",
-              "client-legacy"
-            ],
-            "aarch64-linux-android": [
-              "client",
-              "client-legacy"
-            ],
-            "aarch64-pc-windows-msvc": [
-              "client",
-              "client-legacy"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "client",
-              "client-legacy"
-            ],
-            "arm-unknown-linux-gnueabi": [
-              "client",
-              "client-legacy"
-            ],
-            "armv7-linux-androideabi": [
-              "client",
-              "client-legacy"
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              "client",
-              "client-legacy"
-            ],
-            "i686-apple-darwin": [
-              "client",
-              "client-legacy"
-            ],
-            "i686-linux-android": [
-              "client",
-              "client-legacy"
-            ],
-            "i686-pc-windows-msvc": [
-              "client",
-              "client-legacy"
-            ],
-            "i686-unknown-freebsd": [
-              "client",
-              "client-legacy"
-            ],
-            "i686-unknown-linux-gnu": [
-              "client",
-              "client-legacy"
-            ],
-            "powerpc-unknown-linux-gnu": [
-              "client",
-              "client-legacy"
-            ],
-            "riscv32imc-unknown-none-elf": [
-              "client",
-              "client-legacy"
-            ],
-            "riscv64gc-unknown-none-elf": [
-              "client",
-              "client-legacy"
-            ],
-            "s390x-unknown-linux-gnu": [
-              "client",
-              "client-legacy"
-            ],
-            "thumbv7em-none-eabi": [
-              "client",
-              "client-legacy"
-            ],
-            "thumbv8m.main-none-eabi": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-apple-darwin": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-apple-ios": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-fuchsia": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-linux-android": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-pc-windows-msvc": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-unknown-freebsd": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "client",
-              "client-legacy"
-            ],
-            "x86_64-unknown-none": [
-              "client",
-              "client-legacy"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -38120,94 +37992,10 @@
             "default",
             "fs",
             "std",
+            "termios",
             "use-libc-auxv"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "termios"
-            ],
-            "aarch64-apple-ios": [
-              "termios"
-            ],
-            "aarch64-apple-ios-sim": [
-              "termios"
-            ],
-            "aarch64-fuchsia": [
-              "termios"
-            ],
-            "aarch64-linux-android": [
-              "termios"
-            ],
-            "aarch64-unknown-linux-gnu": [
-              "termios"
-            ],
-            "arm-unknown-linux-gnueabi": [
-              "termios"
-            ],
-            "armv7-linux-androideabi": [
-              "termios"
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              "termios"
-            ],
-            "i686-apple-darwin": [
-              "termios"
-            ],
-            "i686-linux-android": [
-              "termios"
-            ],
-            "i686-unknown-freebsd": [
-              "termios"
-            ],
-            "i686-unknown-linux-gnu": [
-              "termios"
-            ],
-            "powerpc-unknown-linux-gnu": [
-              "termios"
-            ],
-            "riscv32imc-unknown-none-elf": [
-              "termios"
-            ],
-            "riscv64gc-unknown-none-elf": [
-              "termios"
-            ],
-            "s390x-unknown-linux-gnu": [
-              "termios"
-            ],
-            "thumbv7em-none-eabi": [
-              "termios"
-            ],
-            "thumbv8m.main-none-eabi": [
-              "termios"
-            ],
-            "wasm32-unknown-unknown": [
-              "termios"
-            ],
-            "wasm32-wasi": [
-              "termios"
-            ],
-            "x86_64-apple-darwin": [
-              "termios"
-            ],
-            "x86_64-apple-ios": [
-              "termios"
-            ],
-            "x86_64-fuchsia": [
-              "termios"
-            ],
-            "x86_64-linux-android": [
-              "termios"
-            ],
-            "x86_64-unknown-freebsd": [
-              "termios"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "termios"
-            ],
-            "x86_64-unknown-none": [
-              "termios"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,7 +2296,6 @@ dependencies = [
  "dirs",
  "dotenv",
  "edit",
- "file_diff",
  "flate2",
  "futures",
  "futures-util",
@@ -2636,12 +2635,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "file_diff"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
 
 [[package]]
 name = "filetime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+dependencies = [
+ "clap 4.5.4",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +2288,7 @@ dependencies = [
  "candid",
  "clap 4.5.4",
  "clap-num",
+ "clap_complete",
  "colored",
  "cryptoki",
  "decentralization",
@@ -2286,6 +2296,7 @@ dependencies = [
  "dirs",
  "dotenv",
  "edit",
+ "file_diff",
  "flate2",
  "futures",
  "futures-util",
@@ -2625,6 +2636,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "file_diff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
 
 [[package]]
 name = "filetime"

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@crate_index_dre//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test", "rust_library")
+load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 DEPS = [
     "//rs/ic-canisters",
@@ -8,7 +9,19 @@ DEPS = [
     "//rs/ic-management-backend:ic-management-backend-lib",
 ]
 
+BUILD_SCRIPT_DEPS = [
+    "//rs/ic-management-types",
+]
+
 package(default_visibility = ["//visibility:public"])
+
+cargo_build_script(
+    name = "build_script",
+    srcs = ["src/cli.rs", "src/build_script_.rs"],
+    deps = all_crate_deps(
+        build = True
+    ) + BUILD_SCRIPT_DEPS
+)
 
 rust_binary(
     name = "dre",
@@ -20,7 +33,7 @@ rust_binary(
     ),
     deps = all_crate_deps(
         normal = True,
-    ) + DEPS + ["//rs/cli:dre-lib"],
+    ) + DEPS + ["//rs/cli:dre-lib", ":build_script"],
 )
 
 rust_library(

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -58,11 +58,17 @@ tabular = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 tempfile = "3.10.0"
-clap_complete = "4.5.2"
-file_diff = "1.0.0"
 
 [dev-dependencies]
 wiremock = { workspace = true }
+
+[build-dependencies]
+clap_complete = "4.5.2"
+clap = { workspace = true }
+clap-num = { workspace = true }
+ic-base-types = { workspace = true }
+ic-management-types = { workspace = true }
+url = { workspace = true }
 
 [[bin]]
 name = "dre"

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -58,6 +58,8 @@ tabular = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 tempfile = "3.10.0"
+clap_complete = "4.5.2"
+file_diff = "1.0.0"
 
 [dev-dependencies]
 wiremock = { workspace = true }

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dre"
-build = "build.rs"
+# Required because of BAZEL
+build = "src/build_script_.rs"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/rs/cli/build.rs
+++ b/rs/cli/build.rs
@@ -1,5 +1,9 @@
 // Construct a useful and specific version string for the CLI
-use std::process::Command;
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{generate_to, Shell};
+use std::{env, fs, process::Command};
+
+include!("src/cli.rs");
 
 fn main() {
     // taken from https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
@@ -21,5 +25,57 @@ fn main() {
                 .map(|v| format!("{}-{}", v, git_rev))
                 .unwrap_or_default()
         );
+    }
+
+    generate_completions()
+}
+
+fn generate_completions() {
+    let outdir = match env::var_os("OUT_DIR") {
+        None => {
+            println!("cargo:warning=OUT_DIR var not set, not generating completions");
+            return;
+        }
+        Some(o) => o,
+    };
+    let completions_dir = PathBuf::from(outdir).join("completions");
+    if let Err(e) = fs::create_dir_all(&completions_dir) {
+        println!(
+            "cargo:warning=Couldn't create '{}' dir: {:?}",
+            completions_dir.display(),
+            e
+        );
+        return;
+    }
+
+    let mut command = Opts::command();
+
+    for &shell in Shell::value_variants() {
+        if let Err(e) = generate_to(shell, &mut command, "dre", &completions_dir) {
+            println!("cargo:warning=Couldn't write completions due to: {:?}", e);
+            continue;
+        };
+    }
+
+    if let Some(val) = env::var_os("COMPLETIONS_OUT_DIR") {
+        if let Err(e) = fs::create_dir_all(&val) {
+            println!(
+                "cargo:warning=Couldn't create '{}' due to: {:?}",
+                val.into_string().unwrap(),
+                e
+            );
+            return;
+        }
+        for entry in fs::read_dir(completions_dir).unwrap() {
+            let entry = entry.unwrap();
+            let val = PathBuf::from(&val).join(entry.file_name());
+            if let Err(e) = fs::copy(entry.path(), &val) {
+                println!(
+                    "cargo:warning=Couldn't copy completions to '{}' due to: {:?}",
+                    val.display(),
+                    e
+                );
+            }
+        }
     }
 }

--- a/rs/cli/src/build_script_.rs
+++ b/rs/cli/src/build_script_.rs
@@ -3,7 +3,7 @@ use clap::{CommandFactory, ValueEnum};
 use clap_complete::{generate_to, Shell};
 use std::{env, fs, process::Command};
 
-include!("src/cli.rs");
+include!("cli.rs");
 
 fn main() {
     // taken from https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program

--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -3,10 +3,8 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 use clap_num::maybe_hex;
 use ic_base_types::PrincipalId;
-use ic_management_types::{Artifact, Network};
+use ic_management_types::Artifact;
 use url::Url;
-
-use crate::detect_neuron::Neuron;
 
 // For more info about the version setup, look at https://docs.rs/clap/latest/clap/struct.Command.html#method.version
 #[derive(Parser, Clone, Default)]
@@ -334,9 +332,24 @@ pub mod version {
 }
 
 pub mod hostos {
-    use crate::operations::hostos_rollout::{NodeAssignment, NodeOwner};
+    #[derive(ValueEnum, Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Parser, Default)]
+    pub enum NodeOwner {
+        Dfinity,
+        Others,
+        #[default]
+        All,
+    }
+
+    #[derive(ValueEnum, Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Default)]
+    pub enum NodeAssignment {
+        Unassigned,
+        Assigned,
+        #[default]
+        All,
+    }
 
     use super::*;
+    use clap::ValueEnum;
     use ic_base_types::PrincipalId;
 
     #[derive(Parser, Clone)]
@@ -410,82 +423,5 @@ pub mod nodes {
             #[clap(long, aliases = ["summary"])]
             motivation: Option<String>,
         },
-    }
-}
-
-#[derive(Clone)]
-pub struct ParsedCli {
-    pub network: Network,
-    pub ic_admin_bin_path: Option<String>,
-    pub yes: bool,
-    pub neuron: Neuron,
-}
-
-#[derive(Clone)]
-pub struct UpdateVersion {
-    pub release_artifact: Artifact,
-    pub version: String,
-    pub title: String,
-    pub summary: String,
-    pub update_urls: Vec<String>,
-    pub stringified_hash: String,
-    pub versions_to_retire: Option<Vec<String>>,
-}
-
-impl ParsedCli {
-    pub fn get_neuron(&self) -> &Neuron {
-        &self.neuron
-    }
-
-    pub fn get_update_cmd_args(update_version: &UpdateVersion) -> Vec<String> {
-        [
-            [
-                vec![
-                    format!("--{}-version-to-elect", update_version.release_artifact),
-                    update_version.version.to_string(),
-                    "--release-package-sha256-hex".to_string(),
-                    update_version.stringified_hash.to_string(),
-                    "--release-package-urls".to_string(),
-                ],
-                update_version.update_urls.clone(),
-            ]
-            .concat(),
-            match update_version.versions_to_retire.clone() {
-                Some(versions) => [
-                    vec![format!("--{}-versions-to-unelect", update_version.release_artifact)],
-                    versions,
-                ]
-                .concat(),
-                None => vec![],
-            },
-        ]
-        .concat()
-    }
-
-    pub async fn from_opts(opts: &Opts, require_authentication: bool) -> anyhow::Result<Self> {
-        let network = Network::new(&opts.network, &opts.nns_urls).await.map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to parse network from name {} and NNS urls {:?}. Error: {}",
-                opts.network,
-                opts.nns_urls,
-                e
-            )
-        })?;
-        let neuron = Neuron::new(
-            &network,
-            require_authentication,
-            opts.neuron_id,
-            opts.private_key_pem.clone(),
-            opts.hsm_slot,
-            opts.hsm_pin.clone(),
-            opts.hsm_key_id.clone(),
-        )
-        .await?;
-        Ok(ParsedCli {
-            network,
-            yes: opts.yes,
-            neuron,
-            ic_admin_bin_path: opts.ic_admin.clone(),
-        })
     }
 }

--- a/rs/cli/src/ic_admin.rs
+++ b/rs/cli/src/ic_admin.rs
@@ -1,5 +1,5 @@
+use crate::parsed_cli::UpdateVersion;
 use anyhow::{anyhow, Error, Result};
-use cli::UpdateVersion;
 use colored::Colorize;
 use dialoguer::Confirm;
 use flate2::read::GzDecoder;
@@ -31,9 +31,9 @@ use std::{fmt::Display, path::Path, process::Command};
 use strum::Display;
 use tempfile::NamedTempFile;
 
-use crate::cli::ParsedCli;
+use crate::defaults;
 use crate::detect_neuron::{Auth, Neuron};
-use crate::{cli, defaults};
+use crate::parsed_cli::ParsedCli;
 
 const MAX_SUMMARY_CHAR_COUNT: usize = 14000;
 

--- a/rs/cli/src/lib.rs
+++ b/rs/cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod general;
 pub mod ic_admin;
 pub mod operations;
 pub mod ops_subnet_node_replace;
+pub mod parsed_cli;
 pub mod registry_dump;
 pub mod runner;
 

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -420,12 +420,9 @@ fn init_logger() {
 
 fn generate_completions(command: &mut Command) {
     let completions_dir = dirs::data_local_dir().unwrap().join("completions");
-    match fs::create_dir_all(&completions_dir) {
-        Ok(_) => info!("Created '{}' directory", completions_dir.display()),
-        Err(e) => {
-            warn!("Couldn't create '{}' dir: {:?}", completions_dir.display(), e);
-            return;
-        }
+    if let Err(e) = fs::create_dir_all(&completions_dir) {
+        warn!("Couldn't create '{}' dir: {:?}", completions_dir.display(), e);
+        return;
     }
 
     for &shell in Shell::value_variants() {
@@ -463,19 +460,9 @@ fn generate_completions(command: &mut Command) {
         };
 
         if diff(path.to_str().unwrap(), current_completions.to_str().unwrap()) {
-            info!(
-                "Complitions for {} shell is up to date on path '{}'",
-                shell,
-                current_completions.display()
-            );
             continue;
         }
 
-        info!(
-            "Updating completions file '{}' for shell {}.",
-            current_completions.display(),
-            shell
-        );
         match fs::copy(path, current_completions) {
             Ok(_) => info!("Successfully copied completions"),
             Err(e) => warn!("Couldn't copy complitions due to: {:?}", e),

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -30,10 +30,10 @@ async fn main() -> Result<(), anyhow::Error> {
     init_logger();
     info!("Running version {}", env!("CARGO_PKG_VERSION"));
 
-    let mut cli_opts = cli::Opts::parse();
     let mut cmd = cli::Opts::command();
-
     generate_completions(&mut cmd);
+
+    let mut cli_opts = cli::Opts::parse();
 
     let target_network = ic_management_types::Network::new(cli_opts.network.clone(), &cli_opts.nns_urls)
         .await

--- a/rs/cli/src/operations/hostos_rollout.rs
+++ b/rs/cli/src/operations/hostos_rollout.rs
@@ -1,6 +1,5 @@
 use anyhow::anyhow;
 use async_recursion::async_recursion;
-use clap::{Parser, ValueEnum};
 use futures_util::future::try_join;
 use ic_base_types::{NodeId, PrincipalId};
 use ic_management_backend::health;
@@ -8,6 +7,8 @@ use ic_management_backend::proposal::ProposalAgent;
 use ic_management_types::{Network, Node, Status, Subnet, UpdateNodesHostosVersionsProposal};
 use log::{debug, info};
 use std::{collections::BTreeMap, fmt::Display, str::FromStr};
+
+use crate::cli::hostos::{NodeAssignment, NodeOwner};
 
 pub enum HostosRolloutResponse {
     Ok(Vec<Node>, Option<Vec<HostosRolloutSubnetAffected>>),
@@ -46,22 +47,6 @@ impl Display for HostosRolloutReason {
             Self::NoNodeSelected => write!(f, "No candidate nodes have been selected"),
         }
     }
-}
-
-#[derive(ValueEnum, Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Parser, Default)]
-pub enum NodeOwner {
-    Dfinity,
-    Others,
-    #[default]
-    All,
-}
-
-#[derive(ValueEnum, Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Default)]
-pub enum NodeAssignment {
-    Unassigned,
-    Assigned,
-    #[default]
-    All,
 }
 
 #[derive(Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd)]

--- a/rs/cli/src/parsed_cli.rs
+++ b/rs/cli/src/parsed_cli.rs
@@ -1,0 +1,80 @@
+use ic_management_types::{Artifact, Network};
+
+use crate::{cli::Opts, detect_neuron::Neuron};
+
+#[derive(Clone)]
+pub struct ParsedCli {
+    pub network: Network,
+    pub ic_admin_bin_path: Option<String>,
+    pub yes: bool,
+    pub neuron: Neuron,
+}
+
+#[derive(Clone)]
+pub struct UpdateVersion {
+    pub release_artifact: Artifact,
+    pub version: String,
+    pub title: String,
+    pub summary: String,
+    pub update_urls: Vec<String>,
+    pub stringified_hash: String,
+    pub versions_to_retire: Option<Vec<String>>,
+}
+
+impl ParsedCli {
+    pub fn get_neuron(&self) -> &Neuron {
+        &self.neuron
+    }
+
+    pub fn get_update_cmd_args(update_version: &UpdateVersion) -> Vec<String> {
+        [
+            [
+                vec![
+                    format!("--{}-version-to-elect", update_version.release_artifact),
+                    update_version.version.to_string(),
+                    "--release-package-sha256-hex".to_string(),
+                    update_version.stringified_hash.to_string(),
+                    "--release-package-urls".to_string(),
+                ],
+                update_version.update_urls.clone(),
+            ]
+            .concat(),
+            match update_version.versions_to_retire.clone() {
+                Some(versions) => [
+                    vec![format!("--{}-versions-to-unelect", update_version.release_artifact)],
+                    versions,
+                ]
+                .concat(),
+                None => vec![],
+            },
+        ]
+        .concat()
+    }
+
+    pub async fn from_opts(opts: &Opts, require_authentication: bool) -> anyhow::Result<Self> {
+        let network = Network::new(&opts.network, &opts.nns_urls).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to parse network from name {} and NNS urls {:?}. Error: {}",
+                opts.network,
+                opts.nns_urls,
+                e
+            )
+        })?;
+        let neuron = Neuron::new(
+            &network,
+            require_authentication,
+            opts.neuron_id,
+            opts.private_key_pem.clone(),
+            opts.hsm_slot,
+            opts.hsm_pin.clone(),
+            opts.hsm_key_id.clone(),
+        )
+        .await?;
+        Ok(ParsedCli {
+            network,
+            yes: opts.yes,
+            neuron,
+            ic_admin_bin_path: opts.ic_admin.clone(),
+        })
+    }
+}


### PR DESCRIPTION
Added functionality to build script (now its `src/build_script_.rs` because of Bazel) to generate autocompletion scripts.
To generate completions in `~/Downloads/completions` using cargo:
```bash
COMPLETIONS_OUT_DIR=~/Downloads/completions cargo build --bin dre (--release)
```
To generate completions using bazel (After this they will be present in `bazel-out/k8-opt/bin/rs/cli/build_script.out_dir/completions`):
```bash
bazel build //rs/cli:dre
```

Additional notes:
* Added these scripts to releases. If someone finds them useful they can download them, if not, they can opt out.