### PR TITLE
feat(msd): adding timestamp of last successful sync

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4bbd989bbf5c42e742aa858a262040efe99e2a94f7211a585016f04055bd73bb",
+  "checksum": "87e2c8f3dba5c353695777f770c5dd8e59ed40002ef4a441217e73677175c77b",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -30087,7 +30087,7 @@
               "target": "ic_types"
             },
             {
-              "id": "opentelemetry 0.21.0",
+              "id": "opentelemetry 0.22.0",
               "target": "opentelemetry"
             },
             {
@@ -32305,85 +32305,6 @@
         "links": "openssl"
       },
       "license": "MIT"
-    },
-    "opentelemetry 0.21.0": {
-      "name": "opentelemetry",
-      "version": "0.21.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/opentelemetry/0.21.0/download",
-          "sha256": "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "opentelemetry",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "opentelemetry",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "metrics",
-            "pin-project-lite",
-            "trace"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-sink 0.3.30",
-              "target": "futures_sink"
-            },
-            {
-              "id": "indexmap 2.2.6",
-              "target": "indexmap"
-            },
-            {
-              "id": "once_cell 1.19.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "thiserror 1.0.61",
-              "target": "thiserror"
-            },
-            {
-              "id": "urlencoding 2.1.3",
-              "target": "urlencoding"
-            }
-          ],
-          "selects": {
-            "cfg(all(target_arch = \"wasm32\", not(target_os = \"wasi\")))": [
-              {
-                "id": "js-sys 0.3.69",
-                "target": "js_sys"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.21.0"
-      },
-      "license": "Apache-2.0"
     },
     "opentelemetry 0.22.0": {
       "name": "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -6034,7 +6034,7 @@ dependencies = [
  "ic-registry-client",
  "ic-types",
  "multiservice-discovery-shared",
- "opentelemetry 0.21.0",
+ "opentelemetry",
  "reqwest 0.11.27",
  "retry",
  "serde",
@@ -6458,22 +6458,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
-dependencies = [
- "futures-core",
- "futures-sink",
- "indexmap 2.2.6",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
@@ -6494,7 +6478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bbcf6341cab7e2193e5843f0ac36c446a5b3fccb28747afaeda17996dcd02e"
 dependencies = [
  "once_cell",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
  "protobuf",
@@ -6519,7 +6503,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "ordered-float",
  "percent-encoding",
  "rand",

--- a/rs/ic-observability/multiservice-discovery/Cargo.toml
+++ b/rs/ic-observability/multiservice-discovery/Cargo.toml
@@ -28,8 +28,8 @@ tokio = { workspace = true }
 url = { workspace = true }
 futures.workspace = true
 axum = "0.7.4"
-axum-otel-metrics = "0.8.0"
-opentelemetry = { version = "0.21.0", features = ["metrics"] }
+axum-otel-metrics = "0.8.1"
+opentelemetry = { version = "0.22.0", features = ["metrics"] }
 retry = { workspace = true }
 
 [dev-dependencies]

--- a/rs/ic-observability/multiservice-discovery/src/metrics.rs
+++ b/rs/ic-observability/multiservice-discovery/src/metrics.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use opentelemetry::{global, metrics::Observer, KeyValue};
@@ -32,6 +33,7 @@ struct LatestValues {
     sync_registry_error: u64,
     definitions_load_successful: u64,
     definitions_sync_successful: u64,
+    successful_sync_ts: u64,
 }
 
 impl LatestValues {
@@ -41,6 +43,7 @@ impl LatestValues {
             sync_registry_error: 0,
             definitions_load_successful: 0,
             definitions_sync_successful: 0,
+            successful_sync_ts: 0,
         }
     }
 }
@@ -76,11 +79,17 @@ impl RunningDefinitionsMetrics {
             .u64_observable_gauge("msd.definitions.sync.successful")
             .with_description("Status of last sync of the registry with NNS of definition")
             .init();
+        let successful_sync_ts = meter
+            .clone()
+            .u64_observable_gauge("msd.definitions.sync.ts")
+            .with_description("Timestamp of last successful sync")
+            .init();
         let instruments = [
             load_new_targets_error.as_any(),
             sync_registry_error.as_any(),
             definitions_load_successful.as_any(),
             definitions_sync_successful.as_any(),
+            successful_sync_ts.as_any(),
         ];
         let s = latest_values_by_network.clone();
         let update_instruments = move |observer: &dyn Observer| {
@@ -95,6 +104,7 @@ impl RunningDefinitionsMetrics {
                     (&sync_registry_error, latest_values.sync_registry_error),
                     (&definitions_load_successful, latest_values.definitions_load_successful),
                     (&definitions_sync_successful, latest_values.definitions_sync_successful),
+                    (&successful_sync_ts, latest_values.successful_sync_ts),
                 ]
                 .into_iter()
                 {
@@ -111,7 +121,12 @@ impl RunningDefinitionsMetrics {
         let mut s = self.latest_values_by_network.write().unwrap();
         let latest_values = s.entry(network).or_insert(LatestValues::new());
         latest_values.definitions_sync_successful = match success {
-            true => 1,
+            true => {
+                let now = SystemTime::now();
+                let since_epoch = now.duration_since(UNIX_EPOCH).unwrap();
+                latest_values.successful_sync_ts = since_epoch.as_secs();
+                1
+            }
             false => {
                 latest_values.sync_registry_error += 1;
                 0


### PR DESCRIPTION
Example of the metric:
```text
# HELP http_server_active_requests The number of active HTTP requests.
# TYPE http_server_active_requests gauge
http_server_active_requests{http_request_method="GET",url_scheme="http",otel_scope_name="axum-app"} 1
# HELP msd_definitions_load_errors Total number of errors while loading new targets per definition
# TYPE msd_definitions_load_errors gauge
msd_definitions_load_errors{network="mercury",otel_scope_name="axum-app"} 0
# HELP msd_definitions_load_successful Status of last load of the registry per definition
# TYPE msd_definitions_load_successful gauge
msd_definitions_load_successful{network="mercury",otel_scope_name="axum-app"} 1
# HELP msd_definitions_sync_errors Total number of errors while syncing the registry per definition
# TYPE msd_definitions_sync_errors gauge
msd_definitions_sync_errors{network="mercury",otel_scope_name="axum-app"} 0
# HELP msd_definitions_sync_successful Status of last sync of the registry with NNS of definition
# TYPE msd_definitions_sync_successful gauge
msd_definitions_sync_successful{network="mercury",otel_scope_name="axum-app"} 1
# HELP msd_definitions_sync_ts Timestamp of last successful sync
# TYPE msd_definitions_sync_ts gauge
msd_definitions_sync_ts{network="mercury",otel_scope_name="axum-app"} 1718637276
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="unknown_service",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="0.22.1"} 1

```