### PR TITLE
chore(ci): removing dre completions from releases

### DIFF
--- a/.github/workflows/prepare-release/action.yaml
+++ b/.github/workflows/prepare-release/action.yaml
@@ -3,7 +3,7 @@ description: Prepare a new GitHub release
 
 inputs:
   github_token:
-    description: 'A GitHub token with permissions to create releases'
+    description: "A GitHub token with permissions to create releases"
     required: true
 
 runs:
@@ -16,7 +16,6 @@ runs:
         # query the location of the bazel "dre" binary and copy it to the "release" directory
         mkdir -p release
         cp --dereference bazel-out/k8-opt/bin/rs/cli/dre release/dre
-        tar -cf release/completions.tar -C bazel-out/k8-opt/bin/rs/cli/build_script.out_dir completions
     - name: "🆕 📢 Prepare release"
       # v0.1.15
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844


### PR DESCRIPTION
Migrated to a subcommand that can be used in `~/.bashrc`/`~/.zshrc`
```bash
. $(dre completions -s <bash,zsh,...>)
```