### PR TITLE
chore: changing default behavior if cursor is not present

### DIFF
--- a/rs/log-fetcher/src/main.rs
+++ b/rs/log-fetcher/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), anyhow::Error> {
             cursor,
             match cursor.is_empty() {
                 false => 1,
-                true => -1,
+                true => 0,
             },
             30
         );


### PR DESCRIPTION
Previously, if the `__CURSOR` wasn't present we would start fetching only the newest logs. While convenient it we had some issues where we would lose logs or have to refetch from the start and this would help us achieve that more easily. When the new target is added we will start fetching logs from the start of their journal