### PR TITLE
feat(release-controller): Kill the release controller if it gets stuck

### DIFF
--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -27,6 +27,7 @@ from release_index_loader import GitReleaseLoader
 from release_index_loader import ReleaseLoader
 from release_notes import release_notes
 from util import version_name
+from watchdog import Watchdog
 
 from pylib.ic_admin import IcAdmin
 
@@ -260,6 +261,9 @@ def main():
     else:
         load_dotenv()
 
+    watchdog = Watchdog(timeout_seconds=600)  # Reconciler should report healthy every 10 minutes
+    watchdog.start()
+
     discourse_client = DiscourseClient(
         host=os.environ["DISCOURSE_URL"],
         api_username=os.environ["DISCOURSE_USER"],
@@ -297,6 +301,7 @@ def main():
     while True:
         try:
             reconciler.reconcile()
+            watchdog.report_healthy()
         except Exception as e:
             logging.error(traceback.format_exc())
             logging.error("failed to reconcile: %s", e)

--- a/release-controller/watchdog.py
+++ b/release-controller/watchdog.py
@@ -1,0 +1,31 @@
+import os
+import threading
+
+
+class Watchdog:
+    """A watchdog class that will terminate the application if it is not reported healthy within a given timeout."""
+
+    def __init__(self, timeout_seconds):
+        """Initialize the watchdog with a timeout in seconds."""
+        self.timeout = timeout_seconds
+        self._timer = None
+
+    def _handle_timeout(self):
+        print("Watchdog timeout, terminating the application")
+        # Immediately terminates the process with the given status code,
+        # bypassing the usual cleanup process that Python performs when exiting.
+        # This means that any cleanup handlers, such as try...finally blocks, with statements,
+        # and atexit functions, will not be executed.
+        # This ensures that the process terminates immediately.
+        os._exit(1)  # pylint: disable=protected-access
+
+    def start(self):
+        """Start the watchdog timer."""
+        self._timer = threading.Timer(self.timeout, self._handle_timeout)
+        self._timer.start()
+
+    def report_healthy(self):
+        """Report that the application is healthy, resetting the watchdog timer."""
+        if self._timer:
+            self._timer.cancel()
+        self.start()


### PR DESCRIPTION
Kubernetes will automatically restart it in this case.
Some 3rd party libraries that we use do not implement timeouts properly.

Closes DRE-184