### PR TITLE
fix(release-controller): [DRE-166] use requests instead of urllib, to handle timeouts

### DIFF
--- a/release-controller/governance.py
+++ b/release-controller/governance.py
@@ -1,8 +1,8 @@
 import json
 import pathlib
 import tempfile
-import urllib.request
 
+import requests
 from ic import Canister
 from ic.agent import Agent
 from ic.candid import decode
@@ -40,11 +40,12 @@ class GovernanceCanister:
         with tempfile.TemporaryDirectory() as tmpdirname:
             version = self.version()
             governance_did = pathlib.Path(tmpdirname) / "governance.did"
-            urllib.request.urlretrieve(
+            contents = requests.get(
                 f"https://raw.githubusercontent.com/dfinity/ic/{version}/rs/nns/governance/canister/governance.did",
-                governance_did,
                 timeout=10,
-            )
+            ).text
+            with open(governance_did, "w", encoding="utf8") as f:
+                f.write(contents)
             self.canister = Canister(
                 agent=self.agent, canister_id=self.principal, candid=open(governance_did, encoding="utf8").read()
             )

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import os
 import pathlib
+import socket
 import sys
 import tempfile
 import time
@@ -319,4 +320,5 @@ def oneoff():
 
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    socket.setdefaulttimeout(15)
     main()


### PR DESCRIPTION
source: https://stackoverflow.com/questions/32763720/timeout-a-file-download-with-python-urllib