### PR TITLE
chore(dre): Do not require --motivation if --help-other-args is provided

### DIFF
--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -229,7 +229,12 @@ async fn async_main() -> Result<(), anyhow::Error> {
                         help_other_args,
                     } => {
                         let min_nakamoto_coefficients = parse_min_nakamoto_coefficients(&mut cmd, min_nakamoto_coefficients);
-                        if let Some(motivation) = motivation.clone() {
+                        let motivation = if motivation.is_none() && *help_other_args {
+                            Some("help for options".to_string())
+                        } else {
+                            motivation.clone()
+                        };
+                        if let Some(motivation) = motivation {
                             runner_instance
                                 .subnet_create(
                                     ic_management_types::requests::SubnetCreateRequest {


### PR DESCRIPTION
The requirement of --motivation was an oversight in the earlier code, since we're only asking for help on subnet creation params.
