### PR TITLE
feat(dre): Add WhatifAnalysis command for subnet analysis

### DIFF
--- a/rs/cli/src/commands/proposals/analyze.rs
+++ b/rs/cli/src/commands/proposals/analyze.rs
@@ -33,7 +33,7 @@ impl ExecutableCommand for Analyze {
         let runner = ctx.runner().await;
 
         match filter_map_nns_function_proposals::<ChangeSubnetMembershipPayload>(&[proposal]).first() {
-            Some((_, change_membership)) => runner.decentralization_change(change_membership).await,
+            Some((_, change_membership)) => runner.decentralization_change(change_membership, None).await,
             _ => Err(anyhow::anyhow!(
                 "Proposal {} must have {} type",
                 self.proposal_id,

--- a/rs/cli/src/commands/subnet/mod.rs
+++ b/rs/cli/src/commands/subnet/mod.rs
@@ -4,6 +4,7 @@ use deploy::Deploy;
 use replace::Replace;
 use rescue::Rescue;
 use resize::Resize;
+use whatif::WhatifAnalysis;
 
 use super::{impl_executable_command_for_enums, ExecutableCommand, IcAdminRequirement};
 
@@ -12,6 +13,7 @@ mod deploy;
 mod replace;
 mod rescue;
 mod resize;
+mod whatif;
 
 #[derive(Parser, Debug)]
 pub struct Subnet {
@@ -19,7 +21,7 @@ pub struct Subnet {
     pub subcommand: Subcommands,
 }
 
-impl_executable_command_for_enums! { Deploy, Replace, Resize, Create, Rescue }
+impl_executable_command_for_enums! { WhatifAnalysis, Deploy, Replace, Resize, Create, Rescue }
 
 impl ExecutableCommand for Subnet {
     fn require_ic_admin(&self) -> IcAdminRequirement {

--- a/rs/cli/src/commands/subnet/whatif.rs
+++ b/rs/cli/src/commands/subnet/whatif.rs
@@ -1,0 +1,48 @@
+use clap::Args;
+use ic_types::PrincipalId;
+use registry_canister::mutations::do_change_subnet_membership::ChangeSubnetMembershipPayload;
+
+use crate::commands::{ExecutableCommand, IcAdminRequirement};
+
+#[derive(Args, Debug)]
+#[clap(aliases = &["analyze", "analyze-decentralization", "decentralization", "whatif", "what-if"])]
+pub struct WhatifAnalysis {
+    /// Set of nodes to add to the subnet in the analysis
+    #[clap(long)]
+    pub add_nodes: Vec<PrincipalId>,
+
+    /// Set of nodes to remove from the subnet in the analysis
+    #[clap(long)]
+    pub remove_nodes: Vec<PrincipalId>,
+
+    /// Subnet ID
+    #[clap(long, alias = "id")]
+    subnet_id: Option<PrincipalId>,
+
+    /// List of initial nodes in the provided subnet,
+    /// can be provided to override the current list of subnet nodes for the sake of analysis
+    #[clap(long, num_args(1..))]
+    subnet_nodes_initial: Option<Vec<PrincipalId>>,
+}
+
+impl ExecutableCommand for WhatifAnalysis {
+    fn require_ic_admin(&self) -> IcAdminRequirement {
+        IcAdminRequirement::Anonymous
+    }
+
+    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
+        let runner = ctx.runner().await;
+
+        let change_membership = ChangeSubnetMembershipPayload {
+            subnet_id: self.subnet_id.unwrap_or(PrincipalId::new_anonymous()),
+            node_ids_add: self.add_nodes.iter().map(|id| id.clone().into()).collect(),
+            node_ids_remove: self.remove_nodes.iter().map(|id| id.clone().into()).collect(),
+        };
+
+        runner
+            .decentralization_change(&change_membership, self.subnet_nodes_initial.clone())
+            .await
+    }
+
+    fn validate(&self, _cmd: &mut clap::Command) {}
+}

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -155,6 +155,18 @@ struct ReplacementCandidate {
 }
 
 impl DecentralizedSubnet {
+    pub fn new_with_subnet_id_and_nodes(subnet_id: PrincipalId, nodes: Vec<Node>) -> Self {
+        Self {
+            id: subnet_id,
+            nodes,
+            added_nodes_desc: vec![],
+            removed_nodes_desc: vec![],
+            min_nakamoto_coefficients: None,
+            comment: None,
+            run_log: vec![],
+        }
+    }
+
     pub fn with_subnet_id(self, subnet_id: PrincipalId) -> Self {
         Self { id: subnet_id, ..self }
     }


### PR DESCRIPTION
This commit adds a new command, WhatifAnalysis, to the Subnet module. The WhatifAnalysis command allows users to perform subnet analysis by simulating node additions and removals. It takes in parameters such as the nodes to add and remove, subnet ID, and initial nodes. The command executes the analysis by calling the decentralization_change method in the Runner module.

This allows community members to explore and experiment, to see how particular subnet topology changes would affect the subnet decentralization.

Parts of implementation:
* [x] Add a WhatIf subcommand: `dre subnet whatif <...>`
* [x] Adjust the decentralization_change function to accept (optional) arbitrary initial node list in the subnet
* [ ] Add documentation