### PR TITLE
feat(dre): allowing self update for macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     "rs/np-notifications",
     "rs/rollout-controller",
     "rs/slack-notifications",
-    "rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics"
+    "rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics",
 ]
 
 resolver = "2"
@@ -194,7 +194,7 @@ warp = "0.3"
 wiremock = "0.6.0"
 
 # dre-canisters dependencies
-ic-cdk-timers = "0.9" # Feel free to remove this dependency if you don't need timers
+ic-cdk-timers = "0.9"                                                                                      # Feel free to remove this dependency if you don't need timers
 ic-cdk-macros = "0.15.0"
 ic-stable-structures = "0.6.5"
 ciborium = "0.2.1"

--- a/rs/cli/src/commands/upgrade.rs
+++ b/rs/cli/src/commands/upgrade.rs
@@ -83,14 +83,21 @@ impl Upgrade {
             return Ok(UpdateStatus::NewVersion(release.version.clone()));
         }
 
-        // Complete list can be found: https://doc.rust-lang.org/std/env/consts/constant.OS.html
-        if std::env::consts::OS != "linux" {
-            return Err(anyhow::anyhow!("Only linux is supported for automatic updates"));
-        }
+        let triple = match std::env::consts::OS {
+            "linux" => "x86_64-unknown-linux",
+            "macos" => "x86_64-apple-darwin",
+            s => {
+                return Err(anyhow::anyhow!(
+                    "{} is not currently not supported for automatic upgrades. Try building the code from source",
+                    s
+                ))
+            }
+        };
 
         info!("Binary not up to date. Updating to {}", release.version);
+        info!("Release: {:?}", release);
 
-        let asset = match release.asset_for("dre", None) {
+        let asset = match release.asset_for(&format!("dre-{}", triple), None) {
             Some(asset) => asset,
             None => return Err(anyhow::anyhow!("No assets found for release")),
         };


### PR DESCRIPTION
Goes along with: #623 

When #623 is merged new release will break the upgrading code. After downloading the newest (or building from source) the tool will handle all future architectures and os versions we decide to support.