### PR TITLE
fix(dre): Add compatibility in fetching trustworthy metrics from old subnet versions

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "df6cd8ac2b9ae09159db419dfe2add82ed7e2a07160c72fc167bbb77b19f804e",
+  "checksum": "b0c1429a1d74326f983596231a5f060a6870760dedec91dc54e2a44ca49c6975",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -17775,6 +17775,10 @@
             {
               "id": "ic-utils 0.34.0",
               "target": "ic_utils"
+            },
+            {
+              "id": "log 0.4.21",
+              "target": "log"
             },
             {
               "id": "pkcs11 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ dependencies = [
  "ic-registry-transport",
  "ic-sys",
  "ic-utils 0.34.0",
+ "log",
  "pkcs11",
  "prost",
  "serde",

--- a/rs/ic-canisters/Cargo.toml
+++ b/rs/ic-canisters/Cargo.toml
@@ -23,6 +23,7 @@ ic-protobuf = { workspace = true }
 ic-registry-transport = { workspace = true }
 ic-sys = { workspace = true }
 ic-utils = { workspace = true }
+log = { workspace = true }
 pkcs11 = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }

--- a/rs/ic-canisters/src/management.rs
+++ b/rs/ic-canisters/src/management.rs
@@ -1,9 +1,10 @@
 use anyhow::Context;
-use candid::{Decode, Encode};
+use candid::{CandidType, Decode, Deserialize, Encode};
 use ic_agent::Agent;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_management_canister_types::{NodeMetrics as NM, NodeMetricsHistoryArgs, NodeMetricsHistoryResponse as NMHR};
+use ic_management_canister_types::NodeMetricsHistoryArgs;
 use ic_utils::interfaces::{wallet::CallResult, WalletCanister};
+use log::{error, info};
 use serde::Serialize;
 use std::str::FromStr;
 
@@ -36,11 +37,11 @@ impl WalletCanisterWrapper {
         &self,
         wallet_canister_id: CanisterId,
         start_at_timestamp: u64,
-        subnet: PrincipalId,
+        subnet_id: PrincipalId,
     ) -> anyhow::Result<Vec<NodeMetricsHistoryResponse>> {
         let contract = NodeMetricsHistoryArgs {
             start_at_timestamp_nanos: start_at_timestamp,
-            subnet_id: subnet,
+            subnet_id: subnet_id,
         };
         let wallet_canister = WalletCanister::from_canister(
             ic_utils::Canister::builder()
@@ -65,30 +66,61 @@ impl WalletCanisterWrapper {
 
         let (result,): (Result<CallResult, String>,) =
             builder.build().call_and_wait().await.context("Failed wallet call.")?;
-        Ok(
-            Decode!(&result.map_err(|err| anyhow::anyhow!(err))?.r#return, Vec<NMHR>)?
-                .into_iter()
-                .map(|f| f.into())
-                .collect(),
-        )
+
+        match result {
+            Ok(result) => {
+                match Decode!(&result.r#return, Vec<NodeMetricsHistoryResponse>) {
+                    Ok(result) => Ok(result.into_iter().map(|f| f.into()).collect()),
+                    Err(_) => {
+                        info!("Failed to decode Trustworthy Metrics of subnet {} using the new format. Falling back to the old format.", subnet_id);
+                        // Try to decode as Vec<NodeMetricsHistoryResponseOld> as a fallback, since some subnets may still be running the old version of the management canister.
+                        match Decode!(&result.r#return, Vec<NodeMetricsHistoryResponseOld>) {
+                            Ok(result) => Ok(result.into_iter().map(|f| f.into()).collect()),
+                            Err(err) => {
+                                error!(
+                                    "Failed to decode Trustworthy Metrics of subnet {} using the old format.",
+                                    subnet_id
+                                );
+                                Err(anyhow::anyhow!(err))
+                            }
+                        }
+                    }
+                }
+            }
+            Err(err) => Err(anyhow::anyhow!(err)),
+        }
     }
 }
 
-#[derive(Default, Clone, Debug, Serialize)]
-pub struct NodeMetrics {
+// TODO: Remove the old structs once the old format is no longer used on the Mainnet.
+#[derive(Default, CandidType, Deserialize, Clone, Debug, Serialize)]
+pub struct NodeMetricsOld {
     pub node_id: PrincipalId,
     pub num_blocks_total: u64,
     pub num_block_failures_total: u64,
 }
 
-#[derive(Default, Clone, Debug, Serialize)]
+#[derive(Default, CandidType, Deserialize, Clone, Debug, Serialize)]
+pub struct NodeMetricsHistoryResponseOld {
+    pub timestamp_nanos: u64,
+    pub node_metrics: Vec<NodeMetricsOld>,
+}
+
+#[derive(Default, CandidType, Deserialize, Clone, Debug, Serialize)]
+pub struct NodeMetrics {
+    pub node_id: PrincipalId,
+    pub num_blocks_proposed_total: u64,
+    pub num_block_failures_total: u64,
+}
+
+#[derive(Default, CandidType, Deserialize, Clone, Debug, Serialize)]
 pub struct NodeMetricsHistoryResponse {
     pub timestamp_nanos: u64,
     pub node_metrics: Vec<NodeMetrics>,
 }
 
-impl From<NMHR> for NodeMetricsHistoryResponse {
-    fn from(value: NMHR) -> Self {
+impl From<NodeMetricsHistoryResponseOld> for NodeMetricsHistoryResponse {
+    fn from(value: NodeMetricsHistoryResponseOld) -> Self {
         Self {
             timestamp_nanos: value.timestamp_nanos,
             node_metrics: value.node_metrics.into_iter().map(|f| f.into()).collect(),
@@ -96,11 +128,11 @@ impl From<NMHR> for NodeMetricsHistoryResponse {
     }
 }
 
-impl From<NM> for NodeMetrics {
-    fn from(value: NM) -> Self {
+impl From<NodeMetricsOld> for NodeMetrics {
+    fn from(value: NodeMetricsOld) -> Self {
         Self {
             node_id: value.node_id,
-            num_blocks_total: value.num_blocks_proposed_total,
+            num_blocks_proposed_total: value.num_blocks_total,
             num_block_failures_total: value.num_block_failures_total,
         }
     }

--- a/rs/ic-canisters/src/management.rs
+++ b/rs/ic-canisters/src/management.rs
@@ -41,7 +41,7 @@ impl WalletCanisterWrapper {
     ) -> anyhow::Result<Vec<NodeMetricsHistoryResponse>> {
         let contract = NodeMetricsHistoryArgs {
             start_at_timestamp_nanos: start_at_timestamp,
-            subnet_id: subnet_id,
+            subnet_id,
         };
         let wallet_canister = WalletCanister::from_canister(
             ic_utils::Canister::builder()
@@ -70,7 +70,7 @@ impl WalletCanisterWrapper {
         match result {
             Ok(result) => {
                 match Decode!(&result.r#return, Vec<NodeMetricsHistoryResponse>) {
-                    Ok(result) => Ok(result.into_iter().map(|f| f.into()).collect()),
+                    Ok(result) => Ok(result.to_vec()),
                     Err(_) => {
                         info!("Failed to decode Trustworthy Metrics of subnet {} using the new format. Falling back to the old format.", subnet_id);
                         // Try to decode as Vec<NodeMetricsHistoryResponseOld> as a fallback, since some subnets may still be running the old version of the management canister.


### PR DESCRIPTION
Some subnets are still running the old version which was preventing the dre tool from fetching trustworthy metrics.