### PR TITLE
refactor(dre): embedding default version excluded subnets

### DIFF
--- a/facts-db/BUILD.bazel
+++ b/facts-db/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "non_public_subnets",
+    srcs = [ "non_public_subnets.csv" ],
+    visibility = [ "//visibility:public" ],
+)

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -17,7 +17,11 @@ cargo_build_script(
     srcs = ["src/build.rs"],
     deps = all_crate_deps(
         build = True
-    )
+    ),
+    build_script_env = {
+        "NON_PUBLIC_SUBNETS": "$(execpath //facts-db:non_public_subnets)"
+    },
+    data = [ "//facts-db:non_public_subnets" ]
 )
 
 rust_binary(
@@ -44,7 +48,7 @@ rust_library(
     ),
     deps = all_crate_deps(
         normal = True,
-    ) + DEPS,
+    ) + DEPS + [ ":build_script" ],
 )
 
 rust_test(

--- a/rs/cli/src/build.rs
+++ b/rs/cli/src/build.rs
@@ -16,4 +16,11 @@ fn main() {
             option_env!("CARGO_PKG_VERSION").map(|v| format!("{}-{}", v, git_rev)).unwrap_or_default()
         );
     }
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let path_to_non_public_subnets =
+        std::fs::canonicalize(option_env!("NON_PUBLIC_SUBNETS").unwrap_or("../../facts-db/non_public_subnets.csv")).unwrap();
+
+    std::fs::copy(&path_to_non_public_subnets, format!("{}/non_public_subnets.csv", out_dir))
+        .unwrap_or_else(|e| panic!("Error with file {}: {:?}", path_to_non_public_subnets.display(), e));
 }

--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -67,7 +67,7 @@ impl ExecutableCommand for UpdateAuthorizedSubnets {
 
             let subnet_principal_string = subnet.principal.to_string();
             if let Some((_, description)) = csv_contents.iter().find(|(short_id, _)| subnet_principal_string.starts_with(short_id)) {
-                excluded_subnets.insert(subnet.principal, description.to_owned());
+                excluded_subnets.insert(subnet.principal, format!("[Explicitly removed] {}", description));
                 continue;
             }
 
@@ -111,7 +111,10 @@ impl UpdateAuthorizedSubnets {
     fn parse_csv(&self) -> anyhow::Result<Vec<(String, String)>> {
         let contents = match &self.path {
             Some(p) => std::fs::read_to_string(p)?,
-            None => DEFAULT_AUTHORIZED_SUBNETS_CSV.to_string(),
+            None => {
+                info!("Using embedded version of authorized subnets csv that is added during build time");
+                DEFAULT_AUTHORIZED_SUBNETS_CSV.to_string()
+            }
         };
         let mut ret = vec![];
         for line in contents.lines() {

--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -14,7 +14,7 @@ use super::ExecutableCommand;
 const DEFAULT_CANISTER_LIMIT: u64 = 60_000;
 const DEFAULT_STATE_SIZE_BYTES_LIMIT: u64 = 322_122_547_200; // 300GB
 
-const DEFAULT_AUTHORIZED_SUBNETS_CSV: &str = include_str!("../../../../facts-db/non_public_subnets.csv");
+const DEFAULT_AUTHORIZED_SUBNETS_CSV: &str = include_str!(concat!(env!("OUT_DIR"), "/non_public_subnets.csv"));
 
 #[derive(Args, Debug)]
 pub struct UpdateAuthorizedSubnets {


### PR DESCRIPTION
Since that file will rarely (if ever) be changed, we can have a little better user experience 