### PR TITLE
feat(dre): implementing checks for correct node rewards set for node operators

### DIFF
--- a/rs/cli/src/registry_dump.rs
+++ b/rs/cli/src/registry_dump.rs
@@ -2,8 +2,11 @@ use std::{collections::BTreeMap, path::PathBuf, str::FromStr, time::Duration};
 
 use ic_base_types::{PrincipalId, RegistryVersion};
 use ic_interfaces_registry::RegistryClient;
-use ic_management_backend::registry::{local_registry_path, sync_local_store, RegistryFamilyEntries};
-use ic_management_types::Network;
+use ic_management_backend::{
+    health::{HealthClient, HealthStatusQuerier},
+    registry::{local_registry_path, sync_local_store, RegistryFamilyEntries},
+};
+use ic_management_types::{Network, Status};
 use ic_protobuf::registry::{
     api_boundary_node::v1::ApiBoundaryNodeRecord,
     dc::v1::DataCenterRecord,
@@ -42,7 +45,7 @@ pub async fn dump_registry(path: &Option<PathBuf>, network: &Network, version: &
     let elected_guest_os_versions = get_elected_guest_os_versions(&local_registry, version)?;
     let elected_host_os_versions = get_elected_host_os_versions(&local_registry, version)?;
 
-    let node_operators = get_node_operators(&local_registry, version)?;
+    let mut node_operators = get_node_operators(&local_registry, version)?;
 
     let dcs = get_data_centers(&local_registry, version)?;
 
@@ -54,8 +57,20 @@ pub async fn dump_registry(path: &Option<PathBuf>, network: &Network, version: &
         Err(e) => return Err(e.into()),
     };
 
-    let nodes = get_nodes(&local_registry, version, &node_operators, &subnets)?;
+    let nodes = get_nodes(&local_registry, version, &node_operators, &subnets, &network).await?;
+    // Calculate number of rewardable nodes for node operators
+    for node_operator in node_operators.values_mut() {
+        node_operator.total_up_nodes = nodes
+            .iter()
+            .filter(|n| {
+                n.node_operator_id == node_operator.node_operator_principal_id && (n.status == Status::Healthy || n.status == Status::Degraded)
+            })
+            .count() as u32;
 
+        if node_operator.total_up_nodes == node_operator.rewardable_nodes.iter().map(|n| n.1).sum::<u32>() {
+            node_operator.rewards_correct = true;
+        }
+    }
     let node_rewards_table = get_node_rewards_table(&local_registry, version, network);
 
     let api_bns = get_api_boundary_nodes(&local_registry, version)?;
@@ -110,20 +125,25 @@ fn get_elected_host_os_versions(local_registry: &LocalRegistry, version: Registr
     Ok(elected_versions)
 }
 
-fn get_nodes(
+async fn get_nodes(
     local_registry: &LocalRegistry,
     version: RegistryVersion,
     node_operators: &BTreeMap<PrincipalId, NodeOperator>,
     subnets: &[SubnetRecord],
+    network: &Network,
 ) -> Result<Vec<NodeDetails>, RegistryDumpError> {
+    let health_client = HealthClient::new(network.clone());
+    let nodes_health = health_client.nodes().await?;
+
     let nodes = local_registry
         .get_family_entries_of_version::<NodeRecord>(version)
         .map_err(|e| anyhow::anyhow!("Couldn't get nodes: {:?}", e))?
         .into_iter()
         .map(|(k, (_, record))| {
             let node_operator_id = PrincipalId::try_from(&record.node_operator_id).expect("Couldn't parse principal id");
+            let node_id = PrincipalId::from_str(&k).expect("Couldn't parse principal id");
             NodeDetails {
-                node_id: PrincipalId::from_str(&k).expect("Couldn't parse principal id"),
+                node_id,
                 xnet: record.xnet,
                 http: record.http,
                 node_operator_id,
@@ -143,6 +163,7 @@ fn get_nodes(
                     .expect("Couldn't find node provider for node operator")
                     .dc_id
                     .clone(),
+                status: nodes_health.get(&node_id).unwrap_or(&ic_management_types::Status::Unknown).clone(),
             }
         })
         .collect::<Vec<_>>();
@@ -224,6 +245,8 @@ fn get_node_operators(local_registry: &LocalRegistry, version: RegistryVersion) 
                     dc_id: record.dc_id,
                     rewardable_nodes: record.rewardable_nodes,
                     ipv6: record.ipv6,
+                    total_up_nodes: 0,
+                    rewards_correct: false,
                 },
             )
         })
@@ -294,6 +317,7 @@ struct NodeDetails {
     subnet_id: Option<PrincipalId>,
     dc_id: String,
     node_provider_id: PrincipalId,
+    status: Status,
 }
 
 /// User-friendly representation of a SubnetRecord. For instance,
@@ -331,6 +355,8 @@ struct NodeOperator {
     dc_id: String,
     rewardable_nodes: std::collections::BTreeMap<String, u32>,
     ipv6: Option<String>,
+    total_up_nodes: u32,
+    rewards_correct: bool,
 }
 
 // We re-create the rewards structs here in order to convert the output of get-rewards-table into the format

--- a/rs/cli/src/registry_dump.rs
+++ b/rs/cli/src/registry_dump.rs
@@ -57,7 +57,7 @@ pub async fn dump_registry(path: &Option<PathBuf>, network: &Network, version: &
         Err(e) => return Err(e.into()),
     };
 
-    let nodes = get_nodes(&local_registry, version, &node_operators, &subnets, &network).await?;
+    let nodes = get_nodes(&local_registry, version, &node_operators, &subnets, network).await?;
     // Calculate number of rewardable nodes for node operators
     for node_operator in node_operators.values_mut() {
         node_operator.total_up_nodes = nodes

--- a/rs/ic-management-backend/src/health.rs
+++ b/rs/ic-management-backend/src/health.rs
@@ -41,7 +41,7 @@ impl HealthStatusQuerier for HealthClient {
     }
 }
 
-enum HealthStatusQuerierImplementations {
+pub enum HealthStatusQuerierImplementations {
     Dashboard(PublicDashboardHealthClient),
     Prometheus(PrometheusHealthClient),
 }


### PR DESCRIPTION
This PR builds upon `dump-registry` command. It adds node status to the node output which looks like the following:
```json
  {
    "node_id": "zxxo4-abmdb-uj3ok-cbj4k-is36g-b5o2d-c6akl-vmgyu-d2wie-hgr3y-uae",
    "xnet": {
      "ip_addr": "2a00:fc0:5000:300:6801:4fff:fe2e:6276",
      "port": 2497
    },
    "http": {
      "ip_addr": "2a00:fc0:5000:300:6801:4fff:fe2e:6276",
      "port": 8080
    },
    "node_operator_id": "3xiew-2wo3x-tnbn2-o7kok-wwsnw-7koo2-gna5r-rlrt3-zotsh-dwpg6-kae",
    "chip_id": null,
    "hostos_version_id": "e268b9807f1ab4ae65d7b29fe70a3b358d014d6a",
    "public_ipv4_config": null,
    "subnet_id": null,
    "dc_id": "mb1",
    "node_provider_id": "wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae",
    "status": "Healthy"
  },
  {
    "node_id": "zzhpj-v2jd7-sfsts-suhfq-k4otv-fy5n3-tsogo-6jrk2-adsxv-c3jwu-xqe",
    "xnet": {
      "ip_addr": "2001:1900:2100:2827:6801:bff:fe3b:cab1",
      "port": 2497
    },
    "http": {
      "ip_addr": "2001:1900:2100:2827:6801:bff:fe3b:cab1",
      "port": 8080
    },
    "node_operator_id": "nj365-76cya-vjwgn-vyuxb-y74nh-bhlti-l6mzp-5efbh-u7nld-5jeba-kae",
    "chip_id": null,
    "hostos_version_id": "e268b9807f1ab4ae65d7b29fe70a3b358d014d6a",
    "public_ipv4_config": null,
    "subnet_id": null,
    "dc_id": "mm1",
    "node_provider_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
    "status": "Healthy"
  },
  {
    "node_id": "zzuq4-xiygt-ypkox-2tgdr-yvpzp-optye-xazeq-vnpw5-pata3-4jlle-wqe",
    "xnet": {
      "ip_addr": "2602:ffe4:1:45:6801:75ff:fe37:3ebd",
      "port": 2497
    },
    "http": {
      "ip_addr": "2602:ffe4:1:45:6801:75ff:fe37:3ebd",
      "port": 8080
    },
    "node_operator_id": "4lbqo-vgpoe-kemak-voout-777uo-kk74n-fnct3-pc4eg-3txi3-7cghf-rqe",
    "chip_id": null,
    "hostos_version_id": null,
    "public_ipv4_config": {
      "ip_addr": "128.14.26.19",
      "gateway_ip_addr": [
        "128.14.26.18"
      ],
      "prefix_length": 29
    },
    "subnet_id": null,
    "dc_id": "hk3",
    "node_provider_id": "4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae",
    "status": "Healthy"
  }
```
And adds two fields to the node operators output:
1. `total_up_nodes` - number of `Healthy` and `Degraded` nodes an operator has
2. `rewards_correct` - boolean field which checks if the total number of `rewardable_nodes` matches the `total_up_nodes` field. 
These fields look like the following:
```json
  {
    "node_operator_principal_id": "mjeqs-wxqp7-tecvn-77uxe-eowch-4l4gy-6lc6f-ys6je-qnybm-5fxya-qqe",
    "node_allowance": 0,
    "node_provider_principal_id": "rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae",
    "dc_id": "br1",
    "rewardable_nodes": {
      "type0": 0,
      "type1": 28
    },
    "ipv6": null,
    "total_up_nodes": 28,
    "rewards_correct": true
  },
  {
    "node_operator_principal_id": "7fnoo-4pqrc-tpnof-6mce7-ue5p4-5pe3d-rvyo3-jd2ah-c3bbq-lhyrx-7qe",
    "node_allowance": 2,
    "node_provider_principal_id": "wwdbq-xuqhf-eydzu-oyl7p-ga565-zm7s7-yrive-ozgsy-zzgh3-qwb3j-cae",
    "dc_id": "tp1",
    "rewardable_nodes": {
      "type0": 7
    },
    "ipv6": null,
    "total_up_nodes": 5,
    "rewards_correct": false
  },
  {
    "node_operator_principal_id": "zc635-ppr46-ap6eg-pghtn-wtnxz-6czvv-a4uxm-adjgb-wtoh4-2ddnl-uae",
    "node_allowance": 0,
    "node_provider_principal_id": "efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe",
    "dc_id": "bn1",
    "rewardable_nodes": {
      "type3.1": 6
    },
    "ipv6": null,
    "total_up_nodes": 6,
    "rewards_correct": true
  }
```

Together this can be used to determine which node operators need to have their `rewardable_nodes` adjusted in many ways. One way is to use `jq`:
```bash
dre dump-registry | jq '[.node_operators.[] | select(.rewards_correct == false)]'
```