### PR TITLE
chore: Update dependencies

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "56a1654ffcad2aab45a1a97a7e1bd2e8faf5986e1d11b824bfcd4039e0db3c31",
+  "checksum": "6ddaf5c2a19c29f797d39b0fff169b3760429720a88eb8725e55ab91e6a6e6d3",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -265,7 +265,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -326,7 +326,7 @@
               "target": "regex_lite"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -697,11 +697,11 @@
               "target": "regex_lite"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -789,7 +789,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -1836,7 +1836,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             },
             {
@@ -1887,7 +1887,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -1926,11 +1926,11 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -2119,7 +2119,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -2218,7 +2218,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -2265,7 +2265,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -2412,11 +2412,11 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -2559,7 +2559,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -2721,11 +2721,11 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -3292,7 +3292,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             }
           ],
@@ -3544,7 +3544,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -4026,7 +4026,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -4233,7 +4233,7 @@
               "target": "rustc_version"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -4291,7 +4291,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -4385,7 +4385,7 @@
               "target": "quote"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -4517,7 +4517,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -4893,7 +4893,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             },
             {
@@ -5067,7 +5067,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -5157,7 +5157,7 @@
               "target": "pretty"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -5236,7 +5236,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -5284,11 +5284,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -5335,7 +5335,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -5392,11 +5392,11 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -5407,13 +5407,13 @@
       },
       "license": "MIT"
     },
-    "cc 1.1.8": {
+    "cc 1.1.12": {
       "name": "cc",
-      "version": "1.1.8",
+      "version": "1.1.12",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cc/1.1.8/download",
-          "sha256": "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+          "url": "https://static.crates.io/crates/cc/1.1.12/download",
+          "sha256": "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
         }
       },
       "targets": [
@@ -5443,6 +5443,10 @@
             {
               "id": "jobserver 0.1.32",
               "target": "jobserver"
+            },
+            {
+              "id": "shlex 1.3.0",
+              "target": "shlex"
             }
           ],
           "selects": {
@@ -5455,7 +5459,7 @@
           }
         },
         "edition": "2018",
-        "version": "1.1.8"
+        "version": "1.1.12"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5570,7 +5574,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -5653,7 +5657,7 @@
               "target": "ciborium_ll"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -6052,13 +6056,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_complete 4.5.14": {
