### PR TITLE
feat(dre): Improve the summary of the subnet resize NNS proposals

### DIFF
--- a/rs/cli/src/subnet_manager.rs
+++ b/rs/cli/src/subnet_manager.rs
@@ -10,9 +10,11 @@ use decentralization::{
 };
 use ic_management_backend::health::{self, HealthStatusQuerier};
 use ic_management_backend::lazy_registry::LazyRegistry;
+use ic_management_types::HealthStatus;
 use ic_management_types::MinNakamotoCoefficients;
 use ic_management_types::Network;
 use ic_types::PrincipalId;
+use indexmap::IndexMap;
 use log::{info, warn};
 
 #[derive(Clone)]
@@ -177,6 +179,44 @@ impl SubnetManager {
 
         let change = SubnetChangeResponse::from(&change)
             .with_health_of_nodes(health_of_nodes)
+            .with_motivation(motivation);
+
+        Ok(change)
+    }
+
+    pub async fn subnet_resize(
+        &self,
+        request: ic_management_types::requests::SubnetResizeRequest,
+        proposal_motivation: String,
+        health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
+    ) -> anyhow::Result<SubnetChangeResponse> {
+        let registry = self.registry_instance.clone();
+        let mut motivations = vec![];
+
+        let change = registry
+            .modify_subnet_nodes(SubnetQueryBy::SubnetId(request.subnet))
+            .await?
+            .excluding_from_available(request.exclude.clone().unwrap_or_default())
+            .including_from_available(request.only.clone().unwrap_or_default())
+            .including_from_available(request.include.clone().unwrap_or_default())
+            .resize(request.add, request.remove, 0, health_of_nodes)?;
+
+        for (n, _) in change.removed().iter() {
+            motivations.push(format!("removing {} as per user request", n.id));
+        }
+
+        for (n, _) in change.added().iter() {
+            motivations.push(format!("adding {} as per user request", n.id));
+        }
+
+        let motivation = format!(
+                "{}\n{}\n\nNOTE: The information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.\nCode for calculating replacements is at https://github.com/dfinity/dre/blob/79066127f58c852eaf4adda11610e815a426878c/rs/decentralization/src/network.rs#L912",
+                proposal_motivation,
+                motivations.iter().map(|s| format!(" - {}", s)).collect::<Vec<String>>().join("\n")
+            );
+
+        let change = SubnetChangeResponse::from(&change)
+            .with_health_of_nodes(health_of_nodes.clone())
             .with_motivation(motivation);
 
         Ok(change)


### PR DESCRIPTION
In addition to the improved summary:

Changes:
- arguments --add and --remove now include default values, allowing users to omit these values if not needed.
- the `id` field has an alias of `subnet-id` for improved readability.

Refactor: the `execute` method now uses the `subnet_manager` to resize the subnet and proposes the subnet change using the `runner`. This makes the `resize` functionality very similar to the `replace` functionality, so more code can be shared between the two.