### PR TITLE
fix(dre): Fix the duplicate output (printout) of the SubnetChangeResponse

### DIFF
--- a/rs/decentralization/src/lib.rs
+++ b/rs/decentralization/src/lib.rs
@@ -111,24 +111,6 @@ impl Display for SubnetChangeResponse {
 
         writeln!(f, "Nodes removed:")?;
         for (id, desc) in &self.removed_with_desc {
-            writeln!(f, " --> {} [{}]", id, desc).expect("write failed");
-        }
-        writeln!(f, "\nNodes added:")?;
-        for (id, desc) in &self.added_with_desc {
-            writeln!(f, " ++> {} [{}]", id, desc).expect("write failed");
-        }
-
-        writeln!(f, "Nodes removed:")?;
-        for (id, desc) in &self.removed_with_desc {
-            writeln!(f, " --> {} [selected based on {}]", id, desc).expect("write failed");
-        }
-        writeln!(f, "\nNodes added:")?;
-        for (id, desc) in &self.added_with_desc {
-            writeln!(f, " ++> {} [selected based on {}]", id, desc).expect("write failed");
-        }
-
-        writeln!(f, "Nodes removed:")?;
-        for (id, desc) in &self.removed_with_desc {
             writeln!(f, " --> {} [selected based on {}]", id, desc).expect("write failed");
         }
         writeln!(f, "\nNodes added:")?;


### PR DESCRIPTION
The duplicates were likely added in some merge conflict resolution