+    "clap_complete 4.5.16": {
       "name": "clap_complete",
-      "version": "4.5.14",
+      "version": "4.5.16",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_complete/4.5.14/download",
-          "sha256": "1d11bff0290e9a266fc9b4ce6fa96c2bf2ca3f9724c41c10202ac1daf7a087f8"
+          "url": "https://static.crates.io/crates/clap_complete/4.5.16/download",
+          "sha256": "9c677cd0126f3026d8b093fa29eae5d812fde5c05bc66dbb29d0374eea95113a"
         }
       },
       "targets": [
@@ -6093,7 +6097,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.5.14"
+        "version": "4.5.16"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6204,7 +6208,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -6472,7 +6476,7 @@
               "target": "pretty_assertions"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -6690,11 +6694,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -7972,7 +7976,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -8186,7 +8190,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -8488,7 +8492,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -8769,7 +8773,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -8863,7 +8867,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -9096,11 +9100,11 @@
               "target": "rand_seeder"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -9338,7 +9342,7 @@
               "target": "powerfmt"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -9432,7 +9436,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -9535,7 +9539,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -9584,7 +9588,7 @@
               "target": "derive_builder_core"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -9666,7 +9670,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -9724,7 +9728,7 @@
               "target": "on_wire"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -9824,7 +9828,7 @@
               "target": "dfn_core"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -10454,7 +10458,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -10641,7 +10645,7 @@
               "target": "clap_num"
             },
             {
-              "id": "clap_complete 4.5.14",
+              "id": "clap_complete 4.5.16",
               "target": "clap_complete"
             },
             {
@@ -10773,7 +10777,7 @@
               "target": "itertools"
             },
             {
-              "id": "keyring 3.0.5",
+              "id": "keyring 3.1.0",
               "target": "keyring"
             },
             {
@@ -10805,11 +10809,11 @@
               "target": "self_update"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -11120,7 +11124,7 @@
               "target": "rand_core"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -11537,7 +11541,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -11639,7 +11643,7 @@
               "target": "humantime"
             },
             {
-              "id": "is-terminal 0.4.12",
+              "id": "is-terminal 0.4.13",
               "target": "is_terminal"
             },
             {
@@ -11792,7 +11796,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -11839,7 +11843,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -13077,7 +13081,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -13699,7 +13703,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.3.0",
+              "id": "indexmap 2.4.0",
               "target": "indexmap"
             },
             {
@@ -13778,7 +13782,7 @@
               "target": "http"
             },
             {
-              "id": "indexmap 2.3.0",
+              "id": "indexmap 2.4.0",
               "target": "indexmap"
             },
             {
@@ -14101,11 +14105,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -14355,6 +14359,36 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "hermit-abi 0.4.0": {
+      "name": "hermit-abi",
+      "version": "0.4.0",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/hermit-abi/0.4.0/download",
+          "sha256": "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hermit_abi",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "hermit_abi",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.4.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "hex 0.4.3": {
       "name": "hex",
       "version": "0.4.3",
@@ -14392,7 +14426,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -14970,11 +15004,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -15092,7 +15126,7 @@
               "target": "humantime"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -15973,7 +16007,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             }
           ],
@@ -16267,7 +16301,7 @@
               "target": "sec1"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -16467,7 +16501,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -16510,7 +16544,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -16572,7 +16606,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -16678,7 +16712,7 @@
               "target": "rustls"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -16798,7 +16832,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -16966,7 +17000,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17028,7 +17062,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17122,7 +17156,7 @@
               "target": "phantom_newtype"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17248,7 +17282,7 @@
               "target": "ic0"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17311,7 +17345,7 @@
               "target": "ic0"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17375,7 +17409,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17437,7 +17471,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17445,7 +17479,7 @@
               "target": "serde_tokenstream"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -17496,7 +17530,7 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17555,7 +17589,7 @@
               "target": "ic0"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17617,7 +17651,7 @@
               "target": "ic0"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17687,7 +17721,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17746,7 +17780,7 @@
               "target": "hex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17844,7 +17878,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -17918,7 +17952,7 @@
               "target": "json5"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -18327,7 +18361,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -18546,7 +18580,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -18608,7 +18642,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -18748,7 +18782,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -18871,7 +18905,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -18966,7 +19000,7 @@
               "target": "phantom_newtype"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -19073,7 +19107,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -19115,7 +19149,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -19219,7 +19253,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -19277,7 +19311,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -19543,7 +19577,7 @@
               "target": "ic_utils"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -19720,7 +19754,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -19852,11 +19886,11 @@
               "target": "scopeguard"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -20000,7 +20034,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -20098,7 +20132,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -20192,7 +20226,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -20263,7 +20297,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -20395,7 +20429,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -20458,7 +20492,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -20512,7 +20546,7 @@
               "target": "hex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -20570,7 +20604,7 @@
               "target": "ic_utils"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -20772,11 +20806,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -20880,7 +20914,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -20979,11 +21013,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -21210,7 +21244,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -21407,11 +21441,11 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -21682,7 +21716,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -21794,7 +21828,7 @@
               "target": "ic_nervous_system_runtime"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -21952,11 +21986,11 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -22071,7 +22105,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -22360,7 +22394,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -22368,7 +22402,7 @@
               "target": "serde_bytes"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -22517,7 +22551,7 @@
               "target": "ic_nns_constants"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -22584,11 +22618,11 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -22886,7 +22920,7 @@
               "target": "ic_types"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -23141,7 +23175,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -23249,7 +23283,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -23303,7 +23337,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -23353,7 +23387,7 @@
               "target": "ic_protobuf"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -23424,7 +23458,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -23590,7 +23624,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -23834,7 +23868,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -24199,7 +24233,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -24326,7 +24360,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -24516,7 +24550,7 @@
               "target": "rust_decimal"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -24613,7 +24647,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -24767,7 +24801,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -24775,7 +24809,7 @@
               "target": "serde_bytes"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -24969,7 +25003,7 @@
               "target": "leb128"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -25104,7 +25138,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -25116,7 +25150,7 @@
               "target": "serde_cbor"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -25207,7 +25241,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -25294,7 +25328,7 @@
               "target": "scoped_threadpool"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -25468,11 +25502,11 @@
               "target": "rustc_demangle"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -25538,7 +25572,7 @@
               "target": "ic_utils"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -25581,7 +25615,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -25877,7 +25911,7 @@
               "target": "data_encoding"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -25999,7 +26033,7 @@
               "target": "prost"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -26074,7 +26108,7 @@
               "target": "icrc_ledger_types"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -26153,7 +26187,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -26396,13 +26430,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "indexmap 2.3.0": {
+    "indexmap 2.4.0": {
       "name": "indexmap",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/indexmap/2.3.0/download",
-          "sha256": "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+          "url": "https://static.crates.io/crates/indexmap/2.4.0/download",
+          "sha256": "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
         }
       },
       "targets": [
@@ -26442,7 +26476,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.3.0"
+        "version": "2.4.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -26664,13 +26698,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "is-terminal 0.4.12": {
+    "is-terminal 0.4.13": {
       "name": "is-terminal",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/is-terminal/0.4.12/download",
-          "sha256": "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+          "url": "https://static.crates.io/crates/is-terminal/0.4.13/download",
+          "sha256": "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
         }
       },
       "targets": [
@@ -26700,7 +26734,7 @@
             ],
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "hermit-abi 0.3.9",
+                "id": "hermit-abi 0.4.0",
                 "target": "hermit_abi"
               }
             ],
