### PR TITLE
fix(dre): asking for update everywhere

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "891d21c460f45215d3826177f5450ce89dc2a0e8774dc85b7f7a84613185094b",
+  "checksum": "a619b6c7f65f05372f7e5dddd4e9a299c95a31a112847e34a992b0dbd1806ec3",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -11155,6 +11155,10 @@
             {
               "id": "anyhow 1.0.86",
               "target": "anyhow"
+            },
+            {
+              "id": "atty 0.2.14",
+              "target": "atty"
             },
             {
               "id": "candid 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,6 +2207,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
+ "atty",
  "candid",
  "clap 4.5.7",
  "clap-num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ assert_matches = "1.5.0"
 async-recursion = "1.1.1"
 async-timer = "0.7.4"
 async-trait = "0.1.80"
+atty = "0.2.14"
 axum-otel-metrics = "0.8.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 backon = "0.4.4"

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -15,6 +15,7 @@ actix-web = { workspace = true }
 anyhow = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
+atty = { workspace = true }
 candid = { workspace = true }
 clap = { workspace = true }
 clap-num = { workspace = true }

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -1,4 +1,5 @@
 use crate::ic_admin::IcAdminWrapper;
+use atty::Stream;
 use clap::{error::ErrorKind, CommandFactory, Parser};
 use dialoguer::Confirm;
 use dotenv::dotenv;
@@ -641,6 +642,10 @@ fn init_logger() {
 }
 
 fn check_latest_release(curr_version: &str) -> anyhow::Result<UpdateStatus> {
+    if atty::isnt(Stream::Stdin) || std::env::var("DRE_REFUSE_UPDATE").is_ok() {
+        return Ok(UpdateStatus::RefusedUpdate);
+    }
+
     // ^                --> start of line
     // v?               --> optional 'v' char
     // (\d+\.\d+\.\d+)  --> string in format '1.22.33'


### PR DESCRIPTION
With this fix we will be able to:
1. Automatically reject upgrades if stdin is not a tty (useful if running in docker container)
  To test this you can run:
  ```bash
  echo "test" | dre registry
  ```
2. Set an environment variable to skip the check (useful if running in some scripts that are still run from terminal)
  To test this you can run:
  ```bash
  DRE_REFUSE_UPDATE=1 dre registry
  ```