### PR TITLE
feat: Support dre binary compiled without .git

### DIFF
--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -611,14 +611,14 @@ fn init_logger() {
 }
 
 fn check_latest_release(curr_version: &str) -> anyhow::Result<UpdateStatus> {
-    let re_version = Regex::new(r"^v?(\d+)\.(\d+)\.(\d+)(-([0-9a-f])+)?$").unwrap();
-    let current_version = if re_version.is_match(curr_version) {
-        match curr_version.split_once('-') {
-            Some((ver, _)) => ver,
-            None => curr_version,
-        }
-    } else {
-        return Err(anyhow::anyhow!("Version '{}' doesn't follow expected naming", curr_version));
+    // ^                --> start of line
+    // v?               --> optional 'v' char
+    // (\d+\.\d+\.\d+)  --> string in format '1.22.33'
+    // (-([0-9a-f])+)   --> string in format '-12345af' (optional)
+    let re_version = Regex::new(r"^v?(\d+\.\d+\.\d+)(-([0-9a-f])+)?$").unwrap();
+    let current_version = match re_version.captures(curr_version) {
+        Some(cap) => cap.get(1).unwrap().as_str(),
+        None => return Err(anyhow::anyhow!("Version '{}' doesn't follow expected naming", curr_version)),
     };
 
     let maybe_configured_backend = self_update::backends::github::ReleaseList::configure()


### PR DESCRIPTION
Binaries compiled without .git directory do not have `-abcd` suffix in their version, which breaks their execution with
```
Error: Version '0.4.0' doesn't follow expected naming
```

With this change we now properly check if the version follows semantic versioning.