@@ -26713,7 +26747,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.4.12"
+        "version": "0.4.13"
       },
       "license": "MIT"
     },
@@ -26781,7 +26815,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -27032,7 +27066,7 @@
               "target": "pest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -27097,11 +27131,11 @@
               "target": "pem"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -27254,13 +27288,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "keyring 3.0.5": {
+    "keyring 3.1.0": {
       "name": "keyring",
-      "version": "3.0.5",
+      "version": "3.1.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/keyring/3.0.5/download",
-          "sha256": "0c163ef0b9da5ccf44ae4d7c9d24fb1a8750aa1969d484865fc1eedc44b26c09"
+          "url": "https://static.crates.io/crates/keyring/3.1.0/download",
+          "sha256": "0e3ffeb4169230bc4f956b7276b688fc203824cc2ace8dc41ceecbd1746011a6"
         }
       },
       "targets": [
@@ -27280,7 +27314,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "3.0.5"
+        "version": "3.1.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -27712,7 +27746,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             }
           ],
@@ -27897,35 +27931,29 @@
         ],
         "crate_features": {
           "common": [
+            "elf",
+            "errno",
             "general",
             "ioctl",
             "no_std"
           ],
           "selects": {
             "aarch64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
             ],
             "arm-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
             ],
             "i686-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
@@ -27941,8 +27969,6 @@
               "system"
             ],
             "x86_64-unknown-linux-gnu": [
-              "elf",
-              "errno",
               "prctl",
               "std",
               "system"
@@ -28203,11 +28229,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -28261,11 +28287,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -28317,11 +28343,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -28458,7 +28484,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             },
             {
@@ -29032,7 +29058,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -29146,11 +29172,11 @@
               "target": "retry"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -29317,11 +29343,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -29702,11 +29728,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -29933,7 +29959,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -30024,7 +30050,7 @@
               "target": "rand"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -30400,7 +30426,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -30539,11 +30565,11 @@
               "target": "secrecy"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -30915,7 +30941,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -31025,7 +31051,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             },
             {
@@ -32247,7 +32273,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -32339,7 +32365,7 @@
               "target": "fixedbitset"
             },
             {
-              "id": "indexmap 2.3.0",
+              "id": "indexmap 2.4.0",
               "target": "indexmap"
             }
           ],
