### PR TITLE
refactor: lazy git

### DIFF
--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -9,6 +9,7 @@ use std::{
 
 use ic_canisters::{governance::governance_canister_version, CanisterClient, IcAgentCanisterClient};
 use ic_management_backend::{
+    lazy_git::LazyGit,
     lazy_registry::{LazyRegistry, LazyRegistryImpl},
     proposal::ProposalAgent,
     registry::{local_registry_path, sync_local_store},
@@ -32,6 +33,7 @@ pub struct DreContext {
     registry: RefCell<Option<Arc<dyn LazyRegistry>>>,
     ic_admin: Option<Arc<IcAdminWrapper>>,
     runner: RefCell<Option<Rc<Runner>>>,
+    ic_repo: RefCell<Option<Arc<dyn LazyGit>>>,
     verbose_runner: bool,
     skip_sync: bool,
     ic_admin_path: Option<String>,
@@ -85,6 +87,7 @@ impl DreContext {
             skip_sync: args.no_sync,
             ic_admin_path,
             forum_post_link: args.forum_post_link.clone(),
+            ic_repo: RefCell::new(None),
         })
     }
 
@@ -232,6 +235,7 @@ impl DreContext {
             self.network().clone(),
             self.proposals_agent(),
             self.verbose_runner,
+            self.ic_repo.clone(),
         ));
         *self.runner.borrow_mut() = Some(runner.clone());
         runner

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -15,6 +15,7 @@ use futures::TryFutureExt;
 use futures_util::future::try_join;
 use ic_management_backend::health;
 use ic_management_backend::health::HealthStatusQuerier;
+use ic_management_backend::lazy_git::LazyGit;
 use ic_management_backend::lazy_git::LazyGitImpl;
 use ic_management_backend::lazy_registry::LazyRegistry;
 use ic_management_backend::proposal::ProposalAgent;

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -15,7 +15,7 @@ use futures::TryFutureExt;
 use futures_util::future::try_join;
 use ic_management_backend::health;
 use ic_management_backend::health::HealthStatusQuerier;
-use ic_management_backend::lazy_git::LazyGit;
+use ic_management_backend::lazy_git::LazyGitImpl;
 use ic_management_backend::lazy_registry::LazyRegistry;
 use ic_management_backend::proposal::ProposalAgent;
 use ic_management_backend::registry::ReleasesOps;
@@ -45,7 +45,7 @@ use crate::operations::hostos_rollout::NodeGroupUpdate;
 pub struct Runner {
     ic_admin: Arc<IcAdminWrapper>,
     registry: Arc<dyn LazyRegistry>,
-    ic_repo: RefCell<Option<Rc<LazyGit>>>,
+    ic_repo: RefCell<Option<Rc<LazyGitImpl>>>,
     network: Network,
     proposal_agent: ProposalAgent,
     verbose: bool,
@@ -63,13 +63,13 @@ impl Runner {
         }
     }
 
