### PR TITLE
feat(msd): adding api boundary nodes to multiservice discovery and downloader

### DIFF
--- a/rs/ic-observability/config-writer-common/src/filters.rs
+++ b/rs/ic-observability/config-writer-common/src/filters.rs
@@ -71,6 +71,7 @@ mod tests {
             dc_id: "test".to_string(),
             operator_id: PrincipalId::new_anonymous(),
             node_provider_id: PrincipalId::new_anonymous(),
+            is_api_bn: false,
         }
     }
 
@@ -88,6 +89,7 @@ mod tests {
             dc_id: "test".to_string(),
             operator_id: PrincipalId::new_anonymous(),
             node_provider_id: PrincipalId::new_anonymous(),
+            is_api_bn: false,
         };
         assert!(filter.filter(accepted_tg));
 
@@ -101,6 +103,7 @@ mod tests {
             dc_id: "test".to_string(),
             operator_id: PrincipalId::new_anonymous(),
             node_provider_id: PrincipalId::new_anonymous(),
+            is_api_bn: false,
         };
         assert!(!filter.filter(rejected_tg));
     }
@@ -121,6 +124,7 @@ mod tests {
             dc_id: "test".to_string(),
             operator_id: PrincipalId::new_anonymous(),
             node_provider_id: PrincipalId::new_anonymous(),
+            is_api_bn: false,
         };
         assert!(filterlist.filter(accepted_tg));
 
@@ -134,6 +138,7 @@ mod tests {
             dc_id: "test".to_string(),
             operator_id: PrincipalId::new_anonymous(),
             node_provider_id: PrincipalId::new_anonymous(),
+            is_api_bn: false,
         };
         assert!(!filterlist.filter(rejected_tg_1));
 

--- a/rs/ic-observability/multiservice-discovery-shared/src/builders/log_vector_config_structure.rs
+++ b/rs/ic-observability/multiservice-discovery-shared/src/builders/log_vector_config_structure.rs
@@ -127,6 +127,7 @@ const IC_SUBNET: &str = "ic_subnet";
 const DC: &str = "dc";
 const ADDRESS: &str = "address";
 const NODE_PROVIDER_ID: &str = "node_provider_id";
+const IS_API_BN: &str = "is_api_bn";
 
 impl VectorRemapTransform {
     pub fn from(target: TargetDto, job: JobType, input: String, is_bn: bool) -> Self {
@@ -145,6 +146,7 @@ impl VectorRemapTransform {
             (ADDRESS.into(), ip),
             (NODE_PROVIDER_ID.into(), target_group.node_provider_id.to_string()),
             (DC.into(), target_group.dc_id),
+            (IS_API_BN.into(), target.is_api_bn.to_string()),
         ])
         .into_iter()
         .chain(target.custom_labels)
@@ -217,6 +219,7 @@ mod tests {
             jobs: jobs.clone(),
             operator_id: PrincipalId::new_anonymous(),
             custom_labels: custom_labels.clone(),
+            is_api_bn: false,
         });
         target_dto.insert(TargetDto {
             node_id: PrincipalId::new_anonymous().into(),
@@ -229,6 +232,7 @@ mod tests {
             jobs: jobs.clone(),
             operator_id: PrincipalId::new_anonymous(),
             custom_labels: custom_labels.clone(),
+            is_api_bn: false,
         });
 
         let config = builder.build(target_dto);

--- a/rs/ic-observability/multiservice-discovery-shared/src/contracts/target.rs
+++ b/rs/ic-observability/multiservice-discovery-shared/src/contracts/target.rs
@@ -26,6 +26,7 @@ pub struct TargetDto {
     pub jobs: Vec<JobType>,
     pub custom_labels: BTreeMap<String, String>,
     pub name: String,
+    pub is_api_bn: bool,
 }
 
 impl DataContract for TargetDto {
@@ -60,6 +61,7 @@ pub fn map_to_target_dto(
         node_provider_id: value.node_provider_id,
         jobs: vec![job_type],
         custom_labels,
+        is_api_bn: value.is_api_bn,
     }
 }
 
@@ -73,6 +75,7 @@ impl From<&TargetDto> for TargetGroup {
             operator_id: value.operator_id,
             subnet_id: value.subnet_id,
             targets: value.targets.clone(),
+            is_api_bn: value.is_api_bn,
         }
     }
 }