@@ -32385,7 +32411,7 @@
               "target": "candid"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -32475,7 +32501,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -33117,7 +33143,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -33898,11 +33924,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -33976,7 +34002,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -34140,7 +34166,7 @@
               "target": "regex"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             },
             {
@@ -34199,7 +34225,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -34355,7 +34381,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             }
           ],
@@ -34495,11 +34521,11 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -35712,7 +35738,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -35905,11 +35931,11 @@
               "target": "http"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -36246,7 +36272,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             }
           ],
@@ -36472,7 +36498,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -36624,7 +36650,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             },
             {
@@ -36710,7 +36736,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -38465,7 +38491,7 @@
               "target": "semver"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -38542,7 +38568,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -38558,13 +38584,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.206": {
+    "serde 1.0.208": {
       "name": "serde",
-      "version": "1.0.206",
+      "version": "1.0.208",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde/1.0.206/download",
-          "sha256": "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
+          "url": "https://static.crates.io/crates/serde/1.0.208/download",
+          "sha256": "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
         }
       },
       "targets": [
@@ -38605,7 +38631,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "build_script_build"
             }
           ],
@@ -38615,13 +38641,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.206",
+              "id": "serde_derive 1.0.208",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.206"
+        "version": "1.0.208"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -38665,7 +38691,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -38715,7 +38741,7 @@
               "target": "half"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -38726,13 +38752,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "serde_derive 1.0.206": {
+    "serde_derive 1.0.208": {
       "name": "serde_derive",
-      "version": "1.0.206",
+      "version": "1.0.208",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_derive/1.0.206/download",
-          "sha256": "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
+          "url": "https://static.crates.io/crates/serde_derive/1.0.208/download",
+          "sha256": "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
         }
       },
       "targets": [
@@ -38768,24 +38794,24 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.206"
+        "version": "1.0.208"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.124": {
+    "serde_json 1.0.125": {
       "name": "serde_json",
-      "version": "1.0.124",
+      "version": "1.0.125",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_json/1.0.124/download",
-          "sha256": "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+          "url": "https://static.crates.io/crates/serde_json/1.0.125/download",
+          "sha256": "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
         }
       },
       "targets": [
@@ -38837,18 +38863,18 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.124"
+        "version": "1.0.125"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -38889,7 +38915,7 @@
               "target": "itoa"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -38936,7 +38962,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -38979,7 +39005,7 @@
               "target": "proc_macro2"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -39030,11 +39056,11 @@
               "target": "quote"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -39085,7 +39111,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -39132,7 +39158,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -39231,7 +39257,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.3.0",
+              "id": "indexmap 2.4.0",
               "target": "indexmap"
             },
             {
@@ -39243,7 +39269,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -39361,11 +39387,11 @@
               "target": "registry_canister"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -40055,11 +40081,11 @@
               "target": "retry"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -40263,11 +40289,11 @@
               "target": "erased_serde"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -40361,7 +40387,7 @@
         "deps": {
           "common": [
             {
-              "id": "is-terminal 0.4.12",
+              "id": "is-terminal 0.4.13",
               "target": "is_terminal"
             },
             {
@@ -40589,7 +40615,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -40641,7 +40667,7 @@
               "target": "reqwest"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -41016,7 +41042,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             }
           ],
@@ -41281,7 +41307,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -41451,13 +41477,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "syn 2.0.72": {
+    "syn 2.0.74": {
       "name": "syn",
-      "version": "2.0.72",
+      "version": "2.0.74",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/syn/2.0.72/download",
-          "sha256": "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+          "url": "https://static.crates.io/crates/syn/2.0.74/download",
+          "sha256": "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
         }
       },
       "targets": [
@@ -41510,7 +41536,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.72"
+        "version": "2.0.74"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -41554,7 +41580,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -41668,7 +41694,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -42292,7 +42318,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -42431,7 +42457,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -42571,7 +42597,7 @@
               "target": "powerfmt"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
@@ -42956,7 +42982,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -43404,7 +43430,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.3.0",
+              "id": "indexmap 2.4.0",
               "target": "indexmap"
             },
             {
@@ -43602,7 +43628,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -43994,7 +44020,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -44249,7 +44275,7 @@
               "target": "leb128"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -44376,11 +44402,11 @@
               "target": "ic_stable_structures"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             }
           ],
@@ -45029,7 +45055,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -45208,7 +45234,7 @@
               "target": "getrandom"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             }
           ],
