### PR TITLE
Refactor authentication detection.

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "98c4b087938d37a4ae4cd08aa4c609f2abde672bb6e51a11137bd24fa1b6b40d",
+  "checksum": "2c42277b10b758d02d577974e54b09d0e0b596963845dfadd0589edcabe3044a",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -6311,6 +6311,81 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "clio 0.3.5": {
+      "name": "clio",
+      "version": "0.3.5",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/clio/0.3.5/download",
+          "sha256": "b7fc6734af48458f72f5a3fa7b840903606427d98a710256e808f76a965047d9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "clio",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "clio",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "clap",
+            "clap-parse"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "clap 4.5.16",
+              "target": "clap"
+            },
+            {
+              "id": "is-terminal 0.4.13",
+              "target": "is_terminal"
+            },
+            {
+              "id": "tempfile 3.12.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "walkdir 2.5.0",
+              "target": "walkdir"
+            }
+          ],
+          "selects": {
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.157",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.42.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.3.5"
+      },
+      "license": "MIT"
+    },
     "colorchoice 1.0.2": {
       "name": "colorchoice",
       "version": "1.0.2",
@@ -7829,13 +7904,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cryptoki 0.3.1": {
+    "cryptoki 0.7.0": {
       "name": "cryptoki",
-      "version": "0.3.1",
+      "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cryptoki/0.3.1/download",
-          "sha256": "570006e51d08ec89ce5bbfdcf428ad96111636d524bf2447bee6377fd0e1d889"
+          "url": "https://static.crates.io/crates/cryptoki/0.7.0/download",
+          "sha256": "60d645cc2c5faf466571c0c752d39d8fbc2746773b2f043ac8f9cd73bec55db9"
         }
       },
       "targets": [
@@ -7857,6 +7932,10 @@
         "deps": {
           "common": [
             {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            },
+            {
               "id": "cryptoki-sys 0.1.8",
               "target": "cryptoki_sys"
             },
@@ -7867,6 +7946,10 @@
             {
               "id": "log 0.4.22",
               "target": "log"
+            },
+            {
+              "id": "secrecy 0.8.0",
+              "target": "secrecy"
             }
           ],
           "selects": {}
@@ -7875,13 +7958,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "derivative 2.2.0",
-              "target": "derivative"
+              "id": "paste 1.0.15",
+              "target": "paste"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.1"
+        "version": "0.7.0"
       },
       "license": "Apache-2.0"
     },
@@ -9464,53 +9547,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "derivative 2.2.0": {
-      "name": "derivative",
-      "version": "2.2.0",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/derivative/2.2.0/download",
-          "sha256": "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "derivative",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "derivative",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.86",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.37",
-              "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "2.2.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "derive_arbitrary 1.3.2": {
       "name": "derive_arbitrary",
       "version": "1.3.2",
@@ -10757,6 +10793,10 @@
               "target": "clap_complete"
             },
             {
+              "id": "clio 0.3.5",
+              "target": "clio"
+            },
+            {
               "id": "colored 2.1.0",
               "target": "colored"
             },
@@ -10765,7 +10805,7 @@
               "target": "comfy_table"
             },
             {
-              "id": "cryptoki 0.3.1",
+              "id": "cryptoki 0.7.0",
               "target": "cryptoki"
             },
             {
@@ -10915,6 +10955,10 @@
             {
               "id": "reqwest 0.12.7",
               "target": "reqwest"
+            },
+            {
+              "id": "secrecy 0.8.0",
+              "target": "secrecy"
             },
             {
               "id": "self_update 0.41.0",
@@ -42680,7 +42724,6 @@
             "printing",
             "proc-macro",
             "quote",
-            "visit",
             "visit-mut"
           ],
           "selects": {}
@@ -48163,6 +48206,121 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows-sys 0.42.0": {
+      "name": "windows-sys",
+      "version": "0.42.0",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-sys/0.42.0/download",
+          "sha256": "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "Win32",
+            "Win32_Foundation",
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-gnullvm": [
+              {
+                "id": "windows_aarch64_gnullvm 0.42.2",
+                "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.2",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "aarch64-uwp-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.2",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "i686-pc-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.2",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.2",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "i686-uwp-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.2",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-uwp-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.2",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "x86_64-pc-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.2",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-pc-windows-gnullvm": [
+              {
+                "id": "windows_x86_64_gnullvm 0.42.2",
+                "target": "windows_x86_64_gnullvm"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.2",
+                "target": "windows_x86_64_msvc"
+              }
+            ],
+            "x86_64-uwp-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.2",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-uwp-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.2",
+                "target": "windows_x86_64_msvc"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.42.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows-sys 0.48.0": {
       "name": "windows-sys",
       "version": "0.48.0",
@@ -48518,6 +48676,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_aarch64_gnullvm 0.42.2": {
+      "name": "windows_aarch64_gnullvm",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/0.42.2/download",
+          "sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_gnullvm 0.42.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.2"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_aarch64_gnullvm 0.48.5": {
       "name": "windows_aarch64_gnullvm",
       "version": "0.48.5",
@@ -48624,6 +48835,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_aarch64_msvc 0.42.2": {
+      "name": "windows_aarch64_msvc",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_aarch64_msvc/0.42.2/download",
+          "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_msvc 0.42.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.2"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_aarch64_msvc 0.48.5": {
       "name": "windows_aarch64_msvc",
       "version": "0.48.5",
@@ -48722,6 +48986,59 @@
         },
         "edition": "2021",
         "version": "0.52.6"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_i686_gnu 0.42.2": {
+      "name": "windows_i686_gnu",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_i686_gnu/0.42.2/download",
+          "sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_gnu 0.42.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -48889,6 +49206,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_i686_msvc 0.42.2": {
+      "name": "windows_i686_msvc",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_i686_msvc/0.42.2/download",
+          "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_msvc 0.42.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.2"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_i686_msvc 0.48.5": {
       "name": "windows_i686_msvc",
       "version": "0.48.5",
@@ -48987,6 +49357,59 @@
         },
         "edition": "2021",
         "version": "0.52.6"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_gnu 0.42.2": {
