### PR TITLE
fix(dashboard): Adjust the node label for zh5-dll25

### DIFF
--- a/node-labels/mainnet.yaml
+++ b/node-labels/mainnet.yaml
@@ -2874,7 +2874,7 @@ data:
     2a01:2a8:a13d:1:6801:daff:feae:f14b:
       dc: zh5
       label: dll11
-    2a01:2a8:a13d:1:6801:e5ff:fe24:d363:
+    2a01:2a8:a13d:1:6801:23ff:feb4:9e0:
       dc: zh5
       label: dll25
     2a01:2a8:a13d:1:6801:edff:fedc:cbed:


### PR DESCRIPTION
The ipv6 address changed after changing the motherboard, and it was provided by the node provider.