@@ -90,6 +93,7 @@ impl From<&TargetGroup> for TargetDto {
             dc_id: value.dc_id.clone(),
             operator_id: value.operator_id,
             node_provider_id: value.node_provider_id,
+            is_api_bn: value.is_api_bn,
         }
     }
 }

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/export_prometheus_config_handler.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/export_prometheus_config_handler.rs
@@ -1,5 +1,5 @@
 use super::Server;
-use crate::definition::RunningDefinition;
+use crate::definition::{api_boundary_nodes_target_dtos_from_definitions, RunningDefinition};
 use crate::{
     definition::{boundary_nodes_from_definitions, ic_node_target_dtos_from_definitions},
     TargetFilterSpec,
@@ -40,7 +40,13 @@ pub fn serialize_definitions_to_prometheus_config(
         })
         .collect();
 
-    let total_targets = [ic_node_targets, boundary_nodes_targets].concat();
+    let api_boundary_nodes_targets: Vec<PrometheusStaticConfig> = map_target_group(
+        api_boundary_nodes_target_dtos_from_definitions(&definitions, &filters)
+            .into_iter()
+            .collect(),
+    );
+
+    let total_targets = [ic_node_targets, boundary_nodes_targets, api_boundary_nodes_targets].concat();
 
     (
         total_targets.len(),

--- a/rs/ic-observability/multiservice-discovery/src/server_handlers/export_targets_handler.rs
+++ b/rs/ic-observability/multiservice-discovery/src/server_handlers/export_targets_handler.rs
@@ -1,6 +1,9 @@
 use super::Server;
 use crate::{
-    definition::{boundary_nodes_from_definitions, ic_node_target_dtos_from_definitions},
+    definition::{
+        api_boundary_nodes_target_dtos_from_definitions, boundary_nodes_from_definitions,
+        ic_node_target_dtos_from_definitions,
+    },
     TargetFilterSpec,
 };
 use axum::{
@@ -33,10 +36,15 @@ pub(super) async fn export_targets(
             node_provider_id: PrincipalId::new_anonymous(),
             operator_id: PrincipalId::new_anonymous(),
             subnet_id: None,
+            // These are old boundary nodes which are not the same as API boundary nodes
+            // with time these should become api boundary nodes
+            is_api_bn: false,
         })
         .collect();
 
-    let total_targets = [ic_node_targets, boundary_nodes_targets].concat();
+    let api_boundary_nodes: Vec<TargetDto> = api_boundary_nodes_target_dtos_from_definitions(&definitions, &filters);
+
+    let total_targets = [ic_node_targets, boundary_nodes_targets, api_boundary_nodes].concat();
 
     if !total_targets.is_empty() {
         Ok(Json(total_targets))

--- a/rs/ic-observability/prometheus-config-updater/src/custom_filters.rs
+++ b/rs/ic-observability/prometheus-config-updater/src/custom_filters.rs
@@ -40,6 +40,7 @@ mod tests {
             dc_id: "test".to_string(),
             operator_id: PrincipalId::new_anonymous(),
             node_provider_id: PrincipalId::new_anonymous(),
+            is_api_bn: false,
         }
     }
 

--- a/rs/ic-observability/prometheus-config-updater/src/prometheus_config.rs
+++ b/rs/ic-observability/prometheus-config-updater/src/prometheus_config.rs
@@ -142,6 +142,7 @@ mod prometheus_serialize {
             dc_id: "test".to_string(),
             operator_id: PrincipalId::new_anonymous(),
             node_provider_id: PrincipalId::new_anonymous(),
+            is_api_bn: false,
         }
     }
 

