### PR TITLE
Add Rewards Computation logging for audit

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3e05383681bea3979640c30ae1e595263eb176f895e48d5962f74816261dc223",
+  "checksum": "2bbd3d15bf606c9af001e99012b5deb363a91b712bf83a21702c95fdf0ccdf21",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -21383,7 +21383,7 @@
               "target": "prost"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             },
             {
@@ -21658,7 +21658,7 @@
               "target": "prost"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             },
             {
@@ -21961,7 +21961,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             },
             {
@@ -21979,7 +21979,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "rust_decimal_macros 1.35.0",
+              "id": "rust_decimal_macros 1.36.0",
               "target": "rust_decimal_macros"
             }
           ],
@@ -22397,7 +22397,7 @@
               "target": "registry_canister"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             },
             {
@@ -22442,7 +22442,7 @@
               "target": "ic_nervous_system_common_build_metadata"
             },
             {
-              "id": "rust_decimal_macros 1.35.0",
+              "id": "rust_decimal_macros 1.36.0",
               "target": "rust_decimal_macros"
             },
             {
@@ -24146,7 +24146,7 @@
               "target": "rand_chacha"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             },
             {
@@ -24176,7 +24176,7 @@
               "target": "ic_nervous_system_common_build_metadata"
             },
             {
-              "id": "rust_decimal_macros 1.35.0",
+              "id": "rust_decimal_macros 1.36.0",
               "target": "rust_decimal_macros"
             },
             {
@@ -24293,7 +24293,7 @@
               "target": "num_traits"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             }
           ],
@@ -24303,7 +24303,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "rust_decimal_macros 1.35.0",
+              "id": "rust_decimal_macros 1.36.0",
               "target": "rust_decimal_macros"
             }
           ],
@@ -24392,7 +24392,7 @@
               "target": "mockall"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             }
           ],
@@ -24832,7 +24832,7 @@
               "target": "prost"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             },
             {
@@ -24854,7 +24854,7 @@
               "target": "async_trait"
             },
             {
-              "id": "rust_decimal_macros 1.35.0",
+              "id": "rust_decimal_macros 1.36.0",
               "target": "rust_decimal_macros"
             }
           ],
@@ -37794,13 +37794,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "rust_decimal 1.35.0": {
+    "rust_decimal 1.36.0": {
       "name": "rust_decimal",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rust_decimal/1.35.0/download",
-          "sha256": "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+          "url": "https://static.crates.io/crates/rust_decimal/1.36.0/download",
+          "sha256": "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
         }
       },
       "targets": [
@@ -37847,7 +37847,7 @@
               "target": "num_traits"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "build_script_build"
             },
             {
@@ -37858,7 +37858,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.35.0"
+        "version": "1.36.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -37867,13 +37867,13 @@
       },
       "license": "MIT"
     },
-    "rust_decimal_macros 1.35.0": {
+    "rust_decimal_macros 1.36.0": {
       "name": "rust_decimal_macros",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rust_decimal_macros/1.35.0/download",
-          "sha256": "a05bf7103af0797dbce0667c471946b29b9eaea34652eff67324f360fec027de"
+          "url": "https://static.crates.io/crates/rust_decimal_macros/1.36.0/download",
+          "sha256": "da991f231869f34268415a49724c6578e740ad697ba0999199d6f22b3949332c"
         }
       },
       "targets": [
@@ -37905,14 +37905,14 @@
               "target": "quote"
             },
             {
-              "id": "rust_decimal 1.35.0",
+              "id": "rust_decimal 1.36.0",
               "target": "rust_decimal"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.35.0"
+        "version": "1.36.0"
       },
       "license": "MIT"
     },
@@ -45532,6 +45532,10 @@
             {
               "id": "num-traits 0.2.19",
               "target": "num_traits"
+            },
+            {
+              "id": "rust_decimal 1.36.0",
+              "target": "rust_decimal"
             }
           ],
           "selects": {}
