### PR TITLE
chore(dre): Rename --simulate to --dry-run

### DIFF
--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -27,12 +27,13 @@ pub struct Opts {
     pub dev: bool,
 
     // Skip the confirmation prompt
-    #[clap(short, long, env = "YES", global = true, conflicts_with = "simulate")]
+    #[clap(short, long, env = "YES", global = true, conflicts_with = "dry_run")]
     pub yes: bool,
 
-    // Simulate submission of the proposal, but do not actually submit it.
-    #[clap(long, aliases = ["dry-run", "dryrun", "no"], global = true, conflicts_with = "yes")]
-    pub simulate: bool,
+    // Dry-run or simulate proposal submission, but do not actually submit it.
+    // Will show the ic-admin command and the proposal Payload
+    #[clap(long, aliases = ["dry-run", "dryrun", "simulate", "no"], global = true, conflicts_with = "yes")]
+    pub dry_run: bool,
 
     #[clap(long, env = "VERBOSE", global = true)]
     pub verbose: bool,

--- a/rs/cli/src/general.rs
+++ b/rs/cli/src/general.rs
@@ -68,7 +68,7 @@ pub async fn vote_on_proposals(
     nns_urls: &[Url],
     accepted_proposers: &[u64],
     accepted_topics: &[i32],
-    simulate: bool,
+    dry_run: bool,
     sleep: Duration,
 ) -> anyhow::Result<()> {
     let client: GovernanceCanisterWrapper = match &neuron.get_auth().await? {
@@ -105,7 +105,7 @@ pub async fn vote_on_proposals(
                 proposal.proposal.clone().unwrap().title.unwrap()
             );
 
-            if !simulate {
+            if !dry_run {
                 let response = client.register_vote(neuron.get_neuron_id().await?, proposal.id.unwrap().id).await?;
                 info!("{}", response);
             } else {

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -86,7 +86,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
     let srv = rx.recv().unwrap();
 
     let r = ic_admin::with_ic_admin(governance_canister_version.into(), async {
-        let simulate = cli_opts.simulate;
+        let dry_run = cli_opts.dry_run;
 
         let runner_instance = {
             let cli = dre::parsed_cli::ParsedCli::from_opts(&cli_opts)
@@ -114,7 +114,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                             max_replaceable_nodes_per_sub: *max_replaceable_nodes_per_sub,
                         },
                         cli_opts.verbose,
-                        simulate,
+                        dry_run,
                     )
                     .await
             }
@@ -147,7 +147,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
 
                 // Execute the command
                 match &subnet.subcommand {
-                    cli::subnet::Commands::Deploy { version } => runner_instance.deploy(&subnet.id.unwrap(), version, simulate).await,
+                    cli::subnet::Commands::Deploy { version } => runner_instance.deploy(&subnet.id.unwrap(), version, dry_run).await,
                     cli::subnet::Commands::Replace {
                         nodes,
                         no_heal,
@@ -184,7 +184,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                     min_nakamoto_coefficients,
                                 },
                                 cli_opts.verbose,
-                                simulate,
+                                dry_run,
                             )
                             .await
                     }
@@ -209,7 +209,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                     },
                                     motivation,
                                     cli_opts.verbose,
-                                    simulate,
+                                    dry_run,
                                 )
                                 .await
                         } else {
@@ -241,7 +241,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                     },
                                     motivation,
                                     cli_opts.verbose,
-                                    simulate,
+                                    dry_run,
                                     replica_version.clone(),
                                     other_args.to_vec(),
                                     *help_other_args,
@@ -260,7 +260,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                 Ok(())
             }
 
-            cli::Commands::Propose { args } => runner_instance.ic_admin.run_passthrough_propose(args, simulate).await,
+            cli::Commands::Propose { args } => runner_instance.ic_admin.run_passthrough_propose(args, dry_run).await,
 
             cli::Commands::UpdateUnassignedNodes { nns_subnet_id } => {
                 let runner_instance = if target_network.is_mainnet() {
@@ -281,7 +281,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                 };
                 runner_instance
                     .ic_admin
-                    .update_unassigned_nodes(&nns_subnet_id, &target_network, simulate)
+                    .update_unassigned_nodes(&nns_subnet_id, &target_network, dry_run)
                     .await
             }
 
