### PR TITLE
Restore original, intended behavior of cargo deny.

### DIFF
--- a/.github/workflows/build/action.yaml
+++ b/.github/workflows/build/action.yaml
@@ -10,6 +10,8 @@ runs:
   using: composite
   steps:
     - name: "Cargo deny checks"
+      # Only run on pull request.  No need to run on tag or push.
+      if: ${{ contains(fromJSON('["pull_request"]'), github.event_name) }}
       id: cargo-deny
       run: |
         set -xe

--- a/bin/cargo-deny-checks.sh
+++ b/bin/cargo-deny-checks.sh
@@ -10,4 +10,10 @@ command -v cargo >/dev/null || {
 }
 
 command -v cargo-deny >/dev/null || echo "'cargo-deny' not found. Please install it by running 'cargo install cargo-deny'"
-cargo deny check --warn unmaintained
+# Do not change -D here.
+# If there is a warning that causes a problem, and there
+# is no fix at hand, then add an exception to deny.toml.
+# If --warn unmaintained is added below, then the exceptions
+# already listed in deny.toml are ignored, which is exactly
+# the OPPOSITE of what we want.
+cargo deny check -D warnings


### PR DESCRIPTION
--warn unmaintained causes Cargo Deny to ignore the exceptions we have coded into deny.toml.

Therefore removed.

Also restored -D to intentionally cause failures when this is executed, so that a commit is not possible to be merged when it introduces a problem.