### PR TITLE
chore: refactoring proposals agent to increase testability

### DIFF
--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -11,7 +11,7 @@ use ic_canisters::{governance::governance_canister_version, CanisterClient, IcAg
 use ic_management_backend::{
     lazy_git::LazyGit,
     lazy_registry::{LazyRegistry, LazyRegistryImpl},
-    proposal::ProposalAgent,
+    proposal::ProposalAgentImpl,
     registry::{local_registry_path, sync_local_store},
 };
 use ic_management_types::Network;
@@ -220,8 +220,8 @@ impl DreContext {
         SubnetManager::new(registry, self.network().clone())
     }
 
-    pub fn proposals_agent(&self) -> ProposalAgent {
-        ProposalAgent::new(self.network().get_nns_urls())
+    pub fn proposals_agent(&self) -> ProposalAgentImpl {
+        ProposalAgentImpl::new(self.network().get_nns_urls())
     }
 
     pub async fn runner(&self) -> Rc<Runner> {

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -11,7 +11,7 @@ use ic_canisters::{governance::governance_canister_version, CanisterClient, IcAg
 use ic_management_backend::{
     lazy_git::LazyGit,
     lazy_registry::{LazyRegistry, LazyRegistryImpl},
-    proposal::ProposalAgentImpl,
+    proposal::{ProposalAgent, ProposalAgentImpl},
     registry::{local_registry_path, sync_local_store},
 };
 use ic_management_types::Network;
@@ -34,6 +34,7 @@ pub struct DreContext {
     ic_admin: Option<Arc<dyn IcAdmin>>,
     runner: RefCell<Option<Rc<Runner>>>,
     ic_repo: RefCell<Option<Arc<dyn LazyGit>>>,
+    proposal_agent: Arc<dyn ProposalAgent>,
     verbose_runner: bool,
     skip_sync: bool,
     ic_admin_path: Option<String>,
@@ -79,6 +80,7 @@ impl DreContext {
         .await?;
 
         Ok(Self {
+            proposal_agent: Arc::new(ProposalAgentImpl::new(&network.nns_urls)),
             network,
             registry: RefCell::new(None),
             ic_admin,
@@ -165,7 +167,12 @@ impl DreContext {
         info!("Using local registry path for network {}: {}", network.name, local_path.display());
         let local_registry = LocalRegistry::new(local_path, Duration::from_millis(1000)).expect("Failed to create local registry");
 
-        let registry = Arc::new(LazyRegistryImpl::new(local_registry, network.clone(), self.skip_sync));
+        let registry = Arc::new(LazyRegistryImpl::new(
+            local_registry,
+            network.clone(),
+            self.skip_sync,
+            self.proposals_agent(),
+        ));
         *self.registry.borrow_mut() = Some(registry.clone());
         registry
     }
@@ -220,8 +227,8 @@ impl DreContext {
         SubnetManager::new(registry, self.network().clone())
     }
 
-    pub fn proposals_agent(&self) -> ProposalAgentImpl {
-        ProposalAgentImpl::new(self.network().get_nns_urls())
+    pub fn proposals_agent(&self) -> Arc<dyn ProposalAgent> {
+        self.proposal_agent.clone()
     }
 
     pub async fn runner(&self) -> Rc<Runner> {

--- a/rs/cli/src/operations/hostos_rollout.rs
+++ b/rs/cli/src/operations/hostos_rollout.rs
@@ -533,6 +533,7 @@ impl HostosRollout {
 pub mod test {
     use crate::operations::hostos_rollout::NodeAssignment::{Assigned, Unassigned};
     use crate::operations::hostos_rollout::NodeOwner::{Dfinity, Others};
+    use ic_management_backend::proposal::ProposalAgentImpl;
     use ic_management_types::{Network, Node, Operator, Provider, Subnet};
     use std::net::Ipv6Addr;
 
@@ -584,7 +585,7 @@ pub mod test {
             Arc::new(union.clone()),
             Arc::new(subnet.clone()),
             &network,
-            ProposalAgent::new(nns_urls),
+            Arc::new(ProposalAgentImpl::new(nns_urls)) as Arc<dyn ProposalAgent>,
             version_one.clone().as_str(),
             &[],
             &[],
@@ -623,7 +624,7 @@ pub mod test {
             Arc::new(union.clone()),
             Arc::new(subnet.clone()),
             &network,
-            ProposalAgent::new(nns_urls),
+            Arc::new(ProposalAgentImpl::new(nns_urls)) as Arc<dyn ProposalAgent>,
             version_one.clone().as_str(),
             &[],
             &nodes_to_exclude,
@@ -651,7 +652,7 @@ pub mod test {
             Arc::new(union.clone()),
             Arc::new(subnet.clone()),
             &network,
-            ProposalAgent::new(nns_urls),
+            Arc::new(ProposalAgentImpl::new(nns_urls)) as Arc<dyn ProposalAgent>,
             version_two.clone().as_str(),
             &[],
             &[],

--- a/rs/cli/src/operations/hostos_rollout.rs
+++ b/rs/cli/src/operations/hostos_rollout.rs
@@ -3,7 +3,7 @@ use async_recursion::async_recursion;
 use futures_util::future::try_join;
 use ic_base_types::{NodeId, PrincipalId};
 use ic_management_backend::health::{self, HealthStatusQuerier};
-use ic_management_backend::proposal::ProposalAgentImpl;
+use ic_management_backend::proposal::ProposalAgent;
 use ic_management_types::{HealthStatus, Network, Node, Subnet, UpdateNodesHostosVersionsProposal};
 use log::{debug, info, warn};
 use std::sync::Arc;
@@ -132,7 +132,7 @@ pub struct HostosRollout {
     pub grouped_nodes: BTreeMap<NodeGroup, Vec<Node>>,
     pub subnets: Arc<BTreeMap<PrincipalId, Subnet>>,
     pub network: Network,
-    pub proposal_agent: ProposalAgentImpl,
+    pub proposal_agent: Arc<dyn ProposalAgent>,
     pub only_filter: Vec<String>,
     pub exclude_filter: Vec<String>,
     pub version: String,
@@ -142,7 +142,7 @@ impl HostosRollout {
         nodes: Arc<BTreeMap<PrincipalId, Node>>,
         subnets: Arc<BTreeMap<PrincipalId, Subnet>>,
         network: &Network,
-        proposal_agent: ProposalAgentImpl,
+        proposal_agent: Arc<dyn ProposalAgent>,
         rollout_version: &str,
         only_filter: &[String],
         exclude_filter: &[String],

--- a/rs/cli/src/operations/hostos_rollout.rs
+++ b/rs/cli/src/operations/hostos_rollout.rs
@@ -3,7 +3,7 @@ use async_recursion::async_recursion;
 use futures_util::future::try_join;
 use ic_base_types::{NodeId, PrincipalId};
 use ic_management_backend::health::{self, HealthStatusQuerier};
-use ic_management_backend::proposal::ProposalAgent;
+use ic_management_backend::proposal::ProposalAgentImpl;
 use ic_management_types::{HealthStatus, Network, Node, Subnet, UpdateNodesHostosVersionsProposal};
 use log::{debug, info, warn};
 use std::sync::Arc;
@@ -132,7 +132,7 @@ pub struct HostosRollout {
     pub grouped_nodes: BTreeMap<NodeGroup, Vec<Node>>,
     pub subnets: Arc<BTreeMap<PrincipalId, Subnet>>,
     pub network: Network,
-    pub proposal_agent: ProposalAgent,
+    pub proposal_agent: ProposalAgentImpl,
     pub only_filter: Vec<String>,
     pub exclude_filter: Vec<String>,
     pub version: String,
@@ -142,7 +142,7 @@ impl HostosRollout {
         nodes: Arc<BTreeMap<PrincipalId, Node>>,
         subnets: Arc<BTreeMap<PrincipalId, Subnet>>,
         network: &Network,
-        proposal_agent: ProposalAgent,
+        proposal_agent: ProposalAgentImpl,
         rollout_version: &str,
         only_filter: &[String],
         exclude_filter: &[String],

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -17,7 +17,7 @@ use ic_management_backend::health::HealthStatusQuerier;
 use ic_management_backend::lazy_git::LazyGit;
 use ic_management_backend::lazy_git::LazyGitImpl;
 use ic_management_backend::lazy_registry::LazyRegistry;
-use ic_management_backend::proposal::ProposalAgent;
+use ic_management_backend::proposal::ProposalAgentImpl;
 use ic_management_backend::registry::ReleasesOps;
 use ic_management_types::Artifact;
 use ic_management_types::HealthStatus;
@@ -47,7 +47,7 @@ pub struct Runner {
     registry: Arc<dyn LazyRegistry>,
     ic_repo: RefCell<Option<Arc<dyn LazyGit>>>,
     network: Network,
-    proposal_agent: ProposalAgent,
+    proposal_agent: ProposalAgentImpl,
     verbose: bool,
 }
 
@@ -56,7 +56,7 @@ impl Runner {
         ic_admin: Arc<dyn IcAdmin>,
         registry: Arc<dyn LazyRegistry>,
         network: Network,
-        agent: ProposalAgent,
+        agent: ProposalAgentImpl,
         verbose: bool,
         ic_repo: RefCell<Option<Arc<dyn LazyGit>>>,
     ) -> Self {

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -17,7 +17,7 @@ use ic_management_backend::health::HealthStatusQuerier;
 use ic_management_backend::lazy_git::LazyGit;
 use ic_management_backend::lazy_git::LazyGitImpl;
 use ic_management_backend::lazy_registry::LazyRegistry;
-use ic_management_backend::proposal::ProposalAgentImpl;
+use ic_management_backend::proposal::ProposalAgent;
 use ic_management_backend::registry::ReleasesOps;
 use ic_management_types::Artifact;
 use ic_management_types::HealthStatus;
@@ -47,7 +47,7 @@ pub struct Runner {
     registry: Arc<dyn LazyRegistry>,
     ic_repo: RefCell<Option<Arc<dyn LazyGit>>>,
     network: Network,
-    proposal_agent: ProposalAgentImpl,
+    proposal_agent: Arc<dyn ProposalAgent>,
     verbose: bool,
 }
 
@@ -56,7 +56,7 @@ impl Runner {
         ic_admin: Arc<dyn IcAdmin>,
         registry: Arc<dyn LazyRegistry>,
         network: Network,
-        agent: ProposalAgentImpl,
+        agent: Arc<dyn ProposalAgent>,
         verbose: bool,
         ic_repo: RefCell<Option<Arc<dyn LazyGit>>>,
     ) -> Self {

--- a/rs/ic-management-backend/src/endpoints/mod.rs
+++ b/rs/ic-management-backend/src/endpoints/mod.rs
@@ -159,7 +159,7 @@ async fn get_subnet(
 #[get("/rollout")]
 async fn rollout(registry: web::Data<Arc<RwLock<registry::RegistryState>>>) -> Result<HttpResponse, Error> {
     let registry = registry.read().await;
-    let proposal_agent = proposal::ProposalAgent::new(registry.get_nns_urls());
+    let proposal_agent = proposal::ProposalAgentImpl::new(registry.get_nns_urls());
     let network = registry.network();
     let prometheus_client = prometheus::client(&network);
     let service = RolloutBuilder {
@@ -175,7 +175,7 @@ async fn rollout(registry: web::Data<Arc<RwLock<registry::RegistryState>>>) -> R
 #[get("/subnets/versions")]
 async fn subnets_release(registry: web::Data<Arc<RwLock<registry::RegistryState>>>) -> Result<HttpResponse, Error> {
     let registry = registry.read().await;
-    let proposal_agent = proposal::ProposalAgent::new(registry.get_nns_urls());
+    let proposal_agent = proposal::ProposalAgentImpl::new(registry.get_nns_urls());
     let network = registry.network();
     let prometheus_client = prometheus::client(&network);
     response_from_result(

--- a/rs/ic-management-backend/src/lazy_registry.rs
+++ b/rs/ic-management-backend/src/lazy_registry.rs
@@ -686,7 +686,7 @@ impl LazyRegistry for LazyRegistryImpl {
                 return Ok(());
             }
 
-            let proposal_agent = proposal::ProposalAgent::new(self.network.get_nns_urls());
+            let proposal_agent = proposal::ProposalAgentImpl::new(self.network.get_nns_urls());
             let nodes = self.nodes().await?;
             let subnets = self.subnets().await?;
 

--- a/rs/ic-management-backend/src/lazy_registry.rs
+++ b/rs/ic-management-backend/src/lazy_registry.rs
@@ -33,9 +33,10 @@ use tokio::sync::RwLock;
 use tokio::try_join;
 
 use crate::health::HealthStatusQuerier;
+use crate::node_labels;
+use crate::proposal::ProposalAgent;
 use crate::public_dashboard::query_ic_dashboard_list;
 use crate::registry::{DFINITY_DCS, NNS_SUBNET_NAME};
-use crate::{node_labels, proposal};
 
 const KNOWN_SUBNETS: &[(&str, &str)] = &[
     (
@@ -181,6 +182,7 @@ where
     unassigned_nodes_replica_version: RwLock<Option<Arc<String>>>,
     firewall_rule_set: RwLock<Option<Arc<BTreeMap<String, FirewallRuleSet>>>>,
     no_sync: bool,
+    proposal_agent: Arc<dyn ProposalAgent>,
 }
 
 pub trait LazyRegistryEntry: RegistryValue {
@@ -277,7 +279,7 @@ impl LazyRegistryFamilyEntries for LazyRegistryImpl {
 }
 
 impl LazyRegistryImpl {
-    pub fn new(local_registry: LocalRegistry, network: Network, no_sync: bool) -> Self {
+    pub fn new(local_registry: LocalRegistry, network: Network, no_sync: bool, proposal_agent: Arc<dyn ProposalAgent>) -> Self {
         Self {
             local_registry,
             network,
@@ -290,6 +292,7 @@ impl LazyRegistryImpl {
             unassigned_nodes_replica_version: RwLock::new(None),
             firewall_rule_set: RwLock::new(None),
             no_sync,
+            proposal_agent,
         }
     }
 
@@ -686,11 +689,10 @@ impl LazyRegistry for LazyRegistryImpl {
                 return Ok(());
             }
 
-            let proposal_agent = proposal::ProposalAgentImpl::new(self.network.get_nns_urls());
             let nodes = self.nodes().await?;
             let subnets = self.subnets().await?;
 
-            let topology_proposals = proposal_agent.list_open_topology_proposals().await?;
+            let topology_proposals = self.proposal_agent.list_open_topology_proposals().await?;
             let nodes: BTreeMap<_, _> = nodes
                 .iter()
                 .map(|(p, n)| {

--- a/rs/ic-management-backend/src/proposal.rs
+++ b/rs/ic-management-backend/src/proposal.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 use candid::{Decode, Encode};
+use futures::future::BoxFuture;
 use futures_util::future::try_join_all;
 use ic_agent::agent::http_transport::ReqwestTransport;
 use ic_agent::Agent;
@@ -27,6 +28,20 @@ use registry_canister::mutations::do_update_unassigned_nodes_config::UpdateUnass
 use registry_canister::mutations::node_management::do_remove_nodes::RemoveNodesPayload;
 use serde::Serialize;
 use url::Url;
+
+pub trait ProposalAgent: Send + Sync {
+    fn list_open_topology_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TopologyChangeProposal>>>;
+
+    fn list_open_elect_replica_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedReplicaVersionsProposal>>>;
+
+    fn list_open_elect_hostos_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedHostosVersionsProposal>>>;
+
+    fn list_open_update_nodes_hostos_versions_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateNodesHostosVersionsProposal>>>;
+
+    fn list_update_subnet_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<SubnetUpdateProposal>>>;
+
+    fn list_update_unassigned_nodes_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateUnassignedNodesProposal>>>;
+}
 
 #[derive(Clone)]
 pub struct ProposalAgentImpl {
@@ -84,6 +99,118 @@ pub struct UpdateUnassignedNodesProposal {
     pub payload: UpdateUnassignedNodesConfigPayload,
 }
 
+impl ProposalAgent for ProposalAgentImpl {
+    fn list_open_topology_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TopologyChangeProposal>>> {
+        Box::pin(async {
+            let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
+            let create_subnet_proposals = Self::nodes_proposals(filter_map_nns_function_proposals::<CreateSubnetPayload>(proposals)).into_iter();
+
+            let add_nodes_to_subnet_proposals =
+                Self::nodes_proposals(filter_map_nns_function_proposals::<AddNodesToSubnetPayload>(proposals)).into_iter();
+
+            let remove_nodes_from_subnet_proposals =
+                Self::nodes_proposals(filter_map_nns_function_proposals::<RemoveNodesFromSubnetPayload>(proposals)).into_iter();
+
+            let remove_nodes_proposals = Self::nodes_proposals(filter_map_nns_function_proposals::<RemoveNodesPayload>(proposals)).into_iter();
+
+            let membership_change_proposals =
+                Self::nodes_proposals(filter_map_nns_function_proposals::<ChangeSubnetMembershipPayload>(proposals)).into_iter();
+
+            let mut result = create_subnet_proposals
+                .chain(add_nodes_to_subnet_proposals)
+                .chain(remove_nodes_from_subnet_proposals)
+                .chain(membership_change_proposals)
+                .chain(remove_nodes_proposals)
+                .collect::<Vec<_>>();
+            result.sort_by_key(|p| p.id);
+            result.reverse();
+
+            Ok(result)
+        })
+    }
+
+    fn list_open_elect_replica_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedReplicaVersionsProposal>>> {
+        Box::pin(async {
+            let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
+            let open_elect_guest_proposals = filter_map_nns_function_proposals::<ReviseElectedGuestosVersionsPayload>(proposals);
+
+            let result = open_elect_guest_proposals
+                .into_iter()
+                .map(|(proposal_info, proposal_payload)| UpdateElectedReplicaVersionsProposal {
+                    proposal_id: proposal_info.id.expect("proposal should have an id").id,
+                    version_elect: proposal_payload.replica_version_to_elect.expect("version elect should exist"),
+
+                    versions_unelect: proposal_payload.replica_versions_to_unelect,
+                })
+                .sorted_by_key(|p| p.proposal_id)
+                .rev()
+                .collect::<Vec<_>>();
+
+            Ok(result)
+        })
+    }
+
+    fn list_open_elect_hostos_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedHostosVersionsProposal>>> {
+        Box::pin(async {
+            let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
+            let open_elect_guest_proposals = filter_map_nns_function_proposals::<UpdateElectedHostosVersionsPayload>(proposals);
+
+            let result = open_elect_guest_proposals
+                .into_iter()
+                .map(|(proposal_info, proposal_payload)| UpdateElectedHostosVersionsProposal {
+                    proposal_id: proposal_info.id.expect("proposal should have an id").id,
+                    version_elect: proposal_payload.hostos_version_to_elect.expect("version elect should exist"),
+
+                    versions_unelect: proposal_payload.hostos_versions_to_unelect,
+                })
+                .sorted_by_key(|p| p.proposal_id)
+                .rev()
+                .collect::<Vec<_>>();
+
+            Ok(result)
+        })
+    }
+
+    fn list_open_update_nodes_hostos_versions_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateNodesHostosVersionsProposal>>> {
+        Box::pin(async {
+            let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
+            let open_update_nodes_hostos_versions_proposals = filter_map_nns_function_proposals::<UpdateNodesHostosVersionPayload>(proposals);
+
+            let result = open_update_nodes_hostos_versions_proposals
+                .into_iter()
+                .map(|(proposal_info, proposal_payload)| UpdateNodesHostosVersionsProposal {
+                    proposal_id: proposal_info.id.expect("proposal should have an id").id,
+                    hostos_version_id: proposal_payload.hostos_version_id.expect("version elect should exist"),
+
+                    node_ids: proposal_payload.node_ids,
+                })
+                .sorted_by_key(|p| p.proposal_id)
+                .rev()
+                .collect::<Vec<_>>();
+
+            Ok(result)
+        })
+    }
+
+    fn list_update_subnet_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<SubnetUpdateProposal>>> {
+        Box::pin(async {
+            Ok(filter_map_nns_function_proposals(&self.list_proposals(vec![]).await?)
+                .into_iter()
+                .map(|(info, payload)| SubnetUpdateProposal { info: info.into(), payload })
+                .collect::<Vec<_>>())
+        })
+    }
+
+    fn list_update_unassigned_nodes_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateUnassignedNodesProposal>>> {
+        Box::pin(async {
+            Ok(filter_map_nns_function_proposals(&self.list_proposals(vec![]).await?)
+                .into_iter()
+                .map(|(info, payload)| UpdateUnassignedNodesProposal { info: info.into(), payload })
+                .collect::<Vec<_>>())
+        })
+    }
+}
+
 #[allow(dead_code)]
 impl ProposalAgentImpl {
     pub fn new(nns_urls: &[Url]) -> Self {
@@ -103,104 +230,6 @@ impl ProposalAgentImpl {
 
     fn nodes_proposals<T: TopologyChangePayload>(proposals: Vec<(ProposalInfo, T)>) -> Vec<TopologyChangeProposal> {
         proposals.into_iter().map(TopologyChangeProposal::from).collect()
-    }
-
-    pub async fn list_open_topology_proposals(&self) -> Result<Vec<TopologyChangeProposal>> {
-        let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
-        let create_subnet_proposals = Self::nodes_proposals(filter_map_nns_function_proposals::<CreateSubnetPayload>(proposals)).into_iter();
-
-        let add_nodes_to_subnet_proposals =
-            Self::nodes_proposals(filter_map_nns_function_proposals::<AddNodesToSubnetPayload>(proposals)).into_iter();
-
-        let remove_nodes_from_subnet_proposals =
-            Self::nodes_proposals(filter_map_nns_function_proposals::<RemoveNodesFromSubnetPayload>(proposals)).into_iter();
-
-        let remove_nodes_proposals = Self::nodes_proposals(filter_map_nns_function_proposals::<RemoveNodesPayload>(proposals)).into_iter();
-
-        let membership_change_proposals =
-            Self::nodes_proposals(filter_map_nns_function_proposals::<ChangeSubnetMembershipPayload>(proposals)).into_iter();
-
-        let mut result = create_subnet_proposals
-            .chain(add_nodes_to_subnet_proposals)
-            .chain(remove_nodes_from_subnet_proposals)
-            .chain(membership_change_proposals)
-            .chain(remove_nodes_proposals)
-            .collect::<Vec<_>>();
-        result.sort_by_key(|p| p.id);
-        result.reverse();
-
-        Ok(result)
-    }
-
-    pub async fn list_open_elect_replica_proposals(&self) -> Result<Vec<UpdateElectedReplicaVersionsProposal>> {
-        let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
-        let open_elect_guest_proposals = filter_map_nns_function_proposals::<ReviseElectedGuestosVersionsPayload>(proposals);
-
-        let result = open_elect_guest_proposals
-            .into_iter()
-            .map(|(proposal_info, proposal_payload)| UpdateElectedReplicaVersionsProposal {
-                proposal_id: proposal_info.id.expect("proposal should have an id").id,
-                version_elect: proposal_payload.replica_version_to_elect.expect("version elect should exist"),
-
-                versions_unelect: proposal_payload.replica_versions_to_unelect,
-            })
-            .sorted_by_key(|p| p.proposal_id)
-            .rev()
-            .collect::<Vec<_>>();
-
-        Ok(result)
-    }
-
-    pub async fn list_open_elect_hostos_proposals(&self) -> Result<Vec<UpdateElectedHostosVersionsProposal>> {
-        let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
-        let open_elect_guest_proposals = filter_map_nns_function_proposals::<UpdateElectedHostosVersionsPayload>(proposals);
-
-        let result = open_elect_guest_proposals
-            .into_iter()
-            .map(|(proposal_info, proposal_payload)| UpdateElectedHostosVersionsProposal {
-                proposal_id: proposal_info.id.expect("proposal should have an id").id,
-                version_elect: proposal_payload.hostos_version_to_elect.expect("version elect should exist"),
-
-                versions_unelect: proposal_payload.hostos_versions_to_unelect,
-            })
-            .sorted_by_key(|p| p.proposal_id)
-            .rev()
-            .collect::<Vec<_>>();
-
-        Ok(result)
-    }
-
-    pub async fn list_open_update_nodes_hostos_versions_proposals(&self) -> Result<Vec<UpdateNodesHostosVersionsProposal>> {
-        let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
-        let open_update_nodes_hostos_versions_proposals = filter_map_nns_function_proposals::<UpdateNodesHostosVersionPayload>(proposals);
-
-        let result = open_update_nodes_hostos_versions_proposals
-            .into_iter()
-            .map(|(proposal_info, proposal_payload)| UpdateNodesHostosVersionsProposal {
-                proposal_id: proposal_info.id.expect("proposal should have an id").id,
-                hostos_version_id: proposal_payload.hostos_version_id.expect("version elect should exist"),
-
-                node_ids: proposal_payload.node_ids,
-            })
-            .sorted_by_key(|p| p.proposal_id)
-            .rev()
-            .collect::<Vec<_>>();
-
-        Ok(result)
-    }
-
-    pub async fn list_update_subnet_version_proposals(&self) -> Result<Vec<SubnetUpdateProposal>> {
-        Ok(filter_map_nns_function_proposals(&self.list_proposals(vec![]).await?)
-            .into_iter()
-            .map(|(info, payload)| SubnetUpdateProposal { info: info.into(), payload })
-            .collect::<Vec<_>>())
-    }
-
-    pub async fn list_update_unassigned_nodes_version_proposals(&self) -> Result<Vec<UpdateUnassignedNodesProposal>> {
-        Ok(filter_map_nns_function_proposals(&self.list_proposals(vec![]).await?)
-            .into_iter()
-            .map(|(info, payload)| UpdateUnassignedNodesProposal { info: info.into(), payload })
-            .collect::<Vec<_>>())
     }
 
     async fn list_proposals(&self, include_status: Vec<ProposalStatus>) -> Result<Vec<ProposalInfo>> {

--- a/rs/ic-management-backend/src/proposal.rs
+++ b/rs/ic-management-backend/src/proposal.rs
@@ -29,6 +29,7 @@ use registry_canister::mutations::node_management::do_remove_nodes::RemoveNodesP
 use serde::Serialize;
 use url::Url;
 
+#[allow(dead_code)]
 pub trait ProposalAgent: Send + Sync {
     fn list_open_topology_proposals(&self) -> BoxFuture<'_, Result<Vec<TopologyChangeProposal>>>;
 

--- a/rs/ic-management-backend/src/proposal.rs
+++ b/rs/ic-management-backend/src/proposal.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 use url::Url;
 
 #[derive(Clone)]
-pub struct ProposalAgent {
+pub struct ProposalAgentImpl {
     agent: Agent,
 }
 
@@ -85,7 +85,7 @@ pub struct UpdateUnassignedNodesProposal {
 }
 
 #[allow(dead_code)]
-impl ProposalAgent {
+impl ProposalAgentImpl {
     pub fn new(nns_urls: &[Url]) -> Self {
         let client = reqwest::Client::builder()
             .use_rustls_tls()

--- a/rs/ic-management-backend/src/proposal.rs
+++ b/rs/ic-management-backend/src/proposal.rs
@@ -30,17 +30,17 @@ use serde::Serialize;
 use url::Url;
 
 pub trait ProposalAgent: Send + Sync {
-    fn list_open_topology_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TopologyChangeProposal>>>;
+    fn list_open_topology_proposals(&self) -> BoxFuture<'_, Result<Vec<TopologyChangeProposal>>>;
 
-    fn list_open_elect_replica_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedReplicaVersionsProposal>>>;
+    fn list_open_elect_replica_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateElectedReplicaVersionsProposal>>>;
 
-    fn list_open_elect_hostos_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedHostosVersionsProposal>>>;
+    fn list_open_elect_hostos_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateElectedHostosVersionsProposal>>>;
 
-    fn list_open_update_nodes_hostos_versions_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateNodesHostosVersionsProposal>>>;
+    fn list_open_update_nodes_hostos_versions_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateNodesHostosVersionsProposal>>>;
 
-    fn list_update_subnet_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<SubnetUpdateProposal>>>;
+    fn list_update_subnet_version_proposals(&self) -> BoxFuture<'_, Result<Vec<SubnetUpdateProposal>>>;
 
-    fn list_update_unassigned_nodes_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateUnassignedNodesProposal>>>;
+    fn list_update_unassigned_nodes_version_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateUnassignedNodesProposal>>>;
 }
 
 #[derive(Clone)]
@@ -100,7 +100,7 @@ pub struct UpdateUnassignedNodesProposal {
 }
 
 impl ProposalAgent for ProposalAgentImpl {
-    fn list_open_topology_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<TopologyChangeProposal>>> {
+    fn list_open_topology_proposals(&self) -> BoxFuture<'_, Result<Vec<TopologyChangeProposal>>> {
         Box::pin(async {
             let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
             let create_subnet_proposals = Self::nodes_proposals(filter_map_nns_function_proposals::<CreateSubnetPayload>(proposals)).into_iter();
@@ -129,7 +129,7 @@ impl ProposalAgent for ProposalAgentImpl {
         })
     }
 
-    fn list_open_elect_replica_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedReplicaVersionsProposal>>> {
+    fn list_open_elect_replica_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateElectedReplicaVersionsProposal>>> {
         Box::pin(async {
             let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
             let open_elect_guest_proposals = filter_map_nns_function_proposals::<ReviseElectedGuestosVersionsPayload>(proposals);
@@ -150,7 +150,7 @@ impl ProposalAgent for ProposalAgentImpl {
         })
     }
 
-    fn list_open_elect_hostos_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateElectedHostosVersionsProposal>>> {
+    fn list_open_elect_hostos_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateElectedHostosVersionsProposal>>> {
         Box::pin(async {
             let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
             let open_elect_guest_proposals = filter_map_nns_function_proposals::<UpdateElectedHostosVersionsPayload>(proposals);
@@ -171,7 +171,7 @@ impl ProposalAgent for ProposalAgentImpl {
         })
     }
 
-    fn list_open_update_nodes_hostos_versions_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateNodesHostosVersionsProposal>>> {
+    fn list_open_update_nodes_hostos_versions_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateNodesHostosVersionsProposal>>> {
         Box::pin(async {
             let proposals = &self.list_proposals(vec![ProposalStatus::Open]).await?;
             let open_update_nodes_hostos_versions_proposals = filter_map_nns_function_proposals::<UpdateNodesHostosVersionPayload>(proposals);
@@ -192,7 +192,7 @@ impl ProposalAgent for ProposalAgentImpl {
         })
     }
 
-    fn list_update_subnet_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<SubnetUpdateProposal>>> {
+    fn list_update_subnet_version_proposals(&self) -> BoxFuture<'_, Result<Vec<SubnetUpdateProposal>>> {
         Box::pin(async {
             Ok(filter_map_nns_function_proposals(&self.list_proposals(vec![]).await?)
                 .into_iter()
@@ -201,7 +201,7 @@ impl ProposalAgent for ProposalAgentImpl {
         })
     }
 
-    fn list_update_unassigned_nodes_version_proposals<'a>(&'a self) -> BoxFuture<'a, Result<Vec<UpdateUnassignedNodesProposal>>> {
+    fn list_update_unassigned_nodes_version_proposals(&self) -> BoxFuture<'_, Result<Vec<UpdateUnassignedNodesProposal>>> {
         Box::pin(async {
             Ok(filter_map_nns_function_proposals(&self.list_proposals(vec![]).await?)
                 .into_iter()

--- a/rs/ic-management-backend/src/registry.rs
+++ b/rs/ic-management-backend/src/registry.rs
@@ -615,7 +615,7 @@ impl RegistryState {
 
     pub async fn nodes_with_proposals(&self) -> Result<BTreeMap<PrincipalId, Node>> {
         let nodes = self.nodes.clone();
-        let proposal_agent = proposal::ProposalAgent::new(self.network.get_nns_urls());
+        let proposal_agent = proposal::ProposalAgentImpl::new(self.network.get_nns_urls());
 
         let topology_proposals = proposal_agent.list_open_topology_proposals().await?;
 
@@ -633,18 +633,18 @@ impl RegistryState {
     }
 
     pub async fn open_elect_replica_proposals(&self) -> Result<Vec<UpdateElectedReplicaVersionsProposal>> {
-        let proposal_agent = proposal::ProposalAgent::new(self.network.get_nns_urls());
+        let proposal_agent = proposal::ProposalAgentImpl::new(self.network.get_nns_urls());
         proposal_agent.list_open_elect_replica_proposals().await
     }
 
     pub async fn open_elect_hostos_proposals(&self) -> Result<Vec<UpdateElectedHostosVersionsProposal>> {
-        let proposal_agent = proposal::ProposalAgent::new(self.network.get_nns_urls());
+        let proposal_agent = proposal::ProposalAgentImpl::new(self.network.get_nns_urls());
         proposal_agent.list_open_elect_hostos_proposals().await
     }
 
     pub async fn subnets_with_proposals(&self) -> Result<BTreeMap<PrincipalId, Subnet>> {
         let subnets = self.subnets.clone();
-        let proposal_agent = proposal::ProposalAgent::new(self.network.get_nns_urls());
+        let proposal_agent = proposal::ProposalAgentImpl::new(self.network.get_nns_urls());
 
         let topology_proposals = proposal_agent.list_open_topology_proposals().await?;
 
@@ -682,13 +682,13 @@ impl RegistryState {
     }
 
     pub async fn open_subnet_upgrade_proposals(&self) -> Result<Vec<SubnetUpdateProposal>> {
-        let proposal_agent = proposal::ProposalAgent::new(self.get_nns_urls());
+        let proposal_agent = proposal::ProposalAgentImpl::new(self.get_nns_urls());
 
         proposal_agent.list_update_subnet_version_proposals().await
     }
 
     pub async fn open_upgrade_unassigned_nodes_proposals(&self) -> Result<Vec<UpdateUnassignedNodesProposal>> {
-        let proposal_agent = proposal::ProposalAgent::new(self.get_nns_urls());
+        let proposal_agent = proposal::ProposalAgentImpl::new(self.get_nns_urls());
 
         proposal_agent.list_update_unassigned_nodes_version_proposals().await
     }

--- a/rs/ic-management-backend/src/registry.rs
+++ b/rs/ic-management-backend/src/registry.rs
@@ -1,7 +1,7 @@
 use crate::git_ic_repo::IcRepo;
 use crate::health::HealthStatusQuerier;
 use crate::node_labels;
-use crate::proposal::{self, SubnetUpdateProposal, UpdateUnassignedNodesProposal};
+use crate::proposal::{self, ProposalAgent, SubnetUpdateProposal, UpdateUnassignedNodesProposal};
 use crate::public_dashboard::query_ic_dashboard_list;
 use decentralization::network::{AvailableNodesQuerier, NodesConverter, SubnetQuerier, SubnetQueryBy};
 use futures::future::BoxFuture;

--- a/rs/ic-management-backend/src/release.rs
+++ b/rs/ic-management-backend/src/release.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
+use crate::proposal::ProposalAgent;
 use crate::proposal::{ProposalAgentImpl, SubnetUpdateProposal};
 use crate::registry::NNS_SUBNET_NAME;
 

--- a/rs/ic-management-backend/src/release.rs
+++ b/rs/ic-management-backend/src/release.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
-use crate::proposal::{ProposalAgent, SubnetUpdateProposal};
+use crate::proposal::{ProposalAgentImpl, SubnetUpdateProposal};
 use crate::registry::NNS_SUBNET_NAME;
 
 #[derive(Serialize, Clone, Display, EnumString)]
@@ -141,7 +141,7 @@ impl RolloutConfig {
 }
 
 pub struct RolloutBuilder {
-    pub proposal_agent: ProposalAgent,
+    pub proposal_agent: ProposalAgentImpl,
     pub prometheus_client: prometheus_http_query::Client,
     pub subnets: BTreeMap<PrincipalId, Subnet>,
     pub releases: Vec<Release>,
@@ -620,7 +620,7 @@ async fn get_update_states(
 }
 
 pub async fn list_subnets_release_statuses(
-    proposal_agent: &ProposalAgent,
+    proposal_agent: &ProposalAgentImpl,
     prometheus_client: &prometheus_http_query::Client,
     network: Network,
     subnets: BTreeMap<PrincipalId, Subnet>,


### PR DESCRIPTION
This PR migrates `ProposalAgent` to be a trait to support easier mocking. The real solution would be to migrate `ProposalAgent` functionality into `GovernanceCanisterWrapper` because it includes only calls for that canister. But to not polute this PR with extra code this was done as a step in between.