@@ -318,7 +318,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                 summary: Some(update_version.summary.clone()),
                                 motivation: None,
                             },
-                            simulate,
+                            dry_run,
                         )
                         .await?;
                     Ok(())
@@ -332,7 +332,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                     runner_instance
                 };
                 match &nodes.subcommand {
-                    cli::hostos::Commands::Rollout { version, nodes } => runner_instance.hostos_rollout(nodes.clone(), version, simulate, None).await,
+                    cli::hostos::Commands::Rollout { version, nodes } => runner_instance.hostos_rollout(nodes.clone(), version, dry_run, None).await,
                     cli::hostos::Commands::RolloutFromNodeGroup {
                         version,
                         assignment,
@@ -342,7 +342,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                     } => {
                         let update_group = NodeGroupUpdate::new(*assignment, *owner, NumberOfNodes::from_str(nodes_in_group)?);
                         if let Some((nodes_to_update, summary)) = runner_instance.hostos_rollout_nodes(update_group, version, exclude).await? {
-                            return runner_instance.hostos_rollout(nodes_to_update, version, simulate, Some(summary)).await;
+                            return runner_instance.hostos_rollout(nodes_to_update, version, dry_run, Some(summary)).await;
                         }
                         Ok(())
                     }
@@ -370,7 +370,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                 exclude: Some(exclude.clone()),
                                 motivation: motivation.clone().unwrap_or_default(),
                             },
-                            simulate,
+                            dry_run,
                         )
                         .await
                 }
@@ -390,7 +390,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                 summary: Some(format!("Update {} API boundary node(s) to {version}", nodes.clone().len())),
                                 motivation: motivation.clone(),
                             },
-                            simulate,
+                            dry_run,
                         )
                         .await?;
                     Ok(())
@@ -408,7 +408,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                 summary: Some(format!("Add {} API boundary node(s)", nodes.clone().len())),
                                 motivation: motivation.clone(),
                             },
-                            simulate,
+                            dry_run,
                         )
                         .await?;
                     Ok(())
@@ -423,7 +423,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                                 summary: Some(format!("Remove {} API boundary node(s)", nodes.clone().len())),
                                 motivation: None,
                             },
-                            simulate,
+                            dry_run,
                         )
                         .await?;
                     Ok(())
@@ -441,7 +441,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                     target_network.get_nns_urls(),
                     accepted_neurons,
                     accepted_topics,
-                    simulate,
+                    dry_run,
                     *sleep_time,
                 )
                 .await
@@ -481,7 +481,7 @@ async fn async_main() -> Result<(), anyhow::Error> {
                             ..Default::default()
                         },
                         rules_scope,
