### PR TITLE
fix(release-notes): Do not exclude "canister" changes in release notes

### DIFF
--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -99,7 +99,6 @@ EXCLUDE_PACKAGES_FILTERS = [
     r".+\/sns\/.+",
     r".+\/ckbtc\/.+",
     r".+\/cketh\/.+",
-    r".+canister.+",
     r"rs\/nns.+",
     r".+test.+",
     r"^bazel$",

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -68,7 +68,6 @@ EXCLUDE_PACKAGES_FILTERS = [
     r".+\/sns\/.+",
     r".+\/ckbtc\/.+",
     r".+\/cketh\/.+",
-    r".+canister.+",
     r"rs\/nns.+",
     r".+test.+",
     r"^bazel$",


### PR DESCRIPTION
Addresses the following complaint:
```
author: Maks Arut | 48afaffa4 Execution: limit the max number of nodes in compute_initial_*_dealings request argument  (48afaff ) was not in the release notes. 
```
openchat link: https://oc.app/community/32l35-yaaaa-aaaar-aw57q-cai/channel/78010556105983937984590438937075688039/92?open=true

slack link: https://dfinity.slack.com/archives/CGZJ7G1J6/p1718623326453169