@@ -45746,7 +45772,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             },
             {
@@ -45906,7 +45932,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             },
             {
@@ -47951,11 +47977,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.206",
+              "id": "serde 1.0.208",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.124",
+              "id": "serde_json 1.0.125",
               "target": "serde_json"
             },
             {
@@ -48351,7 +48377,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -48445,7 +48471,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.72",
+              "id": "syn 2.0.74",
               "target": "syn"
             }
           ],
@@ -48547,7 +48573,7 @@
               "target": "hmac"
             },
             {
-              "id": "indexmap 2.3.0",
+              "id": "indexmap 2.4.0",
               "target": "indexmap"
             },
             {
@@ -48914,7 +48940,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.1.8",
+              "id": "cc 1.1.12",
               "target": "cc"
             },
             {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -372,7 +372,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
  "synstructure",
 ]
 
@@ -384,7 +384,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -432,7 +432,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
  "syn_derive",
 ]
 
@@ -1033,7 +1033,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1076,12 +1076,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.8"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1199,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.14"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11bff0290e9a266fc9b4ce6fa96c2bf2ca3f9724c41c10202ac1daf7a087f8"
+checksum = "9c677cd0126f3026d8b093fa29eae5d812fde5c05bc66dbb29d0374eea95113a"
 dependencies = [
  "clap 4.5.15",
 ]
@@ -1228,7 +1229,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1607,7 +1608,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1724,7 +1725,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1746,7 +1747,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1861,7 +1862,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1882,7 +1883,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1892,7 +1893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1905,7 +1906,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2067,7 +2068,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2279,7 +2280,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2579,7 +2580,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2693,7 +2694,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2712,7 +2713,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2826,6 +2827,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -3489,7 +3496,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.1",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -5333,9 +5340,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -5390,11 +5397,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -5508,9 +5515,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "3.0.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c163ef0b9da5ccf44ae4d7c9d24fb1a8750aa1969d484865fc1eedc44b26c09"
+checksum = "0e3ffeb4169230bc4f956b7276b688fc203824cc2ace8dc41ceecbd1746011a6"
 
 [[package]]
 name = "language-tags"
@@ -5838,7 +5845,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6216,7 +6223,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6471,7 +6478,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6492,7 +6499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
 ]
 
 [[package]]
@@ -6522,7 +6529,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6649,7 +6656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6842,7 +6849,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.74",
  "tempfile",
 ]
 
@@ -6856,7 +6863,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -7350,7 +7357,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.72",
+ "syn 2.0.74",
  "unicode-ident",
 ]
 
@@ -7682,9 +7689,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.206"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -7710,20 +7717,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.206"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -7749,7 +7756,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -7772,7 +7779,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -7815,7 +7822,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "itoa",
  "ryu",
  "serde",
@@ -8083,7 +8090,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8227,7 +8234,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8255,9 +8262,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8273,7 +8280,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8296,7 +8303,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8421,7 +8428,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8447,7 +8454,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8548,7 +8555,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8641,7 +8648,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow",
 ]
@@ -8683,7 +8690,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -8759,7 +8766,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -9100,7 +9107,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
  "wasm-bindgen-shared",
 ]
 
@@ -9134,7 +9141,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9529,7 +9536,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -9549,7 +9556,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -9568,7 +9575,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap 2.3.0",
+ "indexmap 2.4.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ axum-otel-metrics = "0.8.1"
 axum = "0.7.5"
 backoff = { version = "0.4.0", features = ["tokio"] }
 backon = "0.4.4"