--- a/rs/ic-observability/service-discovery/src/job_types.rs
+++ b/rs/ic-observability/service-discovery/src/job_types.rs
@@ -14,6 +14,7 @@ pub enum JobType {
     NodeExporter(NodeOS),
     Orchestrator,
     MetricsProxy(NodeOS),
+    IcBoundary,
 }
 
 /// By convention, the first two bytes of the host-part of the replica's IP
@@ -43,6 +44,7 @@ impl JobType {
             Self::Orchestrator => 9091,
             Self::MetricsProxy(NodeOS::Host) => 19100,
             Self::MetricsProxy(NodeOS::Guest) => 19100,
+            Self::IcBoundary => 9324,
         }
     }
     pub fn endpoint(&self) -> &'static str {
@@ -51,6 +53,7 @@ impl JobType {
             Self::NodeExporter(_) => "/metrics",
             Self::Orchestrator => "/",
             Self::MetricsProxy(_) => "/metrics",
+            Self::IcBoundary => "/metrics",
         }
     }
     pub fn scheme(&self) -> &'static str {
@@ -59,6 +62,7 @@ impl JobType {
             Self::NodeExporter(_) => "https",
             Self::Orchestrator => "http",
             Self::MetricsProxy(_) => "https",
+            Self::IcBoundary => "http",
         }
     }
 
@@ -124,6 +128,18 @@ impl JobType {
         .collect::<Vec<Self>>()
     }
 
+    pub fn all_for_api_boundary_nodes() -> Vec<Self> {
+        [
+            JobType::Replica,
+            JobType::Orchestrator,
+            JobType::NodeExporter(NodeOS::Guest),
+            JobType::NodeExporter(NodeOS::Host),
+            JobType::IcBoundary,
+        ]
+        .into_iter()
+        .collect::<Vec<Self>>()
+    }
+
     pub fn all_for_logs() -> Vec<Self> {
         [
             JobType::NodeExporter(NodeOS::Guest),
@@ -184,6 +200,7 @@ impl fmt::Display for JobType {
             JobType::Orchestrator => write!(f, "orchestrator"),
             JobType::MetricsProxy(NodeOS::Host) => write!(f, "host_metrics_proxy"),
             JobType::MetricsProxy(NodeOS::Guest) => write!(f, "guest_metrics_proxy"),
+            JobType::IcBoundary => write!(f, "ic_boundary"),
         }
     }
 }

