### PR TITLE
feat(dre): listing proposals

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e6da14722080ba8a0b4069a6eb6deaec83172a87557d77964c9e84894b72a822",
+  "checksum": "a23efd2a9223be99e707de45f95191617e14ea319d026e8ae5eff0ec08ad9243",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -11743,6 +11743,10 @@
             {
               "id": "ic-interfaces-registry 0.9.0",
               "target": "ic_interfaces_registry"
+            },
+            {
+              "id": "ic-nns-common 0.9.0",
+              "target": "ic_nns_common"
             },
             {
               "id": "ic-nns-constants 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,7 @@ dependencies = [
  "ic-interfaces-registry",
  "ic-management-backend",
  "ic-management-types",
+ "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-governance",
  "ic-protobuf",

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -35,6 +35,7 @@ ic-management-backend = { workspace = true }
 ic-management-types = { workspace = true }
 ic-nns-constants = { workspace = true }
 ic-nns-governance = { workspace = true }
+ic-nns-common = { workspace = true }
 ic-protobuf = { workspace = true }
 ic-registry-keys = { workspace = true }
 ic-registry-local-registry = { workspace = true }

--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -154,6 +154,9 @@ pub enum Commands {
         #[clap(long, default_value = None, required = true)]
         summary: Option<String>,
     },
+
+    /// Proposal Listing
+    Proposals(proposals::Cmd),
 }
 
 impl Default for Commands {
@@ -421,5 +424,21 @@ pub mod nodes {
             #[clap(long, aliases = ["summary"])]
             motivation: Option<String>,
         },
+    }
+}
+
+pub mod proposals {
+    use super::*;
+
+    #[derive(Parser, Clone)]
+    pub struct Cmd {
+        #[clap(subcommand)]
+        pub subcommand: Commands,
+    }
+
+    #[derive(Subcommand, Clone)]
+    pub enum Commands {
+        /// Get list of pending proposals
+        Pending,
     }
 }

--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -440,5 +440,49 @@ pub mod proposals {
     pub enum Commands {
         /// Get list of pending proposals
         Pending,
+
+        /// Get list of filtered proposals
+        List {
+            /// Limit on the number of \[ProposalInfo\] to return. If no value is
+            /// specified, or if a value greater than 100 is specified, 100
+            /// will be used.
+            #[clap(long, default_value = "100")]
+            limit: u32,
+            /// If specified, only return proposals that are strictly earlier than
+            /// the specified proposal according to the proposal ID. If not
+            /// specified, start with the most recent proposal.
+            #[clap(long)]
+            before_proposal: Option<u64>,
+            /// Exclude proposals with a topic in this list. This is particularly
+            /// useful to exclude proposals on the topics TOPIC_EXCHANGE_RATE and
+            /// TOPIC_KYC which most users are not likely to be interested in
+            /// seeing.
+            #[clap(long)]
+            exclude_topic: Vec<i32>,
+            /// Include proposals that have a reward status in this list (see
+            /// \[ProposalRewardStatus\] for more information). If this list is
+            /// empty, no restriction is applied. For example, many users listing
+            /// proposals will only be interested in proposals for which they can
+            /// receive voting rewards, i.e., with reward status
+            /// PROPOSAL_REWARD_STATUS_ACCEPT_VOTES.
+            #[clap(long)]
+            include_reward_status: Vec<i32>,
+            /// Include proposals that have a status in this list (see
+            /// \[ProposalStatus\] for more information). If this list is empty, no
+            /// restriction is applied.
+            #[clap(long)]
+            include_status: Vec<i32>,
+            /// Include all ManageNeuron proposals regardless of the visibility of the
+            /// proposal to the caller principal. Note that exclude_topic is still
+            /// respected even when this option is set to true.
+            #[clap(long)]
+            include_all_manage_neuron_proposals: Option<bool>,
+            /// Omits "large fields" from the response. Currently only omits the
+            /// `logo` and `token_logo` field of CreateServiceNervousSystem proposals. This
+            /// is useful to improve download times and to ensure that the response to the
+            /// request doesn't exceed the message size limit.
+            #[clap(long)]
+            omit_large_fields: Option<bool>,
+        },
     }
 }

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -343,10 +343,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                     let nns_url = target_network.get_nns_urls().first().expect("Should have at least one NNS URL");
                     let client = GovernanceCanisterWrapper::from(CanisterClient::from_anonymous(nns_url)?);
                     let proposals = client.list_proposals(ListProposalInfo {
-                        before_proposal: match before_proposal {
-                            None => None,
-                            Some(p) => Some(ProposalId { id: *p })
-                        },
+                        before_proposal: before_proposal.as_ref().map(|p| ProposalId { id: *p }),
                         exclude_topic: exclude_topic.clone(),
                         include_all_manage_neuron_proposals: *include_all_manage_neuron_proposals,
                         include_reward_status: include_reward_status.clone(),

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -12,6 +12,8 @@ use ic_canisters::CanisterClient;
 use ic_management_backend::endpoints;
 use ic_management_types::requests::NodesRemoveRequest;
 use ic_management_types::{Artifact, MinNakamotoCoefficients, NodeFeature};
+use ic_nns_common::pb::v1::ProposalId;
+use ic_nns_governance::pb::v1::ListProposalInfo;
 use log::{info, warn};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -328,7 +330,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                     ..Default::default()
                 }, cli_opts.simulate).await
             }
-            cli::Commands::Proposals(p) => match p.subcommand {
+            cli::Commands::Proposals(p) => match &p.subcommand {
                 cli::proposals::Commands::Pending => {
                     let nns_url = target_network.get_nns_urls().first().expect("Should have at least one NNS URL");
                     let client = GovernanceCanisterWrapper::from(CanisterClient::from_anonymous(nns_url)?);
@@ -337,6 +339,25 @@ async fn async_main() -> Result<(), anyhow::Error> {
                     println!("{}", proposals);
                     Ok(())
                 }
+                cli::proposals::Commands::List { limit, before_proposal, exclude_topic, include_reward_status, include_status, include_all_manage_neuron_proposals, omit_large_fields } => {
+                    let nns_url = target_network.get_nns_urls().first().expect("Should have at least one NNS URL");
+                    let client = GovernanceCanisterWrapper::from(CanisterClient::from_anonymous(nns_url)?);
+                    let proposals = client.list_proposals(ListProposalInfo {
+                        before_proposal: match before_proposal {
+                            None => None,
+                            Some(p) => Some(ProposalId { id: *p })
+                        },
+                        exclude_topic: exclude_topic.clone(),
+                        include_all_manage_neuron_proposals: *include_all_manage_neuron_proposals,
+                        include_reward_status: include_reward_status.clone(),
+                        include_status: include_status.clone(),
+                        limit: *limit,
+                        omit_large_fields: *omit_large_fields
+                    }).await?;
+                    let proposals = serde_json::to_string(&proposals).map_err(|e| anyhow::anyhow!("Couldn't serialize to string: {:?}", e))?;
+                    println!("{}", proposals);
+                    Ok(())
+                },
             },
         }
     })


### PR DESCRIPTION
Currently supports:
1. Listing pending proposals => maps to [`get_pending_proposals`](https://dashboard.internetcomputer.org/canister/rrkah-fqaaa-aaaaa-aaaaq-cai#get_pending_proposals)
2. Listing proposal with filtering => maps to [`list_proposals`](https://dashboard.internetcomputer.org/canister/rrkah-fqaaa-aaaaa-aaaaq-cai#get_pending_proposals)