### PR TITLE
chore: update deps only on Monday

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -3,7 +3,7 @@ name: Update dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 1 * * Mon,Wed,Fri"
+    - cron: "30 1 * * Mon"
 
 jobs:
   update:


### PR DESCRIPTION
Let this PR serve to remind the team to not update dependencies on Fridays 🙂 