### PR TITLE
feat(dre): Show the date+time when voting, and do not stomp on previous logs

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "373e54054840c62d3438f63f1494707a66f3be25365a3abb2d53c837a692be7b",
+  "checksum": "eb89e30997310654d2570b9d1f5286d416c42b0f77df089644766f478c3fa6d8",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -11163,6 +11163,10 @@
             {
               "id": "candid 0.10.9",
               "target": "candid"
+            },
+            {
+              "id": "chrono 0.4.38",
+              "target": "chrono"
             },
             {
               "id": "clap 4.5.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,6 +2209,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "candid",
+ "chrono",
  "clap 4.5.7",
  "clap-num",
  "clap_complete",

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
 candid = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 clap-num = { workspace = true }
 colored = { workspace = true }

--- a/rs/cli/src/general.rs
+++ b/rs/cli/src/general.rs
@@ -102,7 +102,7 @@ pub async fn vote_on_proposals(
             let datetime = Local::now();
 
             info!(
-                "{} Voting on proposal {} (topic {:?}, proposer {}) -> {}\n",
+                "{} Voting on proposal {} (topic {:?}, proposer {}) -> {}",
                 datetime,
                 proposal.id.unwrap().id,
                 proposal.topic(),

--- a/rs/cli/src/general.rs
+++ b/rs/cli/src/general.rs
@@ -50,6 +50,7 @@ use std::{
 };
 use strum::IntoEnumIterator;
 
+use chrono::Local;
 use ic_canisters::{
     governance::GovernanceCanisterWrapper, management::WalletCanisterWrapper, registry::RegistryCanisterWrapper, CanisterClient,
     IcAgentCanisterClient,
@@ -82,6 +83,7 @@ pub async fn vote_on_proposals(
     // in-memory set of proposals that we already voted on.
     let mut voted_proposals = HashSet::new();
 
+    info!("Starting the voting loop...");
     loop {
         let proposals = client.get_pending_proposals().await?;
         let proposals: Vec<&ProposalInfo> = proposals
@@ -97,8 +99,11 @@ pub async fn vote_on_proposals(
         print!("\x1B[1A\x1B[K");
         std::io::stdout().flush().unwrap();
         for proposal in proposals_to_vote.into_iter() {
+            let datetime = Local::now();
+
             info!(
-                "Voting on proposal {} (topic {:?}, proposer {}) -> {}",
+                "{} Voting on proposal {} (topic {:?}, proposer {}) -> {}\n",
+                datetime,
                 proposal.id.unwrap().id,
                 proposal.topic(),
                 proposal.proposer.unwrap_or_default().id,


### PR DESCRIPTION
I noticed that the first "vote" log line overwrites whatever the last log line. Fixed here.
Also, show the date & time of the voting in the logs, for easier auditing.