--- a/rs/ic-observability/service-discovery/src/lib.rs
+++ b/rs/ic-observability/service-discovery/src/lib.rs
@@ -19,6 +19,7 @@ use ic_interfaces_registry::{RegistryClient, RegistryClientResult};
 use ic_protobuf::registry::node::v1::NodeRecord;
 use ic_registry_client::client::{RegistryClientError, RegistryVersion};
 use ic_registry_client_helpers::{
+    api_boundary_node::ApiBoundaryNodeRegistry,
     node::{NodeId, NodeRegistry, SubnetId},
     node_operator::{NodeOperatorRegistry, PrincipalId},
     subnet::{SubnetListRegistry, SubnetTransportRegistry},
@@ -67,6 +68,7 @@ pub struct TargetGroup {
     pub dc_id: String,
     pub operator_id: PrincipalId,
     pub node_provider_id: PrincipalId,
+    pub is_api_bn: bool,
 }
 
 impl TargetGroup {
@@ -208,6 +210,14 @@ impl IcServiceDiscoveryImpl {
             .get_subnet_ids(latest_version)
             .map_registry_err(latest_version, "get_subnet_ids")?;
 
+        let api_bns = match reg_client.get_api_boundary_node_ids(latest_version) {
+            Ok(abn) => abn,
+            Err(e) => {
+                warn!(log, "Error while fetching api boundary node ids: {:?}", e);
+                vec![]
+            }
+        };
+
         for subnet_id in subnet_ids {
             let t_infos = reg_client
                 .get_subnet_node_records(subnet_id, latest_version)
@@ -233,6 +243,7 @@ impl IcServiceDiscoveryImpl {
                     &mut node_targets,
                     Some(subnet_id),
                     ic_name,
+                    api_bns.contains(&node_id),
                 )?;
                 unassigned_node_ids.remove(&node_id);
             }
@@ -263,6 +274,7 @@ impl IcServiceDiscoveryImpl {
                 &mut node_targets,
                 None,
                 ic_name,
+                api_bns.contains(&node_id),
             )?;
         }
         Ok(node_targets)
@@ -276,6 +288,7 @@ impl IcServiceDiscoveryImpl {
         node_targets: &mut BTreeSet<TargetGroup>,
         subnet_id: Option<SubnetId>,
         ic_name: &str,
+        is_api_bn: bool,
     ) -> Result<(), IcServiceDiscoveryError> {
         let socket_addr = Self::node_record_to_target_addr(node_id, latest_version, node_record.clone())?;
 
@@ -294,6 +307,7 @@ impl IcServiceDiscoveryImpl {
             dc_id: node_operator.dc_id,
             operator_id,
             node_provider_id: PrincipalId::try_from(node_operator.node_provider_principal_id).unwrap_or_default(),
+            is_api_bn,
         });
 
         Ok(())


### PR DESCRIPTION
Added a flag `is_api_bn` to all targets on `/targets` path since api boundary nodes have a regular node record.
Generated prometheus config on `/prom/targets` looks like:
```json
{
  "targets": [
    "http://[2a00:fb01:400:200:6801:95ff:fed7:d475]:9091/"
  ],
  "labels": {
    "ic": "api-bns",
    "ic_node": "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe",
    "job": "orchestrator"
  }
}
{
  "targets": [
    "https://[2a00:fb01:400:200:6801:95ff:fed7:d475]:9100/metrics"
  ],
  "labels": {
    "ic": "api-bns",
    "ic_node": "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe",
    "job": "node_exporter"
  }
}
{
  "targets": [
    "https://[2a00:fb01:400:200:6800:95ff:fed7:d475]:9100/metrics"
  ],
  "labels": {
    "ic": "api-bns",
    "ic_node": "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe",
    "job": "host_node_exporter"
  }
}
{
  "targets": [
    "http://[2a00:fb01:400:200:6801:95ff:fed7:d475]:9324/metrics"
  ],
  "labels": {
    "ic": "api-bns",
    "ic_node": "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe",
    "job": "ic_boundary"
  }
}
```

Generated log structures sources look like: 
```json
{
  "sources": {
  ...,
  "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-host_node_exporter": {
      "type": "exec",
      "command": [
        "/log-fetcher",
        "--url",
        "http://[2a00:fb01:400:200:6800:95ff:fed7:d475]:19531/entries",
        "--name",
        "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-host_node_exporter",
        "--cursor-path",
        "/data/dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-host_node_exporter/checkpoint.txt"
      ],
      "mode": "streaming",
      "streaming": {
        "respawn_on_exit": false
      },
      "include_stderr": true
    },
  },
  "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-node_exporter": {
      "type": "exec",
      "command": [
        "/log-fetcher",
        "--url",
        "http://[2a00:fb01:400:200:6801:95ff:fed7:d475]:19531/entries",
        "--name",
        "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-node_exporter",
        "--cursor-path",
        "/data/dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-node_exporter/checkpoint.txt"
      ],
      "mode": "streaming",
      "streaming": {
        "respawn_on_exit": false
      },
      "include_stderr": true
    },
  },
  "transforms": {
  ...,
  "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-host_node_exporter-transform": {
      "type": "remap",
      "inputs": [
        "dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe-host_node_exporter"
      ],
      "source": ".address = \"2a00:fb01:400:200:6800:95ff:fed7:d475\"\n.is_api_bn = \"true\"\n.dc = \"\"\n.ic = \"api-bns\"\n.node_provider_id = \"7532g-cd7sa-3eaay-weltl-purxe-qliyt-hfuto-364ru-b3dsz-kw5uz-kqe\"\n.ic_node = \"dj5ch-uokcu-wctk6-b4mxs-bogcv-tg4xj-4ef2j-wcdsg-q2ngr-ya3ee-fqe\""
    },
}
```