### PR TITLE
Introduce interrupt and retry handling to initial definition sync.

### DIFF
--- a/rs/ic-observability/service-discovery/src/registry_sync.rs
+++ b/rs/ic-observability/service-discovery/src/registry_sync.rs
@@ -50,6 +50,11 @@ pub async fn sync_local_registry(
     let local_store = Arc::new(LocalStoreImpl::new(local_path.clone()));
     let registry_canister = RegistryCanister::new(nns_urls.to_vec());
 
+    if stop_signal.try_recv().is_ok() {
+        // Interrupted early.  Let's get out of here.
+        return Err(SyncError::Interrupted);
+    }
+
     let mut latest_version = if !Path::new(&local_path).exists() {
         ZERO_REGISTRY_VERSION
     } else {
@@ -85,7 +90,7 @@ pub async fn sync_local_registry(
 
     loop {
         if stop_signal.try_recv().is_ok() {
-            // Interrupted early.  Let's get out of here.
+            // Interrupted.  Let's get out of here.
             return Err(SyncError::Interrupted);
         }
 


### PR DESCRIPTION
We have been quite good with regards to handling interrupts / SIGTERMs almost from the very start in MSD.  However, a small oversight with regards to initial sync caused https://github.com/dfinity/dre/issues/314 , which in turn causes the daemon to freeze upon shutdown if any definition failed its initial sync.  The root cause is that the thread terminates on its own, not polling its end of the ender channel used to shut it down.

This PR fixes the issue.

In addition to that, we now also retry initial syncs just as failed incremental syncs are retried.  This adds robustness in the face of temporary network outages just as MSD is starting to execute.