### PR TITLE
feat: pure bazel cargo deny

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,11 @@ exports_files([
     "rustfmt.toml",
     "WORKSPACE.bazel",
 ])
+exports_files([
+    "Cargo.toml"
+],
+    visibility = ["//visibility:public"]
+)
 
 alias(
     name = "rustfmt",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -32,8 +32,8 @@ http_file(
 
 http_file(
     name = "cargo_deny",
-    sha256 = "3df23bbdc19f5bf12284cbebde70f8d00587fe416c1fdd92dd1bee858d6bfada",
-    url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.16.1/cargo-deny-0.16.1-aarch64-unknown-linux-musl.tar.gz",
+    sha256 = "9612f02c85effbc97924c91e1e5b20eb51e48206e2627abb80a8f1b152ac0103",
+    url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.16.1/cargo-deny-0.16.1-x86_64-unknown-linux-musl.tar.gz",
 )
 
 http_file(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -31,6 +31,12 @@ http_file(
 )
 
 http_file(
+    name = "cargo_deny",
+    sha256 = "3df23bbdc19f5bf12284cbebde70f8d00587fe416c1fdd92dd1bee858d6bfada",
+    url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.16.1/cargo-deny-0.16.1-aarch64-unknown-linux-musl.tar.gz",
+)
+
+http_file(
     name = "bazelisk_linux",
     sha256 = "d9af1fa808c0529753c3befda75123236a711d971d3485a390507122148773a3",
     url = "https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64",

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -22,11 +22,24 @@ native_binary(
     out = "cargo-deny",
 )
 
+genrule(
+    name = "untar_cargo_deny",
+    srcs = [":cargo_deny"],
+    outs = ["cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny"],
+    cmd = """
+        tar -xzvf $(execpath :cargo_deny)
+        chmod +x cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny
+        cp cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny $@
+    """,
+    executable = True
+)
+
 run_binary(
     name = "run_cargo_deny",
-    srcs = ["Cargo.toml"],
-    tool = ":cargo_deny",
-    outs = ["cargo-deny-out"]
+    srcs = ["Cargo.toml", ":untar_cargo_deny"],
+    tool = ":untar_cargo_deny",
+    outs = ["cargo-deny-out"],
+    args = ["check"]
 )
 
 cargo_build_script(

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -24,22 +24,23 @@ native_binary(
 
 genrule(
     name = "untar_cargo_deny",
-    srcs = [":cargo_deny"],
+    srcs = [":cargo_deny", "//:Cargo.toml"],
     outs = ["cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny"],
     cmd = """
         tar -xzvf $(execpath :cargo_deny)
         chmod +x cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny
         cp cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny $@
+        cp $(location //:Cargo.toml) $@
     """,
     executable = True
 )
 
 run_binary(
     name = "run_cargo_deny",
-    srcs = ["Cargo.toml", ":untar_cargo_deny"],
+    srcs = [":untar_cargo_deny"],
     tool = ":untar_cargo_deny",
     outs = ["cargo-deny-out"],
-    args = ["check"]
+    args = ["--manifest-path", "$(location //:Cargo.toml)", "check"]
 )
 
 cargo_build_script(

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -30,14 +30,13 @@ genrule(
         tar -xzvf $(execpath :cargo_deny)
         chmod +x cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny
         cp cargo-deny-0.16.1-x86_64-unknown-linux-musl/cargo-deny $@
-        cp $(location //:Cargo.toml) $@
     """,
     executable = True
 )
 
 run_binary(
     name = "run_cargo_deny",
-    srcs = [":untar_cargo_deny"],
+    srcs = [":untar_cargo_deny", "//:Cargo.toml"],
     tool = ":untar_cargo_deny",
     outs = ["cargo-deny-out"],
     args = ["--manifest-path", "$(location //:Cargo.toml)", "check"]

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@crate_index_dre//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test", "rust_library")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script", "cargo_dep_env")
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 
 DEPS = [
     "//rs/ic-canisters",
@@ -11,6 +13,21 @@ DEPS = [
 ]
 
 package(default_visibility = ["//visibility:public"])
+
+native_binary(
+    name = "cargo_deny",
+    src = select({
+        "@platforms//os:linux": "@cargo_deny//file",
+    }),
+    out = "cargo-deny",
+)
+
+run_binary(
+    name = "run_cargo_deny",
+    srcs = ["Cargo.toml"],
+    tool = ":cargo_deny",
+    outs = ["cargo-deny-out"]
+)
 
 cargo_build_script(
     name = "build_script",
@@ -34,7 +51,8 @@ rust_binary(
     ),
     deps = all_crate_deps(
         normal = True,
-    ) + DEPS + ["//rs/cli:dre-lib", ":build_script"]
+    ) + DEPS + ["//rs/cli:dre-lib", ":build_script"],
+    compile_data = [":run_cargo_deny"]
 )
 
 rust_library(


### PR DESCRIPTION
Outcome of build process:
```bash
INFO: Invocation ID: 7aaa6f43-5095-4c8d-9493-322f76ba457f
INFO: Analyzed target //rs/cli:dre (824 packages loaded, 28969 targets configured).
INFO: Found 1 target...
ERROR: /run/media/nikola/NikolaHDD/Dfinity/dre/rs/cli/BUILD.bazel:25:11: RunBinary rs/cli/cargo-deny-out failed: (Exit 126): cargo-deny failed: error executing command (from target //rs/cli:run_cargo_deny) bazel-out/k8-opt-exec-2B5CBBC6/bin/rs/cli/cargo-deny

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
bazel-out/k8-opt-exec-2B5CBBC6/bin/rs/cli/cargo-deny: bazel-out/k8-opt-exec-2B5CBBC6/bin/rs/cli/cargo-deny: cannot execute binary file
Target //rs/cli:dre failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 2.630s, Critical Path: 0.03s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
```