-candid = "0.10.9"
+candid = "0.10.10"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap-num = "1.1"
 clap = { version = "4.5", features = [
@@ -88,10 +88,10 @@ easy-parallel = "3.3.1"
 edit = "0.1.5"
 either = "1.13.0"
 enum-map = "1.1.1"
-env_logger = "0.11.3"
+env_logger = "0.11.5"
 erased-serde = "0.4.5"
 exitcode = "1.1.2"
-flate2 = "1.0.30"
+flate2 = "1.0.31"
 float-ord = "0.3.2"
 fs-err = "2.11.0"
 fs2 = "0.4.3"
@@ -147,10 +147,10 @@ ic-transport-types = "0.37.1"
 ic-utils = "0.37.0"
 include_dir = "0.7.4"
 itertools = "0.13.0"
-keyring = "3.0.5"
+keyring = "3.1.0"
 lazy_static = "1.5.0"
 log = "0.4.22"
-lru = "0.12.3"
+lru = "0.12.4"
 opentelemetry = { version = "0.22.0", features = ["metrics"] }
 phantom_newtype = { git = "https://github.com/dfinity/ic.git", rev = "7dee90107a88b836fc72e78993913988f4f73ca2" }
 pkcs11 = "0.5.0"
@@ -162,7 +162,7 @@ prost = "0.12"
 rand = { version = "0.8.5", features = ["std_rng"] }
 rand_seeder = "0.3.0"
 rayon = "1.10.0"
-regex = "1.10.5"
+regex = "1.10.6"
 registry-canister = { git = "https://github.com/dfinity/ic.git", rev = "7dee90107a88b836fc72e78993913988f4f73ca2" }
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
@@ -173,8 +173,8 @@ reverse_geocoder = "4.1.1"
 ring = "0.17.8"
 rstest = { version = "0.22.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0.203"
-serde_json = "1.0.124"
+serde_derive = "1.0.208"
+serde_json = "1.0.125"
 serde_yaml = "0.9.34"
 shlex = "1.3.0"
 sha2 = "0.10.8"
@@ -193,14 +193,14 @@ strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
 tabled = "0.16.0"
 tabular = "0.2"
-tempfile = "3.10.1"
-thiserror = "1.0.62"
-tokio = { version = "1.38.1", features = ["full"] }
+tempfile = "3.12.0"
+thiserror = "1.0.63"
+tokio = { version = "1.39.2", features = ["full"] }
 tokio-util = "0.7.11"
 url = "2.5.2"
 urlencoding = "2.1.3"
 warp = "0.3"
-wiremock = "0.6.0"
+wiremock = "0.6.1"
 human_bytes = "0.4"
 headless_chrome = { version = "1.0.12", features = [
     "fetch",
@@ -210,7 +210,7 @@ headless_chrome = { version = "1.0.12", features = [
 ic-cdk-timers = { git = "https://github.com/dfinity/cdk-rs.git", rev = "59795716487fbb8a9910ac503bcea1e0cb08c932" }
 ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs.git", rev = "59795716487fbb8a9910ac503bcea1e0cb08c932" }
 ic-stable-structures = "0.6.5"
-ciborium = "0.2.1"
+ciborium = "0.2.2"
 dfn_core = { git = "https://github.com/dfinity/ic.git", rev = "7dee90107a88b836fc72e78993913988f4f73ca2" }
 
 [profile.release]

--- a/poetry.lock
+++ b/poetry.lock
@@ -5606,17 +5606,17 @@ files = [
 
 [[package]]
 name = "slack-bolt"
-version = "1.19.1"
+version = "1.20.0"
 description = "The Bolt Framework for Python"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "slack_bolt-1.19.1-py2.py3-none-any.whl", hash = "sha256:b916829ece0ff7a2cae1502f1774fd100592cd8a81a39e4f04e3137a3f19522b"},
-    {file = "slack_bolt-1.19.1.tar.gz", hash = "sha256:a3041d8f49eba22c3be4dd8f57602d6685d367c0e1cc7619260e1ce4a363d07f"},
+    {file = "slack_bolt-1.20.0-py2.py3-none-any.whl", hash = "sha256:e253dcae69ac7eea189b3270307fba6d733eb0764ae223b494427a9023a57380"},
+    {file = "slack_bolt-1.20.0.tar.gz", hash = "sha256:373d76a2b1a8ed91d5fe011bd3f671a05ec8620210c3a6ad99477e39d6b2b7fa"},
 ]
 
 [package.dependencies]
-slack-sdk = ">=3.25.0,<4"
+slack-sdk = ">=3.26.0,<4"
 
 [[package]]
 name = "slack-sdk"

--- a/release-controller/release_index.py
+++ b/release-controller/release_index.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List
 
 from pydantic import BaseModel, ConfigDict, RootModel
 
@@ -12,10 +12,8 @@ class Version(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    version: str
     name: str
-    release_notes_ready: Optional[bool] = None
-    subnets: Optional[List[str]] = None
+    version: str
 
 
 class Release(BaseModel):
@@ -26,12 +24,12 @@ class Release(BaseModel):
     versions: List[Version]
 
 
-class ReleaseIndex(BaseModel):
+class Welcome4(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
     releases: List[Release]
 
 
-class Model(RootModel[ReleaseIndex]):
-    root: ReleaseIndex
+class Model(RootModel[Welcome4]):
+    root: Welcome4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2503,9 +2503,9 @@ shellingham==1.5.4 ; python_full_version >= "3.10.0" and python_version < "4.0" 
 six==1.16.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-slack-bolt==1.19.1 ; python_full_version >= "3.10.0" and python_version < "4" \
-    --hash=sha256:a3041d8f49eba22c3be4dd8f57602d6685d367c0e1cc7619260e1ce4a363d07f \
-    --hash=sha256:b916829ece0ff7a2cae1502f1774fd100592cd8a81a39e4f04e3137a3f19522b
+slack-bolt==1.20.0 ; python_full_version >= "3.10.0" and python_version < "4" \
+    --hash=sha256:373d76a2b1a8ed91d5fe011bd3f671a05ec8620210c3a6ad99477e39d6b2b7fa \
+    --hash=sha256:e253dcae69ac7eea189b3270307fba6d733eb0764ae223b494427a9023a57380
 slack-sdk==3.31.0 ; python_full_version >= "3.10.0" and python_version < "4" \
     --hash=sha256:740d2f9c49cbfcbd46fca56b4be9d527934c225312aac18fd2c0fca0ef6bc935 \
     --hash=sha256:a120cc461e8ebb7d9175f171dbe0ded37a6878d9f7b96b28e4bad1227399047b

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -66,7 +66,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 humantime = { workspace = true }
-clap_complete = "4.5.14"
+clap_complete = "4.5.16"
 cryptoki = { workspace = true }
 keyring = { workspace = true }
 comfy-table = { workspace = true }

--- a/rs/ic-observability/multiservice-discovery/Cargo.toml
+++ b/rs/ic-observability/multiservice-discovery/Cargo.toml
@@ -37,4 +37,4 @@ tempfile = { workspace = true }
 reqwest = { workspace = true }
 assert_cmd = "2.0.16"
 anyhow = "1.0.86"
-flate2 = "1.0.30"
+flate2 = "1.0.31"

--- a/rs/ic-observability/node-status-updater/Cargo.toml
+++ b/rs/ic-observability/node-status-updater/Cargo.toml
@@ -16,7 +16,7 @@ ic-agent = { workspace = true }
 ic-async-utils = { workspace = true }
 ic-metrics = { workspace = true }
 obs-canister-clients = { path = "../obs-canister-clients" }
-prometheus-http-query = { version = "0.8.2", default-features = false, features = [
+prometheus-http-query = { version = "0.8.3", default-features = false, features = [
   "rustls-tls-webpki-roots",
 ] }
 service-discovery = { path = "../service-discovery" }


### PR DESCRIPTION
This PR updates poetry (Python) and cargo (Rust) dependencies and recreates the bazel cache.