### PR TITLE
fix(ci): use container image with rye for update-dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-20.04
+    container: ghcr.io/dfinity/dre/actions-runner:9a9cef61d3483d2706b9d030a4a7e4d35c6ff1a2
     steps:
       - uses: actions/checkout@v4
       - name: "🔧 Setup runner"
@@ -16,15 +17,6 @@ jobs:
       ########################################
       # Once per night, update dependencies and completely delete and recreate bazel cache
       ########################################
-      - name: "🐍 Setup Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: "🐍 Install rye"
-        run: |
-          export RYE_INSTALL_OPTION="--yes"
-          curl -sSf https://rye.astral.sh/get | bash
-
       - name: "⚒️ Run autoupdate for ic-deps"
         run: |
           python scripts/auto-update-revisions.py


### PR DESCRIPTION
Upgrade the runner image to the latest version and add a container configuration for the job.