### PR TITLE
fix(release-notes): Drop the re-classification of commits to "other" in some cases

### DIFF
--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -403,7 +403,7 @@ def release_notes(first_commit, last_commit, release_name) -> str:
 
         commit_type = conventional["type"].lower()
         commit_type = commit_type if commit_type in TYPE_PRETTY_MAP else "other"
-        if len(teams) >= 3:
+        if len(teams) >= 5:
             # The change seems to be touching many teams, let's mark it as "other" (generic)
             commit_type = "other"
 

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -403,9 +403,6 @@ def release_notes(first_commit, last_commit, release_name) -> str:
 
         commit_type = conventional["type"].lower()
         commit_type = commit_type if commit_type in TYPE_PRETTY_MAP else "other"
-        if len(teams) >= 5:
-            # The change seems to be touching many teams, let's mark it as "other" (generic)
-            commit_type = "other"
 
         if ["ic-testing-verification"] == teams or all([team in EXCLUDED_TEAMS for team in teams]):
             included = False


### PR DESCRIPTION
This re-classification was triggering wrongly in some cases, marking feature commits as "other" just because the feature commit was touching many teams.

This is not needed anymore since conventional commits are getting enforced in the IC repo.