-                        cli_opts.simulate,
+                        cli_opts.dry_run,
                     )
                     .await
             }

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -24,7 +24,7 @@ pub struct Runner {
 }
 
 impl Runner {
-    pub async fn deploy(&self, subnet: &PrincipalId, version: &str, simulate: bool) -> anyhow::Result<()> {
+    pub async fn deploy(&self, subnet: &PrincipalId, version: &str, dry_run: bool) -> anyhow::Result<()> {
         self.ic_admin
             .propose_run(
                 ic_admin::ProposeCommand::DeployGuestosToAllSubnetNodes {
@@ -36,7 +36,7 @@ impl Runner {
                     summary: format!("Update subnet {subnet} to GuestOS version {version}").into(),
                     motivation: None,
                 },
-                simulate,
+                dry_run,
             )
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
@@ -56,7 +56,7 @@ impl Runner {
         request: ic_management_types::requests::SubnetResizeRequest,
         motivation: String,
         verbose: bool,
-        simulate: bool,
+        dry_run: bool,
     ) -> anyhow::Result<()> {
         let subnet = request.subnet;
         let change = self.dashboard_backend_client.subnet_resize(request).await?;
@@ -71,7 +71,7 @@ impl Runner {
             return Ok(());
         }
         if change.added.len() == change.removed.len() {
-            self.run_membership_change(change.clone(), ops_subnet_node_replace::replace_proposal_options(&change)?, simulate)
+            self.run_membership_change(change.clone(), ops_subnet_node_replace::replace_proposal_options(&change)?, dry_run)
                 .await
         } else {
             let action = if change.added.len() < change.removed.len() {
@@ -86,7 +86,7 @@ impl Runner {
                     summary: format!("{action} subnet {subnet}").into(),
                     motivation: motivation.clone().into(),
                 },
-                simulate,
+                dry_run,
             )
             .await
         }
@@ -97,7 +97,7 @@ impl Runner {
         request: ic_management_types::requests::SubnetCreateRequest,
         motivation: String,
         verbose: bool,
-        simulate: bool,
+        dry_run: bool,
         replica_version: Option<String>,
         other_args: Vec<String>,
         help_other_args: bool,
@@ -134,7 +134,7 @@ impl Runner {
                     summary: Some("# Creating new subnet with nodes: ".into()),
                     motivation: Some(motivation.clone()),
                 },
-                simulate,
+                dry_run,
             )
             .await?;
         Ok(())
@@ -144,7 +144,7 @@ impl Runner {
         &self,
         request: ic_management_types::requests::MembershipReplaceRequest,
         verbose: bool,
-        simulate: bool,
+        dry_run: bool,
     ) -> anyhow::Result<()> {
         let change = self.dashboard_backend_client.membership_replace(request).await?;
         if verbose {
@@ -157,11 +157,11 @@ impl Runner {
         if change.added.is_empty() && change.removed.is_empty() {
             return Ok(());
         }
-        self.run_membership_change(change.clone(), ops_subnet_node_replace::replace_proposal_options(&change)?, simulate)
+        self.run_membership_change(change.clone(), ops_subnet_node_replace::replace_proposal_options(&change)?, dry_run)
             .await
     }
 
-    async fn run_membership_change(&self, change: SubnetChangeResponse, options: ProposeOptions, simulate: bool) -> anyhow::Result<()> {
+    async fn run_membership_change(&self, change: SubnetChangeResponse, options: ProposeOptions, dry_run: bool) -> anyhow::Result<()> {
         let subnet_id = change.subnet_id.ok_or_else(|| anyhow::anyhow!("subnet_id is required"))?;
         let pending_action = self.dashboard_backend_client.subnet_pending_action(subnet_id).await?;
         if let Some(proposal) = pending_action {
@@ -179,7 +179,7 @@ impl Runner {
                     node_ids_remove: change.removed.clone(),
                 },
                 options,
-                simulate,
+                dry_run,
             )
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
@@ -374,7 +374,7 @@ impl Runner {
             }
         }
     }
-    pub async fn hostos_rollout(&self, nodes: Vec<PrincipalId>, version: &str, simulate: bool, maybe_summary: Option<String>) -> anyhow::Result<()> {
+    pub async fn hostos_rollout(&self, nodes: Vec<PrincipalId>, version: &str, dry_run: bool, maybe_summary: Option<String>) -> anyhow::Result<()> {
         let title = format!("Set HostOS version: {version} on {} nodes", nodes.clone().len());
         self.ic_admin
             .propose_run(
@@ -387,7 +387,7 @@ impl Runner {
                     summary: maybe_summary.unwrap_or(title).into(),
                     motivation: None,
                 },
-                simulate,
+                dry_run,
             )
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
@@ -397,7 +397,7 @@ impl Runner {
         Ok(())
     }
 
-    pub async fn remove_nodes(&self, request: NodesRemoveRequest, simulate: bool) -> anyhow::Result<()> {
+    pub async fn remove_nodes(&self, request: NodesRemoveRequest, dry_run: bool) -> anyhow::Result<()> {
         let node_remove_response = self.dashboard_backend_client.remove_nodes(request).await?;
         let mut node_removals = node_remove_response.removals;
         node_removals.sort_by_key(|nr| nr.reason.message());
@@ -440,7 +440,7 @@ impl Runner {
                     summary: "Remove nodes from the network".to_string().into(),
                     motivation: node_remove_response.motivation.into(),
                 },
-                simulate,
+                dry_run,
             )
             .await?;
         Ok(())


### PR DESCRIPTION
- this makes it more consistent with ic-admin
- it's backwards compatible since the old arguments are still accepted
