### PR TITLE
feat(IDX): add trigger for qualifier workflow

### DIFF
--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -7,6 +7,13 @@ on:
         description: "The version that should be qualified"
         type: string
         default: ""
+  # triggered from Release Testing workflow in dfinity/ic
+  workflow_call:
+    inputs:
+      version:
+        description: "The version that should be qualified"
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
DRE requested that the qualifier workflow automatically gets kicked off when the `Release Testing` [workflow](https://github.com/dfinity/ic/blob/master/.github/workflows/release-testing.yml) succeeds. This change allows the qualifier workflow to be triggered by an external workflow.

This still needs to be tested and I may need to make more changes later.