### PR TITLE
fix(backend): Do not crash the backend if some git revisions cannot be found

### DIFF
--- a/rs/ic-management-backend/src/registry.rs
+++ b/rs/ic-management-backend/src/registry.rs
@@ -373,7 +373,13 @@ impl RegistryState {
                 releases.extend(
                     blessed_versions
                         .iter()
-                        .map(|version| commit_to_release.get(version).unwrap().clone())
+                        .filter_map(|version| match commit_to_release.get(version) {
+                            Some(release) => Some(release.clone()),
+                            None => {
+                                error!("Failed to find release for version {}", version);
+                                None
+                            }
+                        })
                         .sorted_by_key(|rr| rr.time)
                         .collect::<Vec<Release>>(),
                 );


### PR DESCRIPTION
Instead just print the error message and continue.
The dashboard is not actively used anymore to get an overview of rollouts, so no need to crash important operations due to missing git revs.