### PR TITLE
fix: initialization logic

### DIFF
--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -109,7 +109,12 @@ impl DreContext {
         Self::new(
             args.network.clone(),
             args.nns_urls.clone(),
-            Auth::from_auth_opts(args.auth_opts.clone()).await?,
+            match args.subcommands.require_ic_admin() {
+                IcAdminRequirement::None | IcAdminRequirement::Anonymous => Auth::Anonymous,
+                IcAdminRequirement::Detect | IcAdminRequirement::OverridableBy { network: _, neuron: _ } => {
+                    Auth::from_auth_opts(args.auth_opts.clone()).await?
+                }
+            },
             args.neuron_id,
             args.verbose,
             args.no_sync,


### PR DESCRIPTION
If the command has `IcAdminRequirement` set to `None` / `Anonymous` we don't need to detect any auth.
Ideally we should rename `IcAdminRequirement` to something like `Auth` and have multiple levels:
1. None - just nothing
2. Anonymous - anonymous
3. Signer - `private-key-pem` / hsm trio
4. Neuron - Signer + `neuron-id`
5. OverridedBy - Custom Neuron for network

But that is a bigger refactor