@@ -45542,6 +45546,10 @@
             {
               "id": "ic-cdk-macros 0.15.0",
               "target": "ic_cdk_macros"
+            },
+            {
+              "id": "rust_decimal_macros 1.36.0",
+              "target": "rust_decimal_macros"
             }
           ],
           "selects": {}

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8f8316053a9bbdfb2e006bb7300906283da5cbb9888e2eaaab85777bd8924e11",
+  "checksum": "3e05383681bea3979640c30ae1e595263eb176f895e48d5962f74816261dc223",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -45528,6 +45528,10 @@
             {
               "id": "itertools 0.13.0",
               "target": "itertools"
+            },
+            {
+              "id": "num-traits 0.2.19",
+              "target": "num_traits"
             }
           ],
           "selects": {}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9078,6 +9078,8 @@ dependencies = [
  "ic-stable-structures",
  "itertools 0.13.0",
  "num-traits",
+ "rust_decimal",
+ "rust_decimal_macros",
  "trustworthy-node-metrics-types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7591,9 +7591,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec 0.7.4",
  "borsh",
@@ -7607,9 +7607,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05bf7103af0797dbce0667c471946b29b9eaea34652eff67324f360fec027de"
+checksum = "da991f231869f34268415a49724c6578e740ad697ba0999199d6f22b3949332c"
 dependencies = [
  "quote",
  "rust_decimal",
@@ -9077,7 +9077,6 @@ dependencies = [
  "ic-registry-keys",
  "ic-stable-structures",
  "itertools 0.13.0",
- "num-traits",
  "rust_decimal",
  "rust_decimal_macros",
  "trustworthy-node-metrics-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9077,6 +9077,7 @@ dependencies = [
  "ic-registry-keys",
  "ic-stable-structures",
  "itertools 0.13.0",
+ "num-traits",
  "rust_decimal",
  "rust_decimal_macros",
  "trustworthy-node-metrics-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9077,6 +9077,7 @@ dependencies = [
  "ic-registry-keys",
  "ic-stable-structures",
  "itertools 0.13.0",
+ "num-traits",
  "trustworthy-node-metrics-types",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ keyring = "3.2.0"
 lazy_static = "1.5.0"
 log = "0.4.22"
 lru = "0.12.4"
+num-traits = "0.2"
 opentelemetry = { version = "0.22.0", features = ["metrics"] }
 phantom_newtype = { git = "https://github.com/dfinity/ic.git", rev = "26d5f9d0bdca0a817c236134dc9c7317b32c69a5" }
 pkcs11 = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,8 @@ retry = "2.0.0"
 reverse_geocoder = "4.1.1"
 ring = "0.17.8"
 rstest = { version = "0.22.0", default-features = false }
+rust_decimal = "1.36.0"  # or the latest version
+rust_decimal_macros = "1.36.0"  # optional, for using macros
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0.209"
 serde_json = "1.0.127"

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/App.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/App.tsx
@@ -68,7 +68,7 @@ const App: React.FC = () => {
           to_ts: dateToNanoseconds(periodFilter.dateEnd),
         };
         const nodeRewardsResponse = await trustworthy_node_metrics.node_rewards(request);
-        const sortedNodeRewards = nodeRewardsResponse.sort((a, b) => a.rewards_percent - b.rewards_percent);
+        const sortedNodeRewards = nodeRewardsResponse.sort((a, b) => a.rewards_computation.rewards_percent - b.rewards_computation.rewards_percent);
         const subnets = new Set(sortedNodeRewards.flatMap(node => node.daily_node_metrics.map(data => data.subnet_assigned.toText())));
         const providers = new Set(sortedNodeRewards.flatMap(node => node.node_provider_id.toText()));
         

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/NodeList.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/NodeList.tsx
@@ -79,8 +79,8 @@ export const NodeList: React.FC<NodeListProps> = ({ nodeRewards }) => {
                     </TableCell>
                     <TableCell>{nodeMetrics.node_provider_id.toText()}</TableCell>
                     <TableCell>{nodeMetrics.daily_node_metrics.length}</TableCell>
-                    <TableCell>{Math.round(nodeMetrics.rewards_percent * 100)}%</TableCell>
-                    <TableCell>{Math.round(nodeMetrics.rewards_stats.failure_rate * 100)}%</TableCell>
+                    <TableCell>{Math.round(nodeMetrics.rewards_computation.rewards_percent * 100)}%</TableCell>
+                    <TableCell>{Math.round(nodeMetrics.rewards_computation.failure_rate * 100)}%</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/NodePage.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/NodePage.tsx
@@ -17,7 +17,7 @@ export interface NodePageProps {
     periodFilter: PeriodFilter;
 }
 
-const NodeMetricsStats: React.FC<{ stats: NodeRewardsResponse['rewards_stats'] }> = ({ stats }) => (
+const NodeMetricsStats: React.FC<{ stats: NodeRewardsResponse['rewards_computation'] }> = ({ stats }) => (
     <Box sx={boxStyleWidget('left')}>
         <WidgetNumber value={stats.blocks_proposed.toString()} title="Blocks Proposed Total" />
         <WidgetNumber value={stats.blocks_failed.toString()} title="Blocks Failed Total" />
@@ -40,8 +40,8 @@ export const NodePage: React.FC<NodePageProps> = ({ nodeRewards, periodFilter })
     }
 
     const chartDailyData: ChartData[] = generateChartData(periodFilter, nodeMetrics.daily_node_metrics);
-    const failureRateAvg = Math.round(nodeMetrics.rewards_stats.failure_rate * 100);
-    const rewardsPercent = Math.round(nodeMetrics.rewards_percent * 100);
+    const failureRateAvg = Math.round(nodeMetrics.rewards_computation.failure_rate * 100);
+    const rewardsPercent = Math.round(nodeMetrics.rewards_computation.rewards_percent * 100);
     const rewardsReduction = 100 - rewardsPercent;
 
     const rows: GridRowsProp = nodeMetrics.daily_node_metrics.map((data, index) => {
@@ -81,7 +81,7 @@ export const NodePage: React.FC<NodePageProps> = ({ nodeRewards, periodFilter })
                         <WidgetGauge value={rewardsPercent} title={"Rewards Total"} />
                     </Grid>
                     <Grid item xs={12} md={4}>
-                        <NodeMetricsStats stats={nodeMetrics.rewards_stats} />
+                        <NodeMetricsStats stats={nodeMetrics.rewards_computation} />
                     </Grid>
                     <Grid item xs={12} md={8}>
                         <NodePerformanceStats rewardsReduction={rewardsReduction.toString().concat("%")} />

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/NodeProviderPage.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/NodeProviderPage.tsx
@@ -22,7 +22,7 @@ export const NodeProviderPage: React.FC<NodeProviderPageProps> = ({ nodeRewards,
     const providerNodeMetrics = nodeRewards
         .filter((nodeMetrics) => nodeMetrics.node_provider_id.toText() === provider)
     const highFailureRateChart = providerNodeMetrics
-        .filter(nodeMetrics => nodeMetrics.rewards_stats.rewards_reduction > 0)
+        .filter(nodeMetrics => nodeMetrics.rewards_computation.rewards_reduction > 0)
         .flatMap(nodeMetrics => {
             const chartData = generateChartData(periodFilter, nodeMetrics.daily_node_metrics);
             return {

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/RewardTable.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/RewardTable.tsx
@@ -35,7 +35,7 @@ const RewardTable: React.FC<RewardTableProps> = ({ nodeRewards }) => {
                 {nodeMetrics.node_id.toText()}
               </TableCell>
               <TableCell component="th" scope="row">
-                {Math.round(nodeMetrics.rewards_stats.failure_rate * 100)}%
+                {nodeMetrics.rewards_computation.failure_rate * 100}%
               </TableCell>
             </TableRow>
           ))}

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
@@ -115,7 +115,7 @@ pub struct RewardsComputationResult {
     pub blocks_failed: u64,
     pub blocks_proposed: u64,
     pub blocks_total: u64,
-    pub failure_rate: u64,
+    pub failure_rate: f64,
     pub computation_log: String,
 }
 

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 use candid::{CandidType, Decode, Deserialize, Encode, Principal};
 use dfn_core::api::PrincipalId;
@@ -77,6 +77,16 @@ pub struct DailyNodeMetrics {
     /// `num_blocks_failed` to `num_blocks_total` = `num_blocks_failed` + `num_blocks_proposed`.
     /// This value ranges from 0.0 (no failures) to 1.0 (all blocks failed).
     pub failure_rate: f64,
+}
+
+impl fmt::Display for DailyNodeMetrics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "timestamp_nanoseconds: {}, num_blocks_proposed: {},  num_blocks_failed: {}",
+            self.ts, self.num_blocks_proposed, self.num_blocks_failed
+        )
+    }
 }
 
 impl DailyNodeMetrics {

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
@@ -110,8 +110,8 @@ impl DailyNodeMetrics {
 
 #[derive(Debug, Deserialize, CandidType)]
 pub struct RewardsComputationResult {
-    pub rewards_percent: u64,
-    pub rewards_reduction: u64,
+    pub rewards_percent: f64,
+    pub rewards_reduction: f64,
     pub blocks_failed: u64,
     pub blocks_proposed: u64,
     pub blocks_total: u64,

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types/src/types.rs
@@ -99,19 +99,20 @@ impl DailyNodeMetrics {
 }
 
 #[derive(Debug, Deserialize, CandidType)]
-pub struct RewardsStats {
+pub struct RewardsComputationResult {
+    pub rewards_percent: u64,
+    pub rewards_reduction: u64,
     pub blocks_failed: u64,
     pub blocks_proposed: u64,
     pub blocks_total: u64,
-    pub failure_rate: f64,
-    pub rewards_reduction: f64,
+    pub failure_rate: u64,
+    pub computation_log: String,
 }
 
 #[derive(Debug, Deserialize, CandidType)]
 pub struct NodeRewardsResponse {
     pub node_id: Principal,
     pub node_provider_id: Principal,
-    pub rewards_percent: f64,
     pub daily_node_metrics: Vec<DailyNodeMetrics>,
-    pub rewards_stats: RewardsStats,
+    pub rewards_computation: RewardsComputationResult,
 }

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
@@ -27,3 +27,4 @@ dfn_core = { workspace = true }
 trustworthy-node-metrics-types = { workspace = true }
 ic-base-types = { workspace = true }
 ic-registry-keys = { workspace = true }
+num-traits = { workspace = true }

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
@@ -28,4 +28,5 @@ trustworthy-node-metrics-types = { workspace = true }
 ic-base-types = { workspace = true }
 ic-registry-keys = { workspace = true }
 rust_decimal = { workspace = true }
-rust_decimal_macros = { workspace = true }  # optional, for using macros
+rust_decimal_macros = { workspace = true }
+num-traits = { workspace = true }

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
@@ -28,3 +28,5 @@ trustworthy-node-metrics-types = { workspace = true }
 ic-base-types = { workspace = true }
 ic-registry-keys = { workspace = true }
 num-traits = { workspace = true }
+rust_decimal = "1.27.0"  # or the latest version
+rust_decimal_macros = "1.27.0"  # optional, for using macros

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/Cargo.toml
@@ -27,6 +27,5 @@ dfn_core = { workspace = true }
 trustworthy-node-metrics-types = { workspace = true }
 ic-base-types = { workspace = true }
 ic-registry-keys = { workspace = true }
-num-traits = { workspace = true }
-rust_decimal = "1.27.0"  # or the latest version
-rust_decimal_macros = "1.27.0"  # optional, for using macros
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }  # optional, for using macros

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use itertools::Itertools;
+use num_traits::Zero;
 use rust_decimal::Decimal;
 
 pub enum Operation {

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
@@ -1,5 +1,7 @@
 use itertools::Itertools;
 use num_traits::{FromPrimitive, Num, ToPrimitive};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use std::fmt::{self, Display};
 
 // Define a trait that will be used to store and manipulate numbers
@@ -20,13 +22,14 @@ impl<T: Number> Operation<T> {
             Operation::Sum(operators) => operators.iter().cloned().sum(),
             Operation::Subtract(o1, o2) => *o1 - *o2,
             Operation::Percent(o1, o2) => {
+                assert!(o2 > &T::zero(), "Percent operation requires o1 <= o2");
                 assert!(o1 <= o2, "Percent operation requires o1 <= o2");
-                assert!(!T::is_zero(o2), "Division by 0");
-                let numerator = o1.to_f64().unwrap();
-                let denominator = o2.to_f64().unwrap();
 
-                let result = (numerator / denominator * 100.0).round();
-                FromPrimitive::from_f64(result).unwrap()
+                let numerator = Decimal::from(o1.to_u64().unwrap());
+                let denominator = Decimal::from(o2.to_u64().unwrap());
+
+                let result = (numerator / denominator * dec!(100)).round().to_u64().unwrap();
+                FromPrimitive::from_u64(result).unwrap()
             }
             Operation::Set(o1) => *o1,
         }

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use itertools::Itertools;
-use num_traits::Zero;
 use rust_decimal::Decimal;
 
 pub enum Operation {

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
@@ -16,7 +16,7 @@ impl Operation {
         match self {
             Operation::Sum(operators) => operators.iter().cloned().fold(Decimal::zero(), |acc, val| acc + val),
             Operation::Subtract(o1, o2) => o1 - o2,
-            Operation::Divide(o1, o2) => o1/o2,
+            Operation::Divide(o1, o2) => o1 / o2,
             Operation::Set(o1) => *o1,
         }
     }
@@ -30,14 +30,14 @@ impl fmt::Display for Operation {
                     f,
                     "{} + {}",
                     values[0],
-                    values[1..].iter().map(ToString::to_string).collect::<Vec<_>>().join(" + ")
+                    values[1..].iter().map(|o| format!("{}", o.round_dp(4))).collect::<Vec<_>>().join(" + ")
                 )
             }
             Operation::Subtract(o1, o2) => ("-", o1, o2),
-            Operation::Divide(o1, o2) => return write!(f, "{} / {}", o1, o2),
+            Operation::Divide(o1, o2) => ("/", o1, o2),
             Operation::Set(o1) => return write!(f, "{}", o1),
         };
-        write!(f, "{} {} {}", o1, symbol, o2)
+        write!(f, "{} {} {}", o1.round_dp(4), symbol, o2.round_dp(4))
     }
 }
 
@@ -63,7 +63,10 @@ impl OperationExecutor {
 
 impl fmt::Display for OperationExecutor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{}: {} = {}", self.reason, self.operation, self.result)?;
+        match self.operation {
+            Operation::Set(x) => writeln!(f, "{}: {}", self.reason, x)?,
+            _ => writeln!(f, "{}: {} = {}", self.reason, self.operation, self.result.round_dp(4))?,
+        }
         Ok(())
     }
 }

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/computation_logger.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use num_traits::{FromPrimitive, Num, ToPrimitive};
 use std::fmt::{self, Display};
 
@@ -8,7 +9,7 @@ impl Number for u64 {}
 
 pub enum Operation<T> {
     Set(T),
-    Add(Vec<T>),
+    Sum(Vec<T>),
     Subtract(T, T),
     Percent(T, T),
 }
@@ -16,7 +17,7 @@ pub enum Operation<T> {
 impl<T: Number> Operation<T> {
     fn execute(&self) -> T {
         match self {
-            Operation::Add(operators) => operators.iter().cloned().sum(),
+            Operation::Sum(operators) => operators.iter().cloned().sum(),
             Operation::Subtract(o1, o2) => *o1 - *o2,
             Operation::Percent(o1, o2) => {
                 assert!(o1 <= o2, "Percent operation requires o1 <= o2");
@@ -35,7 +36,7 @@ impl<T: Number> Operation<T> {
 impl<T: Number> fmt::Display for Operation<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (symbol, o1, o2) = match self {
-            Operation::Add(values) => {
+            Operation::Sum(values) => {
                 return write!(
                     f,
                     "{} + {}",
@@ -51,13 +52,13 @@ impl<T: Number> fmt::Display for Operation<T> {
     }
 }
 
-pub struct OperationTracker<T: Number> {
+pub struct OperationExecuted<T: Number> {
     reason: String,
     operation: Operation<T>,
     result: T,
 }
 
-impl<T: Number> OperationTracker<T> {
+impl<T: Number> OperationExecuted<T> {
     pub fn execute(reason: &str, operation: Operation<T>) -> (Self, T) {
         let result = operation.execute();
 
@@ -71,9 +72,63 @@ impl<T: Number> OperationTracker<T> {
     }
 }
 
-impl<T: Number> fmt::Display for OperationTracker<T> {
+impl<T: Number> fmt::Display for OperationExecuted<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "{}: {} = {}", self.reason, self.operation, self.result)?;
         Ok(())
+    }
+}
+
+pub struct ComputationLogger<T: Number> {
+    maybe_input: Option<String>,
+    operations_executed: Vec<OperationExecuted<T>>,
+}
+
+impl<T: Number> ComputationLogger<T> {
+    pub fn new() -> Self {
+        Self {
+            maybe_input: None,
+            operations_executed: Vec::new(),
+        }
+    }
+    pub fn with_input(self, input: String) -> Self {
+        Self {
+            maybe_input: Some(input),
+            ..self
+        }
+    }
+
+    pub fn execute(&mut self, reason: &str, operation: Operation<T>) -> T {
+        let result = operation.execute();
+
+        let operation_executed = OperationExecuted {
+            reason: reason.to_string(),
+            operation,
+            result,
+        };
+        self.operations_executed.push(operation_executed);
+        result
+    }
+
+    pub fn add_executed(&mut self, operations: Vec<OperationExecuted<T>>) {
+        for operation in operations {
+            self.operations_executed.push(operation)
+        }
+    }
+
+    pub fn get_log(&self) -> String {
+        let operations_log = self
+            .operations_executed
+            .iter()
+            .enumerate()
+            .map(|(index, item)| format!("STEP {}: {}", index + 1, item))
+            .collect_vec()
+            .join("\n");
+
+        if let Some(input) = &self.maybe_input {
+            format!("INPUT:\n{}\nCOMPUTATION LOG:\n\n{}", input, operations_log)
+        } else {
+            format!("COMPUTATION LOG:\n\n{}", operations_log)
+        }
     }
 }

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/lib.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/lib.rs
@@ -7,9 +7,9 @@ use trustworthy_node_metrics_types::types::{
     SubnetNodeMetricsResponse,
 };
 mod metrics_manager;
+mod operations_tracker;
 mod rewards_manager;
 mod stable_memory;
-mod operations_tracker;
 
 // Management canisters updates node metrics every day
 const TIMER_INTERVAL_SEC: u64 = 60 * 60 * 24;

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/lib.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/lib.rs
@@ -9,6 +9,7 @@ use trustworthy_node_metrics_types::types::{
 mod metrics_manager;
 mod rewards_manager;
 mod stable_memory;
+mod operations_tracker;
 
 // Management canisters updates node metrics every day
 const TIMER_INTERVAL_SEC: u64 = 60 * 60 * 24;
@@ -111,15 +112,14 @@ fn node_rewards(args: NodeRewardsArgs) -> Vec<NodeRewardsResponse> {
     daily_metrics
         .into_iter()
         .map(|(node_id, daily_node_metrics)| {
-            let (rewards_percent, rewards_stats) = rewards_manager::compute_rewards_percent(&daily_node_metrics);
+            let rewards_computation = rewards_manager::compute_rewards_percent(&daily_node_metrics);
             let node_provider_id = stable_memory::get_node_provider(&node_id).unwrap_or(Principal::anonymous());
 
             NodeRewardsResponse {
                 node_id,
                 node_provider_id,
-                rewards_percent,
                 daily_node_metrics,
-                rewards_stats,
+                rewards_computation,
             }
         })
         .collect_vec()

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/lib.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/lib.rs
@@ -6,8 +6,8 @@ use trustworthy_node_metrics_types::types::{
     DailyNodeMetrics, NodeMetrics, NodeMetricsStored, NodeMetricsStoredKey, NodeRewardsArgs, NodeRewardsResponse, SubnetNodeMetricsArgs,
     SubnetNodeMetricsResponse,
 };
+mod computation_logger;
 mod metrics_manager;
-mod operations_tracker;
 mod rewards_manager;
 mod stable_memory;
 

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/operations_tracker.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/operations_tracker.rs
@@ -1,0 +1,79 @@
+use num_traits::{FromPrimitive, Num, ToPrimitive};
+use std::fmt::{self, Display};
+
+// Define a trait that will be used to store and manipulate numbers
+pub trait Number: Num + Copy + std::fmt::Debug + Display + ToPrimitive + FromPrimitive + std::iter::Sum + std::cmp::PartialOrd {}
+
+impl Number for u64 {}
+
+pub enum Operation<T> {
+    Set(T),
+    Add(Vec<T>),
+    Subtract(T, T),
+    Percent(T, T),
+}
+
+impl<T: Number> Operation<T> {
+    fn execute(&self) -> T {
+        match self {
+            Operation::Add(operators) => operators.iter().cloned().sum(),
+            Operation::Subtract(o1, o2) => *o1 - *o2,
+            Operation::Percent(o1, o2) => {
+                assert!(o1 <= o2, "Percent operation requires o1 <= o2");
+                assert!(!T::is_zero(o2), "Division by 0");
+                let numerator = o1.to_f64().unwrap();
+                let denominator = o2.to_f64().unwrap();
+
+                let result = (numerator / denominator * 100.0).round();
+                FromPrimitive::from_f64(result).unwrap()
+            }
+            Operation::Set(o1) => *o1,
+        }
+    }
+}
+
+impl<T: Number> fmt::Display for Operation<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (symbol, o1, o2) = match self {
+            Operation::Add(values) => {
+                return write!(
+                    f,
+                    "{} + {}",
+                    values[0],
+                    values[1..].iter().map(ToString::to_string).collect::<Vec<_>>().join(" + ")
+                )
+            }
+            Operation::Subtract(o1, o2) => ("-", o1, o2),
+            Operation::Percent(o1, o2) => return write!(f, "{} / {} * 100", o1, o2),
+            Operation::Set(o1) => return write!(f, "{}", o1),
+        };
+        write!(f, "{} {} {}", o1, symbol, o2)
+    }
+}
+
+pub struct OperationTracker<T: Number> {
+    reason: String,
+    operation: Operation<T>,
+    result: T,
+}
+
+impl<T: Number> OperationTracker<T> {
+    pub fn execute(reason: &str, operation: Operation<T>) -> (Self, T) {
+        let result = operation.execute();
+
+        let operation_executed = Self {
+            reason: reason.to_string(),
+            operation,
+            result,
+        };
+
+        (operation_executed, result)
+    }
+}
+
+impl<T: Number> fmt::Display for OperationTracker<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "{}: {} = {}", self.reason, self.operation, self.result)?;
+        Ok(())
+    }
+}

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -13,14 +13,14 @@ const MAX_FAILURE_RATE: Decimal = dec!(0.7);
 ///
 /// # Arguments
 ///
-/// * `failure_rate` - A reference to a `u64` value representing the failure rate.
+/// * `failure_rate` - A reference to a `Decimal` value representing the failure rate.
 ///
 /// # Returns
 ///
-/// * A `u64` value representing the rewards reduction, where:
+/// * A `Decimal` value representing the rewards reduction, where:
 ///   - `0` indicates no reduction (failure rate below the minimum threshold),
-///   - `100` indicates maximum reduction (failure rate above the maximum threshold),
-///   - A value between `0` and `100` represents a proportional reduction based on the failure rate.
+///   - `1` indicates maximum reduction (failure rate above the maximum threshold),
+///   - A value between `0` and `1` represents a proportional reduction based on the failure rate.
 ///
 /// # Explanation
 ///
@@ -29,8 +29,7 @@ const MAX_FAILURE_RATE: Decimal = dec!(0.7);
 /// 2. It then checks if the `failure_rate` is above the `MAX_FAILURE_RATE` -> maximum reduction in rewards.
 ///
 /// 3. If the `failure_rate` is within the defined range (`MIN_FAILURE_RATE` to `MAX_FAILURE_RATE`),
-///    the function calculates the reduction proportionally:
-///    - The reduction is calculated by normalizing the `failure_rate` within the range, resulting in a value between `0` and `100`.
+///    the function calculates the reduction proportionally.
 fn rewards_reduction_percent(failure_rate: &Decimal) -> (Vec<OperationExecutor>, Decimal) {
     const RF: &str = "Linear Reduction factor";
 
@@ -78,7 +77,7 @@ fn rewards_reduction_percent(failure_rate: &Decimal) -> (Vec<OperationExecutor>,
 ///
 /// # Returns
 ///
-/// * A `f64` value representing the rewards percentage left after the rewards reduction, rounded to two decimal places.
+/// * A `RewardsComputationResult`.
 ///
 /// # Explanation
 ///

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -10,14 +10,14 @@ const MAX_FAILURE_RATE: u64 = 70;
 ///
 /// # Arguments
 ///
-/// * `failure_rate` - A reference to a `f64` value representing the failure rate.
+/// * `failure_rate` - A reference to a `u64` value representing the failure rate.
 ///
 /// # Returns
 ///
-/// * A `f64` value representing the rewards reduction, where:
-///   - `0.0` indicates no reduction (failure rate below the minimum threshold),
-///   - `1.0` indicates maximum reduction (failure rate above the maximum threshold),
-///   - A value between `0.0` and `1.0` represents a proportional reduction based on the failure rate.
+/// * A `u64` value representing the rewards reduction, where:
+///   - `0` indicates no reduction (failure rate below the minimum threshold),
+///   - `100` indicates maximum reduction (failure rate above the maximum threshold),
+///   - A value between `0` and `100` represents a proportional reduction based on the failure rate.
 ///
 /// # Explanation
 ///
@@ -27,8 +27,8 @@ const MAX_FAILURE_RATE: u64 = 70;
 ///
 /// 3. If the `failure_rate` is within the defined range (`MIN_FAILURE_RATE` to `MAX_FAILURE_RATE`),
 ///    the function calculates the reduction proportionally:
-///    - The reduction is calculated by normalizing the `failure_rate` within the range, resulting in a value between `0.0` and `1.0`.
-fn rewards_reduction(failure_rate: &u64) -> (Vec<OperationTracker<u64>>, u64) {
+///    - The reduction is calculated by normalizing the `failure_rate` within the range, resulting in a value between `0` and `100`.
+fn rewards_reduction_percent(failure_rate: &u64) -> (Vec<OperationTracker<u64>>, u64) {
     if failure_rate < &MIN_FAILURE_RATE {
         let (operation, result) = OperationTracker::execute(
             &format!(
@@ -153,7 +153,7 @@ pub fn compute_rewards_percent(daily_metrics: &[DailyNodeMetrics]) -> RewardsCom
         OperationTracker::execute("Computing Total Failure Rate", Operation::Percent(overall_failed, overall_total));
     ops_tracker.push(operation);
 
-    let (operations, rewards_reduction) = rewards_reduction(&overall_failure_rate);
+    let (operations, rewards_reduction) = rewards_reduction_percent(&overall_failure_rate);
     for operation in operations {
         ops_tracker.push(operation);
     }

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -161,14 +161,20 @@ pub fn compute_rewards_percent(daily_metrics: &[DailyNodeMetrics]) -> RewardsCom
     let (operation, rewards_percent) = OperationTracker::execute("Total Rewards Percent", Operation::Subtract(100, rewards_reduction));
     ops_tracker.push(operation);
 
-    let computation_log = ops_tracker
+    let input_log = daily_metrics
+        .iter()
+        .map(|metric| metric.to_string()) // Convert each DailyNodeMetrics to string
+        .collect_vec()
+        .join("\n");
+
+    let operations_log = ops_tracker
         .iter()
         .enumerate() // Get both index and item
         .map(|(index, item)| format!("STEP {}: {}", index + 1, item)) // Format with index and item
         .collect_vec() // Collect into a Vec of Strings
         .join("\n");
 
-    println!("{}", computation_log);
+    let computation_log = format!("INPUT:\n{}\nREWARDS COMPUTATION LOG:\n\n{}", input_log, operations_log);
 
     RewardsComputationResult {
         rewards_percent,

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -31,13 +31,19 @@ const MAX_FAILURE_RATE: u64 = 70;
 fn rewards_reduction(failure_rate: &u64) -> (Vec<OperationTracker<u64>>, u64) {
     if failure_rate < &MIN_FAILURE_RATE {
         let (operation, result) = OperationTracker::execute(
-            &format!("No Reduction applied because {}% is less than {}% failure rate", *failure_rate, MIN_FAILURE_RATE),
+            &format!(
+                "No Reduction applied because {}% is less than {}% failure rate",
+                *failure_rate, MIN_FAILURE_RATE
+            ),
             Operation::Set(0),
         );
         (vec![operation], result)
     } else if failure_rate > &MAX_FAILURE_RATE {
         let (operation, result) = OperationTracker::execute(
-            &format!("Max reduction applied because {}% is over {}% failure rate", *failure_rate, MAX_FAILURE_RATE),
+            &format!(
+                "Max reduction applied because {}% is over {}% failure rate",
+                *failure_rate, MAX_FAILURE_RATE
+            ),
             Operation::Set(100),
         );
 
@@ -161,6 +167,8 @@ pub fn compute_rewards_percent(daily_metrics: &[DailyNodeMetrics]) -> RewardsCom
         .map(|(index, item)| format!("STEP {}: {}", index + 1, item)) // Format with index and item
         .collect_vec() // Collect into a Vec of Strings
         .join("\n");
+
+    println!("{}", computation_log);
 
     RewardsComputationResult {
         rewards_percent,

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/trustworthy-node-metrics.did
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/trustworthy-node-metrics.did
@@ -30,19 +30,24 @@ type DailyNodeMetrics = record {
 };
 
 type RewardsStats = record {
+
+};
+
+type RewardsComputationResult = record {
+  rewards_percent: nat64;
+  rewards_reduction: nat64;
   blocks_failed: nat64;
   blocks_proposed: nat64;
   blocks_total: nat64;
-  failure_rate: float64;
-  rewards_reduction: float64;
+  failure_rate: nat64;
+  computation_log: text;
 };
 
 type NodeRewardsResponse = record {
   node_id: principal;
   node_provider_id: principal;
-  rewards_percent: float64;
   daily_node_metrics: vec DailyNodeMetrics;
-  rewards_stats: RewardsStats;
+  rewards_computation: RewardsComputationResult;
 };
 
 type NodeRewardsArgs = record {

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/trustworthy-node-metrics.did
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/trustworthy-node-metrics.did
@@ -34,12 +34,12 @@ type RewardsStats = record {
 };
 
 type RewardsComputationResult = record {
-  rewards_percent: nat64;
-  rewards_reduction: nat64;
+  rewards_percent: float64;
+  rewards_reduction: float64;
   blocks_failed: nat64;
   blocks_proposed: nat64;
   blocks_total: nat64;
-  failure_rate: nat64;
+  failure_rate: float64;
   computation_log: text;
 };
 


### PR DESCRIPTION
1. Add logging at each step of the computation
2. Adapt test for this
3. Use int for representing `rewards_percent` `rewards_reduction`


    computation_log example:
    
```
INPUT:
timestamp_nanoseconds: 1, num_blocks_proposed: 10,  num_blocks_failed: 0
timestamp_nanoseconds: 2, num_blocks_proposed: 6,  num_blocks_failed: 4
timestamp_nanoseconds: 3, num_blocks_proposed: 7,  num_blocks_failed: 3

REWARDS COMPUTATION LOG:
STEP 1: Computing Total Failed Blocks: 0 + 4 + 3 = 7

STEP 2: Computing Total Proposed Blocks: 10 + 6 + 7 = 23

STEP 3: Computing Total Blocks: 7 + 23 = 30

STEP 4: Computing Total Failure Rate: 7 / 30 * 100 = 23

STEP 5: Linear Reduction Y change: 23 - 10 = 13

STEP 6: Linear Reduction X change: 70 - 10 = 60

STEP 7: Linear Reduction Percent: 13 / 60 * 100 = 22

STEP 8: Total Rewards Percent: 100 - 22 = 78
```