### PR TITLE
refactor: renaming bazel targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
           - --match=.*
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.17.7
+    rev: v3.2.5
     hooks:
       - id: pylint
         name: pylint

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "982c13a29a128a09b521a6a2a453103ab8aea1f631648c92e4ca6072ed60a065",
+  "checksum": "d5d33d6454b8f860b5027bd8ef2ec6082f348be768b504ee6f55c78dd00704bc",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -28893,35 +28893,29 @@
         ],
         "crate_features": {
           "common": [
+            "elf",
+            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
             ],
             "i686-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
@@ -28937,8 +28931,6 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"

--- a/k8s/oci_images.bzl
+++ b/k8s/oci_images.bzl
@@ -14,7 +14,7 @@ def python_oci_image_rules(name, src, base_image = "@distroless_python3"):
         base_image: base image for building py binaries
     """
     binary = native.package_relative_label(src)
-    tar_rule_name = "{}_layer".format(binary.name)
+    tar_rule_name = "tar"
     pkg_tar(
         name = tar_rule_name,
         srcs = [binary],
@@ -27,7 +27,7 @@ def python_oci_image_rules(name, src, base_image = "@distroless_python3"):
         }
     )
 
-    image_rule_name = "{}-image".format(binary.name)
+    image_rule_name = "image"
     oci_image(
         name = image_rule_name,
         # Consider using even more minimalistic docker image since we're using static compile
@@ -39,7 +39,7 @@ def python_oci_image_rules(name, src, base_image = "@distroless_python3"):
         }
     )
 
-    tarball_name = "{}-tarball".format(binary.name)
+    tarball_name = "tarball"
     oci_tarball(
         name = tarball_name,
         image = image_rule_name,

--- a/rs/oci_images.bzl
+++ b/rs/oci_images.bzl
@@ -15,13 +15,13 @@ def rust_binary_oci_image_rules(name, src, base_image = "@distroless_cc_debian12
         other_layers: optional of other layers to be added, e.g. deb packages
     """
     binary = native.package_relative_label(src)
-    tar_rule_name = "{}_layer".format(binary.name)
+    tar_rule_name = "tar"
     pkg_tar(
         name = tar_rule_name,
         srcs = [binary],
     )
 
-    image_rule_name = "{}-image".format(binary.name)
+    image_rule_name = "image"
     oci_image(
         name = image_rule_name,
         # Consider using even more minimalistic docker image since we're using static compile
@@ -30,7 +30,7 @@ def rust_binary_oci_image_rules(name, src, base_image = "@distroless_cc_debian12
         tars = [tar_rule_name] + other_layers,
     )
 
-    tarball_name = "{}-tarball".format(binary.name)
+    tarball_name = "tarball"
     oci_tarball(
         name = tarball_name,
         image = image_rule_name,


### PR DESCRIPTION
Convenience refactor for easier to use targets.
Previously to import a docker image into local registry we would have to run something like:
```
bazel run //rs/ic-observability/multiservice-discovery:multiservice-discovery-tarball
```
Now we can just run:
```
bazel run //rs/ic-observability/multiservice-discovery:tarball
```
And the target names are the same across all binaries.

Contains additional upgrade for pylint in pre-commit so that it works in envs with python3.12: 
Linked issue: https://github.com/pre-commit/pre-commit/issues/3041