### PR TITLE
refactor(dre): implementing background checks for upgrading

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a619b6c7f65f05372f7e5dddd4e9a299c95a31a112847e34a992b0dbd1806ec3",
+  "checksum": "891d21c460f45215d3826177f5450ce89dc2a0e8774dc85b7f7a84613185094b",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -11155,10 +11155,6 @@
             {
               "id": "anyhow 1.0.86",
               "target": "anyhow"
-            },
-            {
-              "id": "atty 0.2.14",
-              "target": "atty"
             },
             {
               "id": "candid 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,7 +2207,6 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
- "atty",
  "candid",
  "clap 4.5.7",
  "clap-num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ assert_matches = "1.5.0"
 async-recursion = "1.1.1"
 async-timer = "0.7.4"
 async-trait = "0.1.80"
-atty = "0.2.14"
 axum-otel-metrics = "0.8.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 backon = "0.4.4"

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -15,7 +15,6 @@ actix-web = { workspace = true }
 anyhow = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
-atty = { workspace = true }
 candid = { workspace = true }
 clap = { workspace = true }
 clap-num = { workspace = true }

--- a/rs/cli/src/cli.rs
+++ b/rs/cli/src/cli.rs
@@ -178,6 +178,9 @@ pub enum Commands {
 
     /// Proposal Listing
     Proposals(proposals::Cmd),
+
+    /// Self upgrade
+    Upgrade,
 }
 
 impl Default for Commands {

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut cli_opts = cli::Opts::parse();
 
     if let cli::Commands::Upgrade = &cli_opts.subcommand {
-        let response = tokio::task::spawn_blocking(move || check_latest_release(&version, true)).await??;
+        let response = tokio::task::spawn_blocking(move || check_latest_release(version, true)).await??;
         match response {
             UpdateStatus::NoUpdate => info!("Running the latest version"),
             UpdateStatus::NewVersion(_) => unreachable!("Shouldn't happen"),
@@ -45,7 +45,7 @@ async fn main() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    let handle = tokio::task::spawn_blocking(move || check_latest_release(&version, false));
+    let handle = tokio::task::spawn_blocking(move || check_latest_release(version, false));
 
     let target_network = ic_management_types::Network::new(cli_opts.network.clone(), &cli_opts.nns_urls)
         .await


### PR DESCRIPTION
As it says, this PR moves checking for new releases to a background thread, meaning it doesn't halt the execution of the commands. 
Example of running any command when there is a new release available:
```bash
./target/debug/dre registry > /dev/null                                                        
 INFO  dre > Running version 0.4.0-2faf0cb-dirty
 INFO  dre::ic_admin > Using ic-admin: /home/nikola/bin/ic-admin.revisions/b39f782ae9e976f6f25c8f1d75b977bd22c81507/ic-admin
 INFO  ic_management_backend::registry > Using local registry path for network mainnet: /home/nikola/.cache/ic-registry-cache/mainnet/local_registry
 INFO  ic_management_backend::git_ic_repo > IC git repo path: /home/nikola/.cache/git/ic, lock file path: /home/nikola/.cache/git/ic.lock
 INFO  dre                                > There is a new version '0.4.1' available. Run 'dre upgrade' to upgrade
```
Example of running proposed `dre upgrade`:
```bash
./target/debug/dre upgrade                                                             
 INFO  dre > Running version 0.4.0-2faf0cb-dirty
 INFO  dre > Binary not up to date. Updating to 0.4.1
[00:00:00] [========================================] 1.45 KiB/1.45 KiB (0s) Done                                                                                                    
INFO  dre > Asset downloaded successfully
[00:00:04] [========================================] 49.87 MiB/49.87 MiB (0s) Done                                                                                                  
INFO  dre > Upgraded: 0.4.0-2faf0cb-dirty -> 0.4.1
```

**NOTICE**:
Since this is a now a subcommand, it is assumed that when you run `dre upgrade` you _want_ to upgrade, thus the prompting for confirmation has been removed.