### PR TITLE
feat(dre): [DRE-178] Accept additional parameters for subnet creation

### DIFF
--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -1,11 +1,10 @@
-use std::{path::PathBuf, time::Duration};
-
 use clap::{Parser, Subcommand};
 use clap_num::maybe_hex;
 use humantime::parse_duration;
 use ic_base_types::PrincipalId;
 use ic_management_types::Artifact;
 use ic_registry_keys::FirewallRulesScope;
+use std::{path::PathBuf, time::Duration};
 use url::Url;
 
 // For more info about the version setup, look at https://docs.rs/clap/latest/clap/struct.Command.html#method.version
@@ -287,6 +286,14 @@ pub mod subnet {
 
             #[clap(long)]
             replica_version: Option<String>,
+
+            /// Arbitrary other ic-admin args
+            #[clap(allow_hyphen_values = true)]
+            other_args: Vec<String>,
+
+            /// Provide the list of all arguments that ic-admin accepts for subnet creation
+            #[clap(long)]
+            help_other_args: bool,
         },
     }
 }

--- a/rs/cli/src/ic_admin.rs
+++ b/rs/cli/src/ic_admin.rs
@@ -352,6 +352,25 @@ impl IcAdminWrapper {
         }
     }
 
+    pub(crate) fn grep_subcommand_arguments(&self, subcommand: &str) -> String {
+        let ic_admin_path = self.ic_admin_bin_path.clone().unwrap_or_else(|| "ic-admin".to_string());
+        let cmd_result = Command::new(ic_admin_path).args([subcommand, "--help"]).output();
+        match cmd_result.map_err(|e| e.to_string()) {
+            Ok(output) => {
+                if output.status.success() {
+                    String::from_utf8_lossy(output.stdout.as_ref()).to_string()
+                } else {
+                    error!("Execution of ic-admin failed: {}", String::from_utf8_lossy(output.stderr.as_ref()));
+                    String::new()
+                }
+            }
+            Err(err) => {
+                error!("Error starting ic-admin process: {}", err);
+                String::new()
+            }
+        }
+    }
+
     /// Run an `ic-admin get-*` command directly, and without an HSM
     pub async fn run_passthrough_get(&self, args: &[String], silent: bool) -> anyhow::Result<String> {
         if args.is_empty() {

--- a/rs/cli/src/ic_admin.rs
+++ b/rs/cli/src/ic_admin.rs
@@ -905,6 +905,7 @@ pub enum ProposeCommand {
     CreateSubnet {
         node_ids: Vec<PrincipalId>,
         replica_version: String,
+        other_args: Vec<String>,
     },
     AddApiBoundaryNodes {
         nodes: Vec<PrincipalId>,
@@ -974,7 +975,11 @@ impl ProposeCommand {
             .concat(),
             Self::RemoveNodes { nodes } => nodes.iter().map(|n| n.to_string()).collect(),
             Self::ReviseElectedVersions { release_artifact: _, args } => args.clone(),
-            Self::CreateSubnet { node_ids, replica_version } => {
+            Self::CreateSubnet {
+                node_ids,
+                replica_version,
+                other_args,
+            } => {
                 let mut args = vec!["--subnet-type".to_string(), "application".to_string()];
 
                 args.push("--replica-version-id".to_string());
@@ -983,6 +988,7 @@ impl ProposeCommand {
                 for id in node_ids {
                     args.push(id.to_string())
                 }
+                args.extend(other_args.to_vec());
                 args
             }
             Self::DeployGuestosToAllUnassignedNodes { replica_version } => {

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -106,6 +106,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
             }
 
             cli::Commands::Subnet(subnet) => {
+                // Check if required arguments are provided
                 match &subnet.subcommand {
                     cli::subnet::Commands::Deploy { .. } | cli::subnet::Commands::Resize { .. } => {
                         if subnet.id.is_none() {
@@ -130,6 +131,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                     cli::subnet::Commands::Create { .. } => {}
                 }
 
+                // Execute the command
                 match &subnet.subcommand {
                     cli::subnet::Commands::Deploy { version } => runner_instance.deploy(&subnet.id.unwrap(), version, simulate).await,
                     cli::subnet::Commands::Replace {
@@ -209,6 +211,8 @@ async fn async_main() -> Result<(), anyhow::Error> {
                         include,
                         motivation,
                         replica_version,
+                        other_args,
+                        help_other_args,
                     } => {
                         let min_nakamoto_coefficients = parse_min_nakamoto_coefficients(&mut cmd, min_nakamoto_coefficients);
                         if let Some(motivation) = motivation.clone() {
@@ -225,6 +229,8 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                     cli_opts.verbose,
                                     simulate,
                                     replica_version.clone(),
+                                    other_args.to_vec(),
+                                    *help_other_args,
                                 )
                                 .await
                         } else {

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -98,7 +98,14 @@ impl Runner {
         verbose: bool,
         simulate: bool,
         replica_version: Option<String>,
+        other_args: Vec<String>,
+        help_other_args: bool,
     ) -> anyhow::Result<()> {
+        if help_other_args {
+            println!("The following additional arguments are available for the `subnet create` command:");
+            println!("{}", self.ic_admin.grep_subcommand_arguments("propose-to-create-subnet"));
+            return Ok(());
+        }
         let subnet_creation_data = self.dashboard_backend_client.subnet_create(request).await?;
         if verbose {
             if let Some(run_log) = &subnet_creation_data.run_log {
@@ -119,6 +126,7 @@ impl Runner {
                 ic_admin::ProposeCommand::CreateSubnet {
                     node_ids: subnet_creation_data.added,
                     replica_version,
+                    other_args,
                 },
                 ic_admin::ProposeOptions {
                     title: Some("Creating new subnet".into()),


### PR DESCRIPTION
The other parameters are optional, of course. We just pass through any unrecognized arguments to ic-admin, expecting that ic-admin will be able to parse them properly, or complain otherwise.
