### PR TITLE
fix(dre): not displaying sensitive pin when running help command

### DIFF
--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -10,7 +10,7 @@ use url::Url;
 #[derive(Parser, Clone, Default)]
 #[clap(about, version = env!("CARGO_PKG_VERSION"), author)]
 pub struct Opts {
-    #[clap(long, env = "HSM_PIN", global = true)]
+    #[clap(long, env = "HSM_PIN", global = true, hide_env_values = true)]
     pub hsm_pin: Option<String>,
     #[clap(long, value_parser=maybe_hex::<u64>, env = "HSM_SLOT", global = true)]
     pub hsm_slot: Option<u64>,


### PR DESCRIPTION
Before:
```bash
dre --help                                                               
 INFO  dre > Running version 0.4.0-9f8fa09
 INFO  dre > Binary up to date.
Tooling for managing the Internet Computer

Usage: dre [OPTIONS] <COMMAND>

Commands:
  der-to-principal         
  subnet                   Manage an existing subnet
  get                      Get a value using ic-admin CLI
  propose                  Place a proposal using the ic-admin CLI
  update-unassigned-nodes  Place a proposal for updating unassigned nodes config
  version                  Manage replica/host-os versions blessing
  hostos                   Rollout hostos version
  nodes                    Manage nodes
  vote                     Vote on our proposals
  trustworthy-metrics      Trustworthy Metrics
  registry                 Registry inspection (dump) operations
  firewall                 Firewall rules
  proposals                Proposal Listing
  help                     Print this message or the help of the given subcommand(s)

Options:
      --hsm-pin <HSM_PIN>                  [env: HSM_PIN=123456]
      --hsm-slot <HSM_SLOT>                [env: HSM_SLOT=0]
      --hsm-key-id <HSM_KEY_ID>            [env: HSM_KEY_ID=0]
      --private-key-pem <PRIVATE_KEY_PEM>  [env: PRIVATE_KEY_PEM=]
      --neuron-id <NEURON_ID>              [env: NEURON_ID=]
      --ic-admin <IC_ADMIN>                [env: IC_ADMIN=]
      --dev                                [env: DEV=]
  -y, --yes                                [env: YES=]
      --simulate                           
      --verbose                            [env: VERBOSE=]
      --network <NETWORK>                  [env: NETWORK=] [default: mainnet]
      --nns-urls <NNS_URLS>                [env: NNS_URLS=]
  -h, --help                               Print help
  -V, --version                            Print version
```

After:
```bash
dre --help                                                                    
 INFO  dre > Running version 0.4.0-9f8fa09-dirty
 INFO  dre > Binary up to date.
Tooling for managing the Internet Computer

Usage: dre [OPTIONS] <COMMAND>

Commands:
  der-to-principal         
  subnet                   Manage an existing subnet
  get                      Get a value using ic-admin CLI
  propose                  Place a proposal using the ic-admin CLI
  update-unassigned-nodes  Place a proposal for updating unassigned nodes config
  version                  Manage replica/host-os versions blessing
  hostos                   Rollout hostos version
  nodes                    Manage nodes
  vote                     Vote on our proposals
  trustworthy-metrics      Trustworthy Metrics
  registry                 Registry inspection (dump) operations
  firewall                 Firewall rules
  proposals                Proposal Listing
  help                     Print this message or the help of the given subcommand(s)

Options:
      --hsm-pin <HSM_PIN>                  [env: HSM_PIN]
      --hsm-slot <HSM_SLOT>                [env: HSM_SLOT=0]
      --hsm-key-id <HSM_KEY_ID>            [env: HSM_KEY_ID=0]
      --private-key-pem <PRIVATE_KEY_PEM>  [env: PRIVATE_KEY_PEM=]
      --neuron-id <NEURON_ID>              [env: NEURON_ID=]
      --ic-admin <IC_ADMIN>                [env: IC_ADMIN=]
      --dev                                [env: DEV=]
  -y, --yes                                [env: YES=]
      --simulate                           
      --verbose                            [env: VERBOSE=]
      --network <NETWORK>                  [env: NETWORK=] [default: mainnet]
      --nns-urls <NNS_URLS>                [env: NNS_URLS=]
  -h, --help                               Print help
  -V, --version                            Print version
```