+      "name": "windows_x86_64_gnu",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_x86_64_gnu/0.42.2/download",
+          "sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnu 0.42.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -49101,6 +49524,59 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "windows_x86_64_gnullvm 0.42.2": {
+      "name": "windows_x86_64_gnullvm",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/0.42.2/download",
+          "sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnullvm 0.42.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.2"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "windows_x86_64_gnullvm 0.48.5": {
       "name": "windows_x86_64_gnullvm",
       "version": "0.48.5",
@@ -49199,6 +49675,59 @@
         },
         "edition": "2021",
         "version": "0.52.6"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_msvc 0.42.2": {
+      "name": "windows_x86_64_msvc",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_x86_64_msvc/0.42.2/download",
+          "sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_msvc 0.42.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -50904,6 +51433,7 @@
     "aarch64-unknown-linux-gnu": [
       "aarch64-unknown-linux-gnu"
     ],
+    "aarch64-uwp-windows-msvc": [],
     "arm-unknown-linux-gnueabi": [
       "arm-unknown-linux-gnueabi"
     ],
@@ -51643,6 +52173,8 @@
     "i686-unknown-linux-gnu": [
       "i686-unknown-linux-gnu"
     ],
+    "i686-uwp-windows-gnu": [],
+    "i686-uwp-windows-msvc": [],
     "powerpc-unknown-linux-gnu": [
       "powerpc-unknown-linux-gnu"
     ],
