### PR TITLE
feat(msd): adding label for api boundary nodes

### DIFF
--- a/.github/workflows/msd-diff.yaml
+++ b/.github/workflows/msd-diff.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - name: "🔭 Compute MSD"
         id: msd-diff
+        shell: bash
         run: |
           set -exuo pipefail
           REGISTRY_DIR_MAIN="$HOME/tmp/main-registry"

--- a/.github/workflows/msd-diff.yaml
+++ b/.github/workflows/msd-diff.yaml
@@ -15,6 +15,8 @@ jobs:
   msd-diff:
     runs-on:
       labels: dre-runner-custom
+    # This image is based on ubuntu:20.04
+    container: ghcr.io/dfinity/dre/actions-runner:0.2.1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/rs/ic-observability/multiservice-discovery-shared/src/builders/prometheus_config_structure.rs
+++ b/rs/ic-observability/multiservice-discovery-shared/src/builders/prometheus_config_structure.rs
@@ -33,6 +33,7 @@ pub const IC_NAME: &str = "ic";
 pub const IC_NODE: &str = "ic_node";
 pub const IC_SUBNET: &str = "ic_subnet";
 pub const JOB: &str = "job";
+pub const API_BOUNDARY_NODE: &str = "api_boundary_node";
 // TODO: Re-add the labels below once we resolve the issues with the public dashboard queries
 // https://dfinity.atlassian.net/browse/OB-442
 // const DC: &str = "dc";
@@ -64,6 +65,10 @@ pub fn map_target_group(target_groups: Vec<TargetDto>) -> Vec<PrometheusStaticCo
                         .chain(match tg.subnet_id {
                             Some(subnet_id) => vec![(IC_SUBNET.into(), subnet_id.to_string())],
                             None => vec![],
+                        })
+                        .chain(match tg.is_api_bn {
+                            true => vec![(API_BOUNDARY_NODE.into(), "1".into())],
+                            false => vec![],
                         })
                         .chain(tg.custom_labels.clone().into_iter())
                         .collect()


### PR DESCRIPTION
This PR adds a new label to the `/prom/targets` endpoint that is being used from victoria metrics to scrape targets.
The new labels only affect api boundary nodes. Other targets won't get the new label.
Output looks like:
```json
...
  // Standard nodes
  
  {
    "targets": [
      "http://[2401:3f00:1000:23:6801:b3ff:fe4d:4fc7]:9091/"
    ],
    "labels": {
      "ic": "mercury",
      "ic_node": "kqurf-2p6ca-j4zte-3wkx5-rovid-kgn7s-yih6m-mj74k-claji-7uoje-vae",
      "job": "orchestrator"
    }
  },
  {
    "targets": [
      "https://[2401:3f00:1000:23:6801:b3ff:fe4d:4fc7]:9100/metrics"
    ],
    "labels": {
      "ic": "mercury",
      "ic_node": "kqurf-2p6ca-j4zte-3wkx5-rovid-kgn7s-yih6m-mj74k-claji-7uoje-vae",
      "job": "node_exporter"
    }
  },
  {
    "targets": [
      "https://[2401:3f00:1000:23:6800:b3ff:fe4d:4fc7]:9100/metrics"
    ],
    "labels": {
      "ic": "mercury",
      "ic_node": "kqurf-2p6ca-j4zte-3wkx5-rovid-kgn7s-yih6m-mj74k-claji-7uoje-vae",
      "job": "host_node_exporter"
    }
  },
  {
    "targets": [
      "https://[2401:3f00:1000:23:6800:b3ff:fe4d:4fc7]:19100/metrics"
    ],
    "labels": {
      "ic": "mercury",
      "ic_node": "kqurf-2p6ca-j4zte-3wkx5-rovid-kgn7s-yih6m-mj74k-claji-7uoje-vae",
      "job": "host_metrics_proxy"
    }
  },
  {
    "targets": [
      "https://[2401:3f00:1000:23:6801:b3ff:fe4d:4fc7]:19100/metrics"
    ],
    "labels": {
      "ic": "mercury",
      "ic_node": "kqurf-2p6ca-j4zte-3wkx5-rovid-kgn7s-yih6m-mj74k-claji-7uoje-vae",
      "job": "guest_metrics_proxy"
    }
  },
...
  // API boundary node 
  {
    "targets": [
      "http://[2001:438:8000:1d:6801:c1ff:feac:bc9]:9091/"
    ],
    "labels": {
      "api_boundary_node": "1",
      "ic": "mercury",
      "ic_node": "5dpkp-lfhr2-j7mfz-gavpn-puej5-wdfzg-fw42o-zupnu-izvk3-ubzzi-6ae",
      "job": "orchestrator"
    }
  },
  {
    "targets": [
      "https://[2001:438:8000:1d:6801:c1ff:feac:bc9]:9100/metrics"
    ],
    "labels": {
      "api_boundary_node": "1",
      "ic": "mercury",
      "ic_node": "5dpkp-lfhr2-j7mfz-gavpn-puej5-wdfzg-fw42o-zupnu-izvk3-ubzzi-6ae",
      "job": "node_exporter"
    }
  },
  {
    "targets": [
      "https://[2001:438:8000:1d:6800:c1ff:feac:bc9]:9100/metrics"
    ],
    "labels": {
      "api_boundary_node": "1",
      "ic": "mercury",
      "ic_node": "5dpkp-lfhr2-j7mfz-gavpn-puej5-wdfzg-fw42o-zupnu-izvk3-ubzzi-6ae",
      "job": "host_node_exporter"
    }
  },
  {
    "targets": [
      "http://[2001:438:8000:1d:6801:c1ff:feac:bc9]:9324/metrics"
    ],
    "labels": {
      "api_boundary_node": "1",
      "ic": "mercury",
      "ic_node": "5dpkp-lfhr2-j7mfz-gavpn-puej5-wdfzg-fw42o-zupnu-izvk3-ubzzi-6ae",
      "job": "ic_boundary"
    }
  }
...
```

Includes small fix for CI for missing custom runner image.