### PR TITLE
feat: slack notification about quali

### DIFF
--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -125,7 +125,7 @@ jobs:
         shell: bash
         run: |
           COMMIT="${{ inputs.version }}"
-          FULL_MESSAGE="Qualification of ${COMMIT}: "
+          FULL_MESSAGE="Qualification of `${COMMIT}`: "
           if [[ "${{ needs.qualify.result }}" =~ ^(success)$ ]]; then
             FULL_MESSAGE="${FULL_MESSAGE} :white_check_mark:"
           elif [[ "${{ needs.qualify.result }}" =~ ^(failure|timed_out)$ ]]; then
@@ -141,7 +141,7 @@ jobs:
           slack-message: |
             ${{ steps.slack.outputs.message }}
 
-            Artifacts of run: ${{ inputs.version }}-${{ steps.date.outputs.date }}.tar
+            Artifacts of run: `${{ inputs.version }}-${{ steps.date.outputs.date }}.tar`
             Artifacts can be found on <https://drive.google.com/drive/u/1/folders/${{secrets.ARTIFACTS_DRIVE_FOLDER_ID}}|Google Drive :open_file_folder:>
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}

--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -8,12 +8,6 @@ on:
         description: "The version that should be qualified"
         type: string
         default: ""
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "The version that should be qualified"
-        type: string
-        default: ""
 
 # Run one qualification per commit.
 # This means we can have multiple qualifications of different versions
@@ -75,7 +69,7 @@ jobs:
         run: |
           mkdir -p ~/.config/dfx/identity/xnet-testing/
           echo "${{ secrets.XNET_PRINCIPAL_KEY }}" > ~/.config/dfx/identity/xnet-testing/identity.pem
-          bazel run //rs/qualifier -- "${{ inputs.version }}" --initial-versions ${{ matrix.version }} --step-range 9
+          bazel run //rs/qualifier -- "${{ inputs.version }}" --initial-versions ${{ matrix.version }}
 
       - name: "⚙️ Uploading artifacts created during qualification"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -8,6 +8,12 @@ on:
         description: "The version that should be qualified"
         type: string
         default: ""
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version that should be qualified"
+        type: string
+        default: ""
 
 # Run one qualification per commit.
 # This means we can have multiple qualifications of different versions
@@ -69,7 +75,7 @@ jobs:
         run: |
           mkdir -p ~/.config/dfx/identity/xnet-testing/
           echo "${{ secrets.XNET_PRINCIPAL_KEY }}" > ~/.config/dfx/identity/xnet-testing/identity.pem
-          bazel run //rs/qualifier -- "${{ inputs.version }}" --initial-versions ${{ matrix.version }}
+          bazel run //rs/qualifier -- "${{ inputs.version }}" --initial-versions ${{ matrix.version }} --step-range 9
 
       - name: "⚙️ Uploading artifacts created during qualification"
         uses: actions/upload-artifact@v4
@@ -113,3 +119,30 @@ jobs:
           filename: ${{ inputs.version }}-${{ steps.date.outputs.date }}.tar
           folderId: ${{ secrets.ARTIFACTS_DRIVE_FOLDER_ID }}
           name: ${{ inputs.version }}-${{ steps.date.outputs.date }}.tar
+
+      - name: "Setup message"
+        id: slack
+        shell: bash
+        run: |
+          COMMIT="${{ inputs.version }}"
+          FULL_MESSAGE="Qualification of ${COMMIT}: "
+          if [[ "${{ needs.qualify.result }}" =~ ^(success)$ ]]; then
+            FULL_MESSAGE="${FULL_MESSAGE} :white_check_mark:"
+          elif [[ "${{ needs.qualify.result }" =~ ^(failure|timed_out)$ ]]; then
+            FULL_MESSAGE="${FULL_MESSAGE} :x:"
+          fi
+
+          echo "message=${FULL_MESSAGE}" >> $GITHUB_OUTPUT
+
+      - name: "Notify DRE on slack"
+        if: ${{ needs.qualify.result != 'success' }}
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        with:
+          channel-id: eng-release-bots
+          message: |
+            ${{ steps.slack.outputs.message }}
+
+            Artifacts of run: ${{ inputs.version }}-${{ steps.date.outputs.date }}.tar
+            Artifacts can be found on <https://drive.google.com/drive/u/1/folders/${{secrets.ARTIFACTS_DRIVE_FOLDER_ID}}|Google Drive :open_file_folder:>
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}

--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -135,7 +135,6 @@ jobs:
           echo "message=${FULL_MESSAGE}" >> $GITHUB_OUTPUT
 
       - name: "Notify DRE on slack"
-        if: ${{ needs.qualify.result != 'success' }}
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           channel-id: eng-release-bots

--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -125,7 +125,7 @@ jobs:
         shell: bash
         run: |
           COMMIT="${{ inputs.version }}"
-          FULL_MESSAGE="Qualification of `${COMMIT}`: "
+          FULL_MESSAGE="Qualification of \`${COMMIT}\`: "
           if [[ "${{ needs.qualify.result }}" =~ ^(success)$ ]]; then
             FULL_MESSAGE="${FULL_MESSAGE} :white_check_mark:"
           elif [[ "${{ needs.qualify.result }}" =~ ^(failure|timed_out)$ ]]; then

--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -128,7 +128,7 @@ jobs:
           FULL_MESSAGE="Qualification of ${COMMIT}: "
           if [[ "${{ needs.qualify.result }}" =~ ^(success)$ ]]; then
             FULL_MESSAGE="${FULL_MESSAGE} :white_check_mark:"
-          elif [[ "${{ needs.qualify.result }" =~ ^(failure|timed_out)$ ]]; then
+          elif [[ "${{ needs.qualify.result }}" =~ ^(failure|timed_out)$ ]]; then
             FULL_MESSAGE="${FULL_MESSAGE} :x:"
           fi
 

--- a/.github/workflows/qualify.yaml
+++ b/.github/workflows/qualify.yaml
@@ -138,7 +138,7 @@ jobs:
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           channel-id: eng-release-bots
-          message: |
+          slack-message: |
             ${{ steps.slack.outputs.message }}
 
             Artifacts of run: ${{ inputs.version }}-${{ steps.date.outputs.date }}.tar


### PR DESCRIPTION
One dumb thing about this is that of how secrets work:
When this is run from our repo, say via a `workflow_dispatch` event, it will say that our `Airflow` bot created a message.
When this is  run automatically from ic repo, it will say that their bot created it.