@@ -51692,6 +52224,8 @@
     ],
     "x86_64-unknown-none": [
       "x86_64-unknown-none"
-    ]
+    ],
+    "x86_64-uwp-windows-gnu": [],
+    "x86_64-uwp-windows-msvc": []
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,14 +1563,16 @@ dependencies = [
 
 [[package]]
 name = "cryptoki"
-version = "0.3.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570006e51d08ec89ce5bbfdcf428ad96111636d524bf2447bee6377fd0e1d889"
+checksum = "60d645cc2c5faf466571c0c752d39d8fbc2746773b2f043ac8f9cd73bec55db9"
 dependencies = [
+ "bitflags 1.3.2",
  "cryptoki-sys",
- "derivative",
  "libloading 0.7.4",
  "log",
+ "paste",
+ "secrecy",
 ]
 
 [[package]]
@@ -1889,17 +1891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2183,7 @@ dependencies = [
  "regex",
  "registry-canister",
  "reqwest",
+ "secrecy",
  "self_update",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "clio"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7fc6734af48458f72f5a3fa7b840903606427d98a710256e808f76a965047d9"
+dependencies = [
+ "cfg-if",
+ "clap 4.5.16",
+ "is-terminal",
+ "libc",
+ "tempfile",
+ "walkdir",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2148,7 @@ dependencies = [
  "clap 4.5.16",
  "clap-num",
  "clap_complete",
+ "clio",
  "colored",
  "comfy-table",
  "cryptoki",
@@ -9566,6 +9582,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -9624,6 +9655,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -9636,6 +9673,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -9645,6 +9688,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9666,6 +9715,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -9675,6 +9730,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9690,6 +9751,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -9699,6 +9766,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ description = "Tooling for managing the Internet Computer"
 documentation = "https://github.com/dfinity/dre/"
 
 [workspace.dependencies]
-actix = "0.13.5"
 actix-web = { version = "4.9.0", default-features = false, features = [
     "compress-gzip",
     "macros",
@@ -44,10 +43,7 @@ actix-web = { version = "4.9.0", default-features = false, features = [
 actix-rt = "2.10.0"
 ahash = "0.8.11"
 anyhow = "1.0.86"
-assert_matches = "1.5.0"
 async-recursion = "1.1.1"
-async-timer = "0.7.4"
-async-trait = "0.1.82"
 axum-otel-metrics = "0.8.1"
 axum = "0.7.5"
 backoff = { version = "0.4.0", features = ["tokio"] }
@@ -67,41 +63,30 @@ clap = { version = "4.5", features = [
     "string",
     "cargo",
 ] }
+clio = { version = "0.3.5", features = ["clap", "clap-parse"] }
 colored = "2.1.0"
-counter = "0.6.0"
 comfy-table = "7.1.1"
 crossbeam = "0.8.4"
 crossbeam-channel = "0.5.13"
 cryptoki = "0.3.1"
-csv = "1.3.0"
 custom_error = "1.9.2"
 decentralization = { path = "rs/decentralization" }
-trustworthy-node-metrics = { path = "rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics" }
 trustworthy-node-metrics-types = { path = "rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types" }
-derive_builder = "0.20.1"
-derive_more = "1"
 dialoguer = "0.11.0"
 dirs = "5.0.1"
 dotenv = "0.15.0"
 base64 = "0.22.1"
-easy-parallel = "3.3.1"
 edit = "0.1.5"
-either = "1.13.0"
-enum-map = "1.1.1"
 env_logger = "0.11.5"
 erased-serde = "0.4.5"
-exitcode = "1.1.2"
 flate2 = "1.0.33"
-float-ord = "0.3.2"
 fs-err = "2.11.0"
 fs2 = "0.4.3"
 futures = "0.3.30"
-futures-core = "0.3.30"
 futures-util = "0.3.30"
 hex = "0.4.3"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
-hyper = { version = "1.4.1" }
 ic-agent = "0.37.1"
 octocrab = "0.39.0"
 self_update = { version = "0.41.0", features = ["archive-tar"] }
@@ -115,8 +100,6 @@ ic-cdk = { git = "https://github.com/dfinity/cdk-rs.git", rev = "3e54016734c8f73
 ic-config = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
 ic-crypto-utils-threshold-sig-der = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
 ic-http-endpoints-metrics = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
-ic-identity-hsm = "0.37.0"
-ic-interfaces = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
 ic-interfaces-registry = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
 ic-management-backend = { path = "rs/ic-management-backend" }
 ic-management-canister-types = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
@@ -146,7 +129,6 @@ ic-sns-wasm = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee
 cycles-minting-canister = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
 ic-transport-types = "0.37.1"
 ic-utils = "0.37.0"
-include_dir = "0.7.4"
 itertools = "0.13.0"
 keyring = { version = "3.2.1", features = [
     "apple-native",
@@ -154,10 +136,8 @@ keyring = { version = "3.2.1", features = [
 ] }
 lazy_static = "1.5.0"
 log = "0.4.22"
-lru = "0.12.4"
 num-traits = "0.2"
 opentelemetry = { version = "0.22.0", features = ["metrics"] }
-phantom_newtype = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
 pkcs11 = "0.5.0"
 pretty_assertions = "1.4.0"
 pretty_env_logger = "0.5.0"
@@ -166,7 +146,6 @@ prometheus = { version = "0.13.4", features = ["process"] }
 prost = "0.12"
 rand = { version = "0.8.5", features = ["std_rng"] }
 rand_seeder = "0.3.0"
-rayon = "1.10.0"
 regex = "1.10.6"
 registry-canister = { git = "https://github.com/dfinity/ic.git", rev = "0ca139ca39dfee21c8ca75e7fe37422df65e4b96" }
 reqwest = { version = "0.12", default-features = false, features = [
@@ -174,13 +153,10 @@ reqwest = { version = "0.12", default-features = false, features = [
     "blocking",
 ] }
 retry = "2.0.0"
-reverse_geocoder = "4.1.1"
-ring = "0.17.8"
 rstest = { version = "0.22.0", default-features = false }
 rust_decimal = "1.36.0" # or the latest version
 rust_decimal_macros = "1.36.0" # optional, for using macros
 serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0.209"
 serde_json = "1.0.127"
 serde_yaml = "0.9.34"
 shlex = "1.3.0"
@@ -194,7 +170,6 @@ slog = { version = "2.7.0", features = [
     "release_max_level_debug",
     "release_max_level_trace",
 ] }
-socket2 = "0.5.7"
 spinners = "4.1.1"
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
@@ -205,8 +180,6 @@ thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-util = "0.7.11"
 url = "2.5.2"
-urlencoding = "2.1.3"
-warp = "0.3"
 wiremock = "0.6.1"
 human_bytes = "0.4"
 headless_chrome = { version = "1.0.13", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ colored = "2.1.0"
 comfy-table = "7.1.1"
 crossbeam = "0.8.4"
 crossbeam-channel = "0.5.13"
-cryptoki = "0.3.1"
+cryptoki = "0.7.0"
 custom_error = "1.9.2"
 decentralization = { path = "rs/decentralization" }
 trustworthy-node-metrics-types = { path = "rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-types" }

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -73,6 +73,7 @@ keyring = { workspace = true }
 comfy-table = { workspace = true }
 human_bytes = { workspace = true }
 headless_chrome = { workspace = true }
+clio = { workspace = true }
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -56,6 +56,7 @@ regex = { workspace = true }
 registry-canister = { workspace = true }
 reqwest = { workspace = true }
 self_update = { workspace = true }
+secrecy = { version = "0.8.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/rs/cli/src/auth.rs
+++ b/rs/cli/src/auth.rs
@@ -116,7 +116,8 @@ impl Auth {
                 // and must fail upfront if autodetection fails, and other operations do not require
                 // authentication and should not even attempt to perform HSM autodetection.
                 // Ideally that means the operations that require authentication, and only those
-                // operations, accept the command line arguments that create authentication.
+                // operations, accept the command line arguments that create authentication --
+                // other operations should outright reject the arguments.
                 (None, None, None) => Ok(Self::detect_hsm_auth()?.map_or(Auth::Anonymous, |a| a)),
                 _ => Err(anyhow::anyhow!("When specifying either --hsm-slot, --hsm-pin or --hsm-key-id, autodetection is disabled and all three arguments must be specified")),
             },

--- a/rs/cli/src/auth.rs
+++ b/rs/cli/src/auth.rs
@@ -1,19 +1,25 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use anyhow::anyhow;
 use clio::InputPath;
+use cryptoki::object::AttributeInfo;
+use cryptoki::session::Session;
 use cryptoki::{
     context::{CInitializeArgs, Pkcs11},
-    session::{SessionFlags, UserType},
+    object::{Attribute, AttributeType},
+    session::UserType,
+    slot::{Slot, TokenInfo},
 };
 use dialoguer::{console::Term, theme::ColorfulTheme, Password, Select};
 use ic_canisters::governance::GovernanceCanisterWrapper;
 use ic_canisters::IcAgentCanisterClient;
 use ic_management_types::Network;
 use keyring::{Entry, Error};
-use log::info;
+use log::{info, warn};
+use secrecy::SecretString;
 
-use crate::commands::{AuthOpts, HsmOpts};
+use crate::commands::{AuthOpts, HsmOpts, HsmParams};
 
 #[derive(Clone, Debug)]
 pub struct Neuron {
@@ -31,6 +37,7 @@ impl Neuron {
             Some(n) => n,
             None => auth.auto_detect_neuron_id(network.get_nns_urls()).await?,
         };
+        info!("Identifying as neuron ID {}", neuron_id);
         Ok(Self {
             auth,
             neuron_id,
@@ -49,7 +56,10 @@ impl Neuron {
         vec![]
     }
 
+    // FIXME: there should be no unchecked anything.
+    // Caller must be able to bubble up the error of the file not existing there.
     pub fn automation_neuron_unchecked() -> Self {
+        info!("Constructing neuron using the release automation private key");
         Self {
             auth: Auth::Keyfile {
                 path: dirs::home_dir().unwrap().join(RELEASE_AUTOMATION_DEFAULT_PRIVATE_KEY_PEM),
@@ -60,6 +70,7 @@ impl Neuron {
     }
 
     pub fn anonymous_neuron() -> Self {
+        info!("Constructing anonymous neuron (ID 0)");
         Self {
             auth: Auth::Anonymous,
             neuron_id: 0,
@@ -104,74 +115,9 @@ impl Auth {
         }
     }
 
-    fn detect_hsm_auth(hsm_pin: Option<String>) -> anyhow::Result<Self> {
-        info!("Detecting HSM devices");
-        let ctx = Pkcs11::new(Self::pkcs11_lib_path()?)?;
-        ctx.initialize(CInitializeArgs::OsThreads)?;
-        for slot in ctx.get_slots_with_token()? {
-            let info = ctx.get_slot_info(slot)?;
-            if info.slot_description().starts_with("Nitrokey Nitrokey HSM") {
-                let key_id = format!("hsm-{}-{}", info.slot_description(), info.manufacturer_id());
-                let pin_entry = Entry::new("dre-tool-hsm-pin", &key_id)?;
-                let pin = match hsm_pin {
-                    Some(pin) => pin,
-                    None => match pin_entry.get_password() {
-                        // TODO: Remove the old keyring entry search ("release-cli") after August 1st, 2024
-                        Err(Error::NoEntry) => match Entry::new("release-cli", &key_id) {
-                            Err(Error::NoEntry) => Password::new().with_prompt("Please enter the HSM PIN: ").interact()?,
-                            Ok(pin_entry) => pin_entry.get_password()?,
-                            Err(e) => return Err(anyhow::anyhow!("Failed to get pin from keyring: {}", e)),
-                        },
-                        Ok(pin) => pin,
-                        Err(e) => return Err(anyhow::anyhow!("Failed to get pin from keyring: {}", e)),
-                    },
-                };
-
-                let mut flags = SessionFlags::new();
-                flags.set_serial_session(true);
-                let session = ctx.open_session_no_callback(slot, flags).unwrap();
-                session.login(UserType::User, Some(&pin))?;
-                info!("HSM login successful");
-                pin_entry.set_password(&pin)?;
-                let detected = Some(Auth::Hsm {
-                    pin,
-                    slot: slot.id(),
-                    key_id: "01".to_string(),
-                });
-                match &detected {
-                    Some(x) => match x {
-                        Auth::Anonymous => info!("Detected anonymous authentication"),
-                        Auth::Keyfile { path } => info!("Detected authentication with private key file {}", path.display()),
-                        Auth::Hsm { slot, key_id, .. } => info!("Using detected HSM slot {} with key ID {}", slot, key_id),
-                    },
-                    None => info!("Detected no authentication, falling back to anonymous"),
-                };
-                return Ok(detected.map_or(Auth::Anonymous, |a| a));
-            }
-        }
-        info!("No HSM detected -- continuing anonymously");
-        Ok(Auth::Anonymous)
-    }
-
-    pub async fn auto(hsm_pin: Option<String>) -> anyhow::Result<Self> {
-        tokio::task::spawn_blocking(|| Self::detect_hsm_auth(hsm_pin)).await?
-    }
-
-    pub async fn pem(private_key_pem: PathBuf) -> anyhow::Result<Self> {
-        // Check path exists.  This blocks.
-        let t = tokio::task::spawn_blocking(move || {
-            let inp = InputPath::new(&private_key_pem);
-            match inp {
-                Ok(inp) => Ok(inp.path().to_path_buf()),
-                Err(e) => Err(e),
-            }
-        })
-        .await?;
-        Ok(Self::Keyfile { path: t? })
-    }
-
     async fn auto_detect_neuron_id(&self, nns_urls: &[url::Url]) -> anyhow::Result<u64> {
-        let url = nns_urls.first().ok_or(anyhow::anyhow!("No nns urls provided"))?.to_owned();
+        // FIXME: why do we even take multiple URLs if only the first one is ever used?
+        let url = nns_urls.first().ok_or(anyhow::anyhow!("No NNS URLs provided"))?.to_owned();
         let client = match self {
             Auth::Hsm { pin, slot, key_id } => {
                 let pin_clone = pin.clone();
@@ -187,7 +133,7 @@ impl Auth {
         let neuron_ids = response.neuron_infos.keys().copied().collect::<Vec<_>>();
         match neuron_ids.len() {
             0 => Err(anyhow::anyhow!(
-                "HSM doesn't control any neurons. Response fro governance canister: {:?}",
+                "Hardware security module doesn't control any neurons. Response from governance canister: {:?}",
                 response
             )),
             1 => Ok(neuron_ids[0]),
@@ -200,6 +146,192 @@ impl Auth {
         }
     }
 
+    fn detect_hsm_auth(maybe_pin: Option<String>, maybe_slot: Option<u64>, maybe_key_id: Option<u8>) -> anyhow::Result<Self> {
+        if maybe_slot.is_none() && maybe_key_id.is_none() {
+            info!("Scanning hardware security module devices");
+        }
+        if let Some(slot) = &maybe_slot {
+            info!("Probing hardware security module in slot {}", slot);
+        }
+        if let Some(key_id) = &maybe_key_id {
+            info!("Limiting key scan to keys with ID {}", key_id);
+        }
+
+        let ctx = Pkcs11::new(Self::pkcs11_lib_path()?)?;
+        ctx.initialize(CInitializeArgs::OsThreads)?;
+        for slot in ctx.get_slots_with_token()? {
+            let info = ctx.get_slot_info(slot)?;
+            let token_info = ctx.get_token_info(slot)?;
+            if info.slot_description().starts_with("Nitrokey Nitrokey HSM") && maybe_slot.is_none() || (maybe_slot.unwrap() == slot.id()) {
+                let session = ctx.open_ro_session(slot)?;
+                let key_id = match Auth::find_key_id_in_slot_session(&session, maybe_key_id)? {
+                    Some((key_id, label)) => {
+                        info!(
+                            "Found key with ID {} ({}) in slot {}",
+                            key_id,
+                            match label {
+                                Some(label) => format!("labeled {}", label),
+                                None => "without label".to_string(),
+                            },
+                            slot.id()
+                        );
+                        key_id
+                    }
+                    None => {
+                        if maybe_slot.is_some() && maybe_key_id.is_some() {
+                            // We have been asked to be very specific.  Fail fast,
+                            // instead of falling back to Auth::Anonymous.
+                            return Err(anyhow!(
+                                "Could not find a key ID {} within hardware security module in slot {}",
+                                maybe_key_id.unwrap(),
+                                slot.id()
+                            ));
+                        } else {
+                            // Let's try the next slot just in case.
+                            continue;
+                        }
+                    }
+                };
+                let memo_key: String = format!("hsm-{}-{}", info.slot_description(), info.manufacturer_id());
+                let pin = Auth::get_or_prompt_pin_checked_for_slot(&session, maybe_pin, slot, token_info, &memo_key)?;
+                let detected = Some(Auth::Hsm {
+                    pin,
+                    slot: slot.id(),
+                    key_id: format!("{}", key_id),
+                });
+                info!("Using key ID {} of hardware security module in slot {}", key_id, slot);
+                return Ok(detected.map_or(Auth::Anonymous, |a| a));
+            }
+        }
+        if maybe_slot.is_none() && maybe_key_id.is_none() {
+            info!("No hardware security module detected -- falling back to anonymous operations");
+        } else {
+            return Err(anyhow!(
+                "No hardware security module detected{}{}",
+                match maybe_slot {
+                    None => "".to_string(),
+                    Some(slot) => format!(" in slot {}", slot),
+                },
+                match maybe_key_id {
+                    None => "".to_string(),
+                    Some(key_id) => format!(" that contains a key ID {}", key_id),
+                }
+            ));
+        }
+        Ok(Auth::Anonymous)
+    }
+
+    /// Finds the key ID in a slot.  If a key ID is specified,
+    /// then the search is limited to that key ID.  If not, then
+    /// the first key that has an ID and is for a token is returned.
+    /// If a key is found, this function returns Some, with a tuple of
+    /// the found key ID, and possibly the label assigned to said key ID
+    /// (None if no / invalid label).
+    fn find_key_id_in_slot_session(session: &Session, key_id: Option<u8>) -> anyhow::Result<Option<(u8, Option<String>)>> {
+        let token_types = vec![AttributeType::Token, AttributeType::Id];
+        let label_types = vec![AttributeType::Label];
+        let objects = session.find_objects(&[])?;
+        for hnd in objects.iter() {
+            if let [AttributeInfo::Available(_), AttributeInfo::Available(_)] = session.get_attribute_info(*hnd, &token_types)?[0..token_types.len()]
+            {
+                // Object may be a token and has an ID.
+                if let [Attribute::Token(true), Attribute::Id(token_id)] = &session.get_attributes(*hnd, &token_types)?[0..token_types.len()] {
+                    // Object is a token, and we have extracted the ID.
+                    if token_id.len() > 0 && (key_id.is_none() || token_id[0] == key_id.unwrap()) {
+                        let found_key_id = token_id[0];
+                        let mut label: Option<String> = None;
+                        if let [AttributeInfo::Available(_)] = &session.get_attribute_info(*hnd, &label_types)?[0..label_types.len()] {
+                            // Object has a label.
+                            if let [Attribute::Label(token_label)] = &session.get_attributes(*hnd, &label_types)?[0..label_types.len()] {
+                                // We have extracted the label; we make a copy of it.
+                                label = match String::from_utf8(token_label.clone()) {
+                                    Ok(label) => Some(label),
+                                    Err(_) => None,
+                                }
+                            }
+                        }
+                        return Ok(Some((found_key_id, label)));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn get_or_prompt_pin_checked_for_slot(
+        session: &Session,
+        maybe_pin: Option<String>,
+        slot: Slot,
+        token_info: TokenInfo,
+        memo_key: &String,
+    ) -> anyhow::Result<String> {
+        if token_info.user_pin_locked() {
+            return Err(anyhow!("The PIN for the token stored in slot {} is locked", slot.id()));
+        }
+        if token_info.user_pin_final_try() {
+            warn!(
+                "The PIN for the token stored in slot {} is at its last try, and if this operation fails, the token will be locked",
+                slot.id()
+            );
+        }
+        let ret = Ok(match maybe_pin {
+            Some(pin) => {
+                let sekrit = SecretString::from_str(pin.as_str()).unwrap();
+                session.login(UserType::User, Some(&sekrit))?;
+                pin
+            }
+            None => {
+                let pin_entry = Entry::new("dre-tool-hsm-pin", &memo_key)?;
+                let tentative_pin = match pin_entry.get_password() {
+                    // TODO: Remove the old keyring entry search ("release-cli") after August 1st, 2024
+                    Err(Error::NoEntry) => match Entry::new("release-cli", &memo_key) {
+                        Err(Error::NoEntry) => Password::new()
+                            .with_prompt("Please enter the hardware security module PIN: ")
+                            .interact()?,
+                        Ok(pin_entry) => pin_entry.get_password()?,
+                        Err(e) => return Err(anyhow::anyhow!("Problem getting PIN from keyring: {}", e)),
+                    },
+                    Ok(pin) => pin,
+                    Err(e) => return Err(anyhow::anyhow!("Problem getting from keyring: {}", e)),
+                };
+                let sekrit = SecretString::from_str(tentative_pin.as_str()).unwrap();
+                match session.login(UserType::User, Some(&sekrit)) {
+                    Ok(_) => {
+                        pin_entry.set_password(&tentative_pin)?;
+                        tentative_pin
+                    }
+                    Err(e) => {
+                        pin_entry.delete_credential()?;
+                        return Err(anyhow!("Hardware security module PIN incorrect ({})", e));
+                    }
+                }
+            }
+        });
+        info!("Hardware security module PIN correct");
+        ret
+    }
+
+    /// Create an Auth that automatically detects an HSM.  Falls back to
+    /// anonymous authentication if no HSM is detected.  Prompts the user
+    /// for a PIN if no PIN is specified and the HSM needs to be unlocked.
+    /// Caller can optionally limit search to a specific slot or key ID.
+    pub async fn auto(hsm_pin: Option<String>, hsm_slot: Option<u64>, hsm_key_id: Option<u8>) -> anyhow::Result<Self> {
+        tokio::task::spawn_blocking(move || Self::detect_hsm_auth(hsm_pin, hsm_slot, hsm_key_id)).await?
+    }
+
+    pub async fn pem(private_key_pem: PathBuf) -> anyhow::Result<Self> {
+        // Check path exists.  This blocks.
+        let t = tokio::task::spawn_blocking(move || {
+            let inp = InputPath::new(&private_key_pem);
+            match inp {
+                Ok(inp) => Ok(inp.path().to_path_buf()),
+                Err(e) => Err(e),
+            }
+        })
+        .await?;
+        Ok(Self::Keyfile { path: t? })
+    }
+
     pub(crate) async fn from_auth_opts(auth_opts: AuthOpts) -> Result<Self, anyhow::Error> {
         match &auth_opts {
             // Private key case.
@@ -210,28 +342,16 @@ impl Auth {
                 info!("Using requested private key file {}", private_key_pem.path());
                 Auth::pem(private_key_pem.path().to_path_buf()).await
             }
-            // Full PIN, slot and key case.
+            // Slot and key case.
+            // Also autodetect case.
             AuthOpts {
                 private_key_pem: _,
-                hsm_opts: HsmOpts {
-                    hsm_pin,
-                    hsm_params: Some(hsm_params),
-                },
-            } => {
-                info!("Using requested HSM slot {} with key ID {}", hsm_params.hsm_slot, hsm_params.hsm_key_id);
-                Ok(Auth::Hsm {
-                    pin: hsm_pin.clone().expect("PIN must have been set because the other HSM parameters were set"),
-                    slot: hsm_params.hsm_slot,
-                    key_id: hsm_params.hsm_key_id.clone(),
-                })
-            }
-            AuthOpts {
-                private_key_pem: _,
-                hsm_opts: HsmOpts {
-                    hsm_pin: pin,
-                    hsm_params: None,
-                },
-            } => Auth::auto(pin.clone()).await,
+                hsm_opts:
+                    HsmOpts {
+                        hsm_pin: pin,
+                        hsm_params: HsmParams { hsm_slot, hsm_key_id },
+                    },
+            } => Auth::auto(pin.clone(), hsm_slot.clone(), hsm_key_id.clone()).await,
         }
     }
 }

--- a/rs/cli/src/auth.rs
+++ b/rs/cli/src/auth.rs
@@ -105,7 +105,7 @@ impl Auth {
         hsm_key_id: Option<String>,
     ) -> anyhow::Result<Self> {
         match private_key_pem {
-            Some(tentative_path) => match tentative_path.exists() {
+            Some(tentative_path) => match tentative_path.is_file() {
                 true => Ok(Auth::Keyfile { path: tentative_path }),
                 false => Err(anyhow::anyhow!("Invalid private key file path: {}", tentative_path.display())),
             },

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -51,6 +51,7 @@ pub mod upgrade;
 mod version;
 mod vote;
 
+/// HSM authentication parameters
 #[derive(ClapArgs, Debug, Clone)]
 pub struct HsmParams {
     /// Slot that HSM key uses, can be read with pkcs11-tool
@@ -72,10 +73,10 @@ pub struct HsmParams {
     pub hsm_key_id: String,
 }
 
-// Stupid clap does not let me define this
-// and the below struct as enums.
-// https://github.com/clap-rs/clap/issues/2621
 /// HSM authentication arguments
+/// These comprise an optional PIN and optional parameters.
+/// The PIN is used during autodetection if the optional
+/// parameters are missing.
 #[derive(ClapArgs, Debug, Clone)]
 pub struct HsmOpts {
     /// Pin for the HSM key used for submitting proposals
@@ -94,9 +95,14 @@ pub struct HsmOpts {
     pub hsm_params: Option<HsmParams>,
 }
 
-// Stupid clap does not let me define this
-// and the above struct as enums.
-// https://github.com/clap-rs/clap/issues/2621
+// The following should ideally be defined in terms of an Enum
+// as there is no conceivable scenario in which both a PEM file
+// and a set of HSM options can be used by the program.
+// Sadly, until ticket
+//   https://github.com/clap-rs/clap/issues/2621
+// is fixed, we cannot do this, and we must use a struct instead.
+// Note that group(multiple = false) has no effect, and therefore
+// we have to use conflicts and requires to specify option deps.
 #[derive(ClapArgs, Debug, Clone)]
 #[group(multiple = false)]
 /// Authentication arguments

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -55,21 +55,13 @@ mod vote;
 pub(crate) struct HsmParams {
     /// Slot that HSM key uses, can be read with pkcs11-tool
     #[clap(required = false,
-        requires_all = ["hsm_slot","hsm_key_id", "hsm_pin"],
         conflicts_with = "private_key_pem",
         long, value_parser=maybe_hex::<u64>, global = true, env = "HSM_SLOT")]
-    pub(crate) hsm_slot: u64,
+    pub(crate) hsm_slot: Option<u64>,
 
     /// HSM Key ID, can be read with pkcs11-tool
-    #[clap(
-        required = false,
-        requires_all = ["hsm_slot","hsm_key_id", "hsm_pin"],
-        conflicts_with = "private_key_pem",
-        long,
-        global = true,
-        env = "HSM_KEY_ID"
-    )]
-    pub(crate) hsm_key_id: String,
+    #[clap(required = false, conflicts_with = "private_key_pem", long, global = true, env = "HSM_KEY_ID")]
+    pub(crate) hsm_key_id: Option<u8>,
 }
 
 /// HSM authentication arguments
@@ -91,7 +83,7 @@ pub(crate) struct HsmOpts {
     )]
     pub(crate) hsm_pin: Option<String>,
     #[clap(flatten)]
-    pub(crate) hsm_params: Option<HsmParams>,
+    pub(crate) hsm_params: HsmParams,
 }
 
 // The following should ideally be defined in terms of an Enum

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -157,7 +157,7 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
 
     /// Don't sync with the registry
     ///
-    /// Useful for when the nns is unreachable
+    /// Useful for when the NNS is unreachable
     #[clap(long)]
     pub no_sync: bool,
 

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -60,7 +60,7 @@ pub(crate) struct HsmParams {
     pub(crate) hsm_slot: Option<u64>,
 
     /// HSM Key ID, can be read with pkcs11-tool
-    #[clap(required = false, conflicts_with = "private_key_pem", long, global = true, env = "HSM_KEY_ID")]
+    #[clap(required = false, conflicts_with = "private_key_pem", long, value_parser=maybe_hex::<u8>, global = true, env = "HSM_KEY_ID")]
     pub(crate) hsm_key_id: Option<u8>,
 }
 

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -20,7 +20,7 @@ use log::info;
 use url::Url;
 
 use crate::{
-    auth::{Auth, Neuron},
+    auth::{hsm_key_id_to_string, Auth, Neuron},
     commands::{Args, ExecutableCommand, IcAdminRequirement},
     ic_admin::{download_ic_admin, should_update_ic_admin, IcAdmin, IcAdminImpl},
     runner::Runner,
@@ -209,7 +209,7 @@ impl DreContext {
         match &self.ic_admin {
             Some(a) => match &a.neuron().auth {
                 crate::auth::Auth::Hsm { pin, slot, key_id } => {
-                    IcAgentCanisterClient::from_hsm(pin.to_string(), *slot, key_id.to_string(), nns_url.to_owned(), lock)
+                    IcAgentCanisterClient::from_hsm(pin.to_string(), *slot, hsm_key_id_to_string(*key_id), nns_url.to_owned(), lock)
                 }
                 crate::auth::Auth::Keyfile { path } => IcAgentCanisterClient::from_key_file(path.into(), nns_url.to_owned()),
                 crate::auth::Auth::Anonymous => IcAgentCanisterClient::from_anonymous(nns_url.to_owned()),

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -96,7 +96,7 @@ impl DreContext {
             ic_admin_path,
             forum_post_link: forum_post_link.clone(),
             ic_repo: RefCell::new(None),
-            dry_run: dry_run,
+            dry_run,
         })
     }
 

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -40,6 +40,7 @@ pub struct DreContext {
     skip_sync: bool,
     ic_admin_path: Option<String>,
     forum_post_link: Option<String>,
+    dry_run: bool,
 }
 
 impl DreContext {
@@ -95,6 +96,7 @@ impl DreContext {
             ic_admin_path,
             forum_post_link: forum_post_link.clone(),
             ic_repo: RefCell::new(None),
+            dry_run: dry_run,
         })
     }
 
@@ -195,6 +197,10 @@ impl DreContext {
 
     pub fn network(&self) -> &Network {
         &self.network
+    }
+
+    pub fn is_dry_run(&self) -> bool {
+        self.dry_run
     }
 
     /// Uses `ic_agent::Agent`

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -64,12 +64,12 @@ impl DreContext {
                     (
                         AuthOpts {
                             private_key_pem: None,
-                            hsm_opts: None,
+                            hsm_opts: opts,
                         },
                         true,
                     ) => AuthOpts {
                         private_key_pem: Some(staging_path.unwrap()),
-                        hsm_opts: None,
+                        hsm_opts: opts.clone(),
                     },
                     _ => args.auth_opts.clone(),
                 },

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
     dotenv().ok();
 
     let args = Args::parse();
+
     let mut cmd = Args::command();
     args.validate(&mut cmd);
 

--- a/rs/qualifier/src/qualify_util.rs
+++ b/rs/qualifier/src/qualify_util.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, str::FromStr};
 
 use anyhow::Error;
 use dre::{
-    commands::{qualify::execute::Execute, Args, ExecutableCommand},
+    commands::{qualify::execute::Execute, Args, AuthOpts, ExecutableCommand},
     ctx::DreContext,
 };
 use ic_management_backend::registry::local_registry_path;
@@ -63,10 +63,7 @@ pub async fn qualify(
     }
 
     let args = Args {
-        hsm_pin: None,
-        hsm_slot: None,
-        hsm_key_id: None,
-        private_key_pem: Some(private_key_pem),
+        auth_opts: AuthOpts::try_from(private_key_pem)?,
         neuron_id: Some(neuron_id),
         ic_admin: None,
         yes: true,

--- a/rs/rollout-controller/src/actions/mod.rs
+++ b/rs/rollout-controller/src/actions/mod.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
 use dre::{
-    auth::Neuron,
-    commands::{AuthOpts, HsmOpts},
+    auth::{Auth, Neuron},
     ic_admin::{IcAdmin, IcAdminImpl, ProposeCommand, ProposeOptions},
 };
 use ic_base_types::PrincipalId;
@@ -113,7 +112,7 @@ pub struct ActionExecutor<'a> {
 
 impl<'a> ActionExecutor<'a> {
     pub async fn new(neuron_id: u64, private_key_pem: String, network: Network, simulate: bool, logger: Option<&'a Logger>) -> anyhow::Result<Self> {
-        let neuron = Neuron::new(AuthOpts::try_from(private_key_pem)?, Some(neuron_id), &network, true).await?;
+        let neuron = Neuron::new(Auth::pem(private_key_pem.into()).await?, Some(neuron_id), &network, true).await?;
         Ok(Self {
             ic_admin_wrapper: IcAdminImpl::new(network, None, true, neuron, simulate),
             logger,
@@ -121,19 +120,7 @@ impl<'a> ActionExecutor<'a> {
     }
 
     pub async fn test(network: Network, logger: Option<&'a Logger>) -> anyhow::Result<Self> {
-        let neuron = Neuron::new(
-            AuthOpts {
-                private_key_pem: None,
-                hsm_opts: HsmOpts {
-                    hsm_pin: None,
-                    hsm_params: None,
-                },
-            },
-            None,
-            &network,
-            true,
-        )
-        .await?;
+        let neuron = Neuron::new(Auth::auto(None).await?, None, &network, true).await?;
         Ok(Self {
             ic_admin_wrapper: IcAdminImpl::new(network, None, true, neuron, true),
             logger,

--- a/rs/rollout-controller/src/actions/mod.rs
+++ b/rs/rollout-controller/src/actions/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use dre::{
     auth::Neuron,
-    commands::AuthOpts,
+    commands::{AuthOpts, HsmOpts},
     ic_admin::{IcAdmin, IcAdminImpl, ProposeCommand, ProposeOptions},
 };
 use ic_base_types::PrincipalId;
@@ -124,7 +124,10 @@ impl<'a> ActionExecutor<'a> {
         let neuron = Neuron::new(
             AuthOpts {
                 private_key_pem: None,
-                hsm_opts: None,
+                hsm_opts: HsmOpts {
+                    hsm_pin: None,
+                    hsm_params: None,
+                },
             },
             None,
             &network,

--- a/rs/rollout-controller/src/actions/mod.rs
+++ b/rs/rollout-controller/src/actions/mod.rs
@@ -1,7 +1,8 @@
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use dre::{
     auth::Neuron,
+    commands::AuthOpts,
     ic_admin::{IcAdmin, IcAdminImpl, ProposeCommand, ProposeOptions},
 };
 use ic_base_types::PrincipalId;
@@ -112,7 +113,7 @@ pub struct ActionExecutor<'a> {
 
 impl<'a> ActionExecutor<'a> {
     pub async fn new(neuron_id: u64, private_key_pem: String, network: Network, simulate: bool, logger: Option<&'a Logger>) -> anyhow::Result<Self> {
-        let neuron = Neuron::new(Some(PathBuf::from(private_key_pem)), None, None, None, Some(neuron_id), &network, true).await?;
+        let neuron = Neuron::new(AuthOpts::try_from(private_key_pem)?, Some(neuron_id), &network, true).await?;
         Ok(Self {
             ic_admin_wrapper: IcAdminImpl::new(network, None, true, neuron, simulate),
             logger,
@@ -120,7 +121,16 @@ impl<'a> ActionExecutor<'a> {
     }
 
     pub async fn test(network: Network, logger: Option<&'a Logger>) -> anyhow::Result<Self> {
-        let neuron = Neuron::new(None, None, None, None, None, &network, true).await?;
+        let neuron = Neuron::new(
+            AuthOpts {
+                private_key_pem: None,
+                hsm_opts: None,
+            },
+            None,
+            &network,
+            true,
+        )
+        .await?;
         Ok(Self {
             ic_admin_wrapper: IcAdminImpl::new(network, None, true, neuron, true),
             logger,

--- a/rs/rollout-controller/src/actions/mod.rs
+++ b/rs/rollout-controller/src/actions/mod.rs
@@ -120,7 +120,7 @@ impl<'a> ActionExecutor<'a> {
     }
 
     pub async fn test(network: Network, logger: Option<&'a Logger>) -> anyhow::Result<Self> {
-        let neuron = Neuron::new(Auth::auto(None).await?, None, &network, true).await?;
+        let neuron = Neuron::new(Auth::auto(None, None, None).await?, None, &network, true).await?;
         Ok(Self {
             ic_admin_wrapper: IcAdminImpl::new(network, None, true, neuron, true),
             logger,


### PR DESCRIPTION
The fundamental change in this PR could have been described as reducing ambiguity in command line processing for the authentication options, by exploiting the Rust type system.  The path was somewhat more tortuous.

Chiefly, we simplify a lot of the inner function calls, which no longer require four different arguments that could each wrongly and independently have missing values when they should never have them.  Argument combinations that are invalid must be rejected.

* Authentication selection:
  * Use of `--private-key-pem` with any HSM-related argument is forbidden.
  * Hardware security module detection now allows the user to narrow down to either an HSM slot, or an HSM key ID, or both, or let autodetection take place as usual.
    * When none are specified, autodetection remains unchanged from before (although arguably when autodetection fails, the program should abort instead of falling back to `::Anonymous` -- that is, if the user's desired command can work with anonymous authentication, autodetection shouldn't even take place to begin with).
    * When an HSM slot is specified, but an HSM is not detected in that slot, the program aborts.
    * When an HSM key ID is specified, but the key ID is not detected in any slot (or the specified slot), the program aborts.
  * All failure / error messages are clear and explain to the user what the problem is.  We no longer bark "Invalid auth parameters" to the user.
* Key ID fixes:
  * The key ID was used both when the DRE tool invokes `ic-admin` via an `exec()` call, and when a canister client is instantiated.
  * Under autodetection, DRE was always hardcoding `01` as the key ID, which is wrong (it only worked by coincidence).
  * We now *detect the correct key ID* (basically, the first object that is a `Token` in the slot) and use that value for `ic-admin`.
  * Key IDs are technically large integers (Vec<u8>) but for simplicity we only support up to 256 key IDs, period.  The text format that the canister client wants (a `String` of hex characters for some odd reason, instead of a `Vec<u8>` or a simple `u64`) is respected.
  * As a result of the key ID change, it is no longer possible for users to supply an invalid key ID.  It continues to be possible for users to supply a nonexistent key ID, but we check it's there before proceeding with it.
* PIN entry fixes:
  * PIN entry is saved to the keyring **only** if the PIN is valid.  The PIN is first tested before saving and using it, and if the PIN is bad, the program aborts and explains why.  The keyring is always cleared upon invalid PIN, to prevent another re-run with a bad PIN, and therefore protect against the exhaustion of PIN entry tries in the HSM, and therefore protect against the HSM being locked (guess whom it happened to first, lol).
  * PIN is never saved in the keyring if specified via `--hsm-pin` or the `HSM_PIN` environment variable.
  * The program warns users when their HSM is about to run out of PIN entry tries, *before* entering the PIN.
  * The program aborts if an attempt to use a locked HSM is made.  The user is informed appropriately.
    * In the unlikely case that the user has two HSMs plugged in and autodetection selected one that just happened to be locked, autodetection fails, but the user can still specify another slot using the `--hsm-slot` argument.

We now have a luxury authentication detection system for DRE!

Additional features:

* The voting loop can now be limited to one cycle, by setting the --sleep-time to zero seconds.
* The flag `--dry-run` is now respected for `dre vote`.
* Some functions that used blocking calls have been converted to `async`; the blocking sections of these functions are spawned using `tokio::blocking_spawn` to prevent starvation.
