### PR TITLE
refactor(dre): renaming to `no_sync` to `offline` for clarity

### DIFF
--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -194,7 +194,7 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
     #[clap(long, env = "VERBOSE", global = true)]
     pub verbose: bool,
 
-    /// Run the tool offline when possible
+    /// Run the tool offline when possible, i.e., do not sync registry and public dashboard data before the run
     ///
     /// Useful for when the NNS or Public dashboard are unreachable
     #[clap(long)]

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -194,11 +194,11 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
     #[clap(long, env = "VERBOSE", global = true)]
     pub verbose: bool,
 
-    /// Don't sync with the registry
+    /// Run the tool offline when possible
     ///
-    /// Useful for when the NNS is unreachable
+    /// Useful for when the NNS or Public dashboard are unreachable
     #[clap(long)]
-    pub no_sync: bool,
+    pub offline: bool,
 
     /// Link to the related forum post, where proposal details can be discussed
     #[clap(long, global = true, visible_aliases = &["forum-link", "forum"])]

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -274,7 +274,7 @@ pub mod tests {
             ic_repo: RefCell::new(Some(git)),
             proposal_agent,
             verbose_runner: true,
-            skip_sync: false,
+            offline: false,
             forum_post_link: None,
             dry_run: true,
             artifact_downloader,


### PR DESCRIPTION
"No sync" is the term we use only for syncing with registry canister. This flag is intended to have a broader use which covers the case of when public dashboard is offline as well.