-    async fn ic_repo(&self) -> Rc<LazyGit> {
+    async fn ic_repo(&self) -> Rc<LazyGitImpl> {
         if let Some(ic_repo) = self.ic_repo.borrow().as_ref() {
             return ic_repo.clone();
         }
 
         let ic_repo = Rc::new(
-            LazyGit::new(
+            LazyGitImpl::new(
                 self.network.clone(),
                 self.registry
                     .elected_guestos()

--- a/rs/ic-management-backend/src/lazy_git.rs
+++ b/rs/ic-management-backend/src/lazy_git.rs
@@ -1,68 +1,83 @@
 use std::{
-    cell::RefCell,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
 
+use futures::future::BoxFuture;
 use ic_management_types::{Artifact, ArtifactReleases, Network, Release};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::{debug, error};
 use regex::Regex;
+use tokio::sync::RwLock;
 
 use crate::git_ic_repo::IcRepo;
 
+pub trait LazyGit: Send + Sync {
+    fn guestos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>>;
+
+    fn hostos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>>;
+}
+
 pub struct LazyGitImpl {
-    guestos_releases: RefCell<Option<Arc<ArtifactReleases>>>,
-    hostos_releases: RefCell<Option<Arc<ArtifactReleases>>>,
-    ic_repo: RefCell<IcRepo>,
+    guestos_releases: RwLock<Option<Arc<ArtifactReleases>>>,
+    hostos_releases: RwLock<Option<Arc<ArtifactReleases>>>,
+    ic_repo: RwLock<IcRepo>,
     network: Network,
     blessed_replica_versions: Vec<String>,
     elected_hostos_versions: Vec<String>,
 }
 
+impl LazyGit for LazyGitImpl {
+    fn guestos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>> {
+        Box::pin(async {
+            if let Some(releases) = self.guestos_releases.read().await.as_ref() {
+                return Ok(releases.to_owned());
+            }
+
+            self.update_releases().await?;
+            self.guestos_releases
+                .read()
+                .await
+                .as_ref()
+                .map(|n| n.to_owned())
+                .ok_or(anyhow::anyhow!("Failed to update releases"))
+        })
+    }
+
+    fn hostos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>> {
+        Box::pin(async {
+            if let Some(releases) = self.hostos_releases.read().await.as_ref() {
+                return Ok(releases.to_owned());
+            }
+
+            self.update_releases().await?;
+            self.hostos_releases
+                .read()
+                .await
+                .as_ref()
+                .map(|n| n.to_owned())
+                .ok_or(anyhow::anyhow!("Failed to update releases"))
+        })
+    }
+}
+
 impl LazyGitImpl {
     pub fn new(network: Network, blessed_replica_versions: Vec<String>, elected_hostos_versions: Vec<String>) -> anyhow::Result<Self> {
         Ok(Self {
-            guestos_releases: RefCell::new(None),
-            hostos_releases: RefCell::new(None),
-            ic_repo: RefCell::new(IcRepo::new()?),
+            guestos_releases: RwLock::new(None),
+            hostos_releases: RwLock::new(None),
+            ic_repo: RwLock::new(IcRepo::new()?),
             network,
             blessed_replica_versions,
             elected_hostos_versions,
         })
     }
 
-    pub async fn guestos_releases(&self) -> anyhow::Result<Arc<ArtifactReleases>> {
-        if let Some(releases) = self.guestos_releases.borrow().as_ref() {
-            return Ok(releases.to_owned());
-        }
-
-        self.update_releases().await?;
-        self.guestos_releases
-            .borrow()
-            .as_ref()
-            .map(|n| n.to_owned())
-            .ok_or(anyhow::anyhow!("Failed to update releases"))
-    }
-
-    pub async fn hostos_releases(&self) -> anyhow::Result<Arc<ArtifactReleases>> {
-        if let Some(releases) = self.hostos_releases.borrow().as_ref() {
-            return Ok(releases.to_owned());
-        }
-
-        self.update_releases().await?;
-        self.hostos_releases
-            .borrow()
-            .as_ref()
-            .map(|n| n.to_owned())
-            .ok_or(anyhow::anyhow!("Failed to update releases"))
-    }
-
     async fn update_releases(&self) -> anyhow::Result<()> {
         if !self.network.eq(&Network::mainnet_unchecked()?) {
-            *self.guestos_releases.borrow_mut() = Some(Arc::new(ArtifactReleases::new(Artifact::GuestOs)));
-            *self.hostos_releases.borrow_mut() = Some(Arc::new(ArtifactReleases::new(Artifact::HostOs)));
+            *self.guestos_releases.write().await = Some(Arc::new(ArtifactReleases::new(Artifact::GuestOs)));
+            *self.hostos_releases.write().await = Some(Arc::new(ArtifactReleases::new(Artifact::HostOs)));
             return Ok(());
         }
 
@@ -84,8 +99,8 @@ impl LazyGitImpl {
         // A HashMap from the git revision to the latest commit branch in which the
         // commit is present
         let mut commit_to_release: HashMap<String, Release> = HashMap::new();
+        let mut ic_repo = self.ic_repo.write().await;
         blessed_versions.into_iter().for_each(|commit_hash| {
-            let mut ic_repo = self.ic_repo.borrow_mut();
             match ic_repo.get_branches_with_commit(commit_hash) {
                 // For each commit get a list of branches that have the commit
                 Ok(branches) => {
@@ -126,8 +141,8 @@ impl LazyGitImpl {
         });
 
         for (blessed_versions, mut to_update, artifact_type) in [
-            (&self.blessed_replica_versions, self.guestos_releases.borrow_mut(), Artifact::GuestOs),
-            (&self.elected_hostos_versions, self.hostos_releases.borrow_mut(), Artifact::HostOs),
+            (&self.blessed_replica_versions, self.guestos_releases.write().await, Artifact::GuestOs),
+            (&self.elected_hostos_versions, self.hostos_releases.write().await, Artifact::HostOs),
         ] {
             let releases = blessed_versions
                 .iter()

--- a/rs/ic-management-backend/src/lazy_git.rs
+++ b/rs/ic-management-backend/src/lazy_git.rs
@@ -14,9 +14,9 @@ use tokio::sync::RwLock;
 use crate::git_ic_repo::IcRepo;
 
 pub trait LazyGit: Send + Sync {
-    fn guestos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>>;
+    fn guestos_releases(&self) -> BoxFuture<'_, anyhow::Result<Arc<ArtifactReleases>>>;
 
-    fn hostos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>>;
+    fn hostos_releases(&self) -> BoxFuture<'_, anyhow::Result<Arc<ArtifactReleases>>>;
 }
 
 pub struct LazyGitImpl {
@@ -29,7 +29,7 @@ pub struct LazyGitImpl {
 }
 
 impl LazyGit for LazyGitImpl {
-    fn guestos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>> {
+    fn guestos_releases(&self) -> BoxFuture<'_, anyhow::Result<Arc<ArtifactReleases>>> {
         Box::pin(async {
             if let Some(releases) = self.guestos_releases.read().await.as_ref() {
                 return Ok(releases.to_owned());
@@ -45,7 +45,7 @@ impl LazyGit for LazyGitImpl {
         })
     }
 
-    fn hostos_releases<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Arc<ArtifactReleases>>> {
+    fn hostos_releases(&self) -> BoxFuture<'_, anyhow::Result<Arc<ArtifactReleases>>> {
         Box::pin(async {
             if let Some(releases) = self.hostos_releases.read().await.as_ref() {
                 return Ok(releases.to_owned());

--- a/rs/ic-management-backend/src/lazy_git.rs
+++ b/rs/ic-management-backend/src/lazy_git.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 
 use crate::git_ic_repo::IcRepo;
 
-pub struct LazyGit {
+pub struct LazyGitImpl {
     guestos_releases: RefCell<Option<Arc<ArtifactReleases>>>,
     hostos_releases: RefCell<Option<Arc<ArtifactReleases>>>,
     ic_repo: RefCell<IcRepo>,
@@ -21,7 +21,7 @@ pub struct LazyGit {
     elected_hostos_versions: Vec<String>,
 }
 
-impl LazyGit {
+impl LazyGitImpl {
     pub fn new(network: Network, blessed_replica_versions: Vec<String>, elected_hostos_versions: Vec<String>) -> anyhow::Result<Self> {
         Ok(Self {
             guestos_releases: RefCell::new(None),


### PR DESCRIPTION
Another PR in the line of making `dre` more testable. With this included we should be able to easily mock fetching information about the branches and releases.