### PR TITLE
feat: Optimize subnet healing process

### DIFF
--- a/rs/decentralization/src/nakamoto/mod.rs
+++ b/rs/decentralization/src/nakamoto/mod.rs
@@ -448,7 +448,7 @@ impl NakamotoScore {
 
         // And finally try to increase the linear average
         match self.score_avg_linear().partial_cmp(&other.score_avg_linear()) {
-            Some(Ordering::Equal) => (Some(Ordering::Equal), "equal Nakamoto scores across all features".to_string()),
+            Some(Ordering::Equal) => (Some(Ordering::Equal), "equal decentralization across all features".to_string()),
             Some(cmp) => (
                 Some(cmp),
                 format!(
@@ -506,7 +506,6 @@ impl Display for NakamotoScore {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
-    use std::sync::Arc;
 
     use crate::network::{DecentralizedSubnet, NetworkHealRequest, NetworkHealSubnets, SubnetChangeRequest};
     use ahash::HashSet;
@@ -1022,7 +1021,7 @@ mod tests {
 
         important.insert(subnet.principal, subnet);
 
-        let network_heal_response = NetworkHealRequest::new(Arc::new(important.clone()))
+        let network_heal_response = NetworkHealRequest::new(important.clone())
             .heal_and_optimize(nodes_available.clone(), healths.clone())
             .await
             .unwrap();

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -15,7 +15,6 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
-use std::sync::Arc;
 
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct DataCenterInfo {
@@ -1167,11 +1166,11 @@ impl Ord for NetworkHealSubnets {
 }
 
 pub struct NetworkHealRequest {
-    pub subnets: Arc<BTreeMap<PrincipalId, ic_management_types::Subnet>>,
+    pub subnets: BTreeMap<PrincipalId, ic_management_types::Subnet>,
 }
 
 impl NetworkHealRequest {
-    pub fn new(subnets: Arc<BTreeMap<PrincipalId, ic_management_types::Subnet>>) -> Self {
+    pub fn new(subnets: BTreeMap<PrincipalId, ic_management_types::Subnet>) -> Self {
         Self { subnets }
     }
 
@@ -1184,9 +1183,9 @@ impl NetworkHealRequest {
         let subnets_to_heal = unhealthy_with_nodes(&self.subnets, &healths)
             .await
             .iter()
-            .flat_map(|(id, unhealthy_nodes)| {
+            .flat_map(|(subnet_id, unhealthy_nodes)| {
                 let unhealthy_nodes = unhealthy_nodes.iter().map(Node::from).collect::<Vec<_>>();
-                let unhealthy_subnet = self.subnets.get(id).ok_or(NetworkError::SubnetNotFound(*id))?;
+                let unhealthy_subnet = self.subnets.get(subnet_id).ok_or(NetworkError::SubnetNotFound(*subnet_id))?;
 
                 Ok::<NetworkHealSubnets, NetworkError>(NetworkHealSubnets {
                     name: unhealthy_subnet.metadata.name.clone(),
@@ -1278,23 +1277,43 @@ impl NetworkHealRequest {
                 .iter()
                 .max_by_key(|change| change.score_after.clone())
                 .expect("Failed to find a replacement with the highest Nakamoto coefficient");
+
+            let optimizations_desc = changes
+                .iter()
+                .enumerate()
+                .skip(1)
+                .map(|(num_opt, change)| {
+                    format!(
+                        "- {} additional node{}: {}",
+                        num_opt,
+                        if num_opt > 1 { "s" } else { "" },
+                        change.score_after.describe_difference_from(&changes[num_opt - 1].score_after).1
+                    )
+                })
+                .collect::<Vec<_>>();
+
             let change = changes
                 .iter()
                 .find(|change| change.score_after == changes_max_score.score_after)
                 .expect("No suitable changes found");
 
             let num_opt = change.removed_with_desc.len() - unhealthy_nodes_len;
-            let reason_additional_optimizations =
-                format!("\nReplacing additional {} node{} optimizes topology based on {}.
+            let reason_additional_optimizations = format!("
+
+Calculated impact on subnet decentralization if replacing:
+
+{}
+
+Based on the calculated impact, replacing {} additional nodes to improve optimization
+
 Note: the heuristic for node replacement relies not only on the Nakamoto coefficient but also on other factors that iteratively optimize network topology.
 Due to this, Nakamoto coefficients may not directly increase in every node replacement proposal.
 Code for comparing decentralization of two candidate subnet topologies is at:
 https://github.com/dfinity/dre/blob/79066127f58c852eaf4adda11610e815a426878c/rs/decentralization/src/nakamoto/mod.rs#L342
 ",
-                    num_opt,
-                    if num_opt > 1 { "s" } else { "" },
-                    change.score_after.describe_difference_from(&changes[0].score_after).1
-                );
+                optimizations_desc.join("\n"),
+                num_opt
+            );
 
             let mut motivations: Vec<String> = Vec::new();
 
@@ -1318,7 +1337,7 @@ https://github.com/dfinity/dre/blob/79066127f58c852eaf4adda11610e815a426878c/rs/
             available_nodes.retain(|node| !nodes_added.contains(&node.id));
             // TODO: Add instructions for independent verification of the decentralization changes
             let motivation = format!(
-                "\n{}\n{}\nNOTE: The information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.\n\n```\n{}\n```\n",
+                "\n{}{}\nNOTE: The information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.\nHere is [an explaination of how decentralization is currently calculated](https://dfinity.github.io/dre/decentralization.html), and there are also [instructions for performing what-if analysis](https://dfinity.github.io/dre/subnet-decentralization-whatif.html) if you are wondering if another node would have improved decentralization more.\n\n```\n{}\n```\n",
                 motivations.iter().map(|s| format!(" - {}", s)).collect::<Vec<String>>().join("\n"),
                 reason_additional_optimizations,
                 change

--- a/rs/decentralization/src/subnets.rs
+++ b/rs/decentralization/src/subnets.rs
@@ -15,7 +15,7 @@ pub async fn unhealthy_with_nodes(
     subnets
         .clone()
         .into_iter()
-        .filter_map(|(id, subnet)| {
+        .filter_map(|(subnet_id, subnet)| {
             let unhealthy = subnet
                 .nodes
                 .into_iter()
@@ -26,7 +26,7 @@ pub async fn unhealthy_with_nodes(
                 .collect::<Vec<_>>();
 
             if !unhealthy.is_empty() {
-                Some((id, unhealthy))
+                Some((subnet_id, unhealthy))
             } else {
                 None
             }

--- a/rs/ic-management-backend/src/lazy_registry.rs
+++ b/rs/ic-management-backend/src/lazy_registry.rs
@@ -504,14 +504,16 @@ impl LazyRegistry {
         self.nodes().await
     }
 
-    pub async fn subnets_with_proposals(&self) -> anyhow::Result<Arc<BTreeMap<PrincipalId, Subnet>>> {
+    /// Get the list of subnets, and the list of open proposal for each subnet, if any
+    pub async fn subnets_and_proposals(&self) -> anyhow::Result<Arc<BTreeMap<PrincipalId, Subnet>>> {
         let subnets = self.subnets().await?;
+
+        self.update_proposal_data().await?;
 
         if subnets.iter().any(|(_, s)| s.proposal.is_some()) {
             return Ok(subnets);
         }
 
-        self.update_proposal_data().await?;
         self.subnets().await
     }
 


### PR DESCRIPTION
- Provide more information in the membership change proposals, to clarify why a particular number of nodes was replaced to optimize decentralization, and to quantify the gain from the replacement
- Refactor the subnet healing to skip subnets with open proposals
- Some variable renamings
- Improving the lazy loading of registry data and proposals