### PR TITLE
feat: cordon features

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "06da4df9dd66c389618b0921a08c03251c247c4325192eb08dcb94e4063b5f9b",
+  "checksum": "af89dd63754a410f065e63d1f5c995d00917264ee3f108f5771db1d5967254c3",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -10446,6 +10446,10 @@
             {
               "id": "serde_json 1.0.128",
               "target": "serde_json"
+            },
+            {
+              "id": "serde_yaml 0.9.34+deprecated",
+              "target": "serde_yaml"
             },
             {
               "id": "sha2 0.10.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,7 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.10.8",
  "shlex",
  "spinners",

--- a/cordoned_features.yaml
+++ b/cordoned_features.yaml
@@ -1,0 +1,8 @@
+# This file is used for cordoining ceratin node features
+# which are used while managing subnets.
+# The full list of features can be found here:
+# https://github.com/dfinity/dre/blob/main/rs/ic-management-types/src/lib.rs#L317-L324
+features:
+  # Example entry
+  # - feature: data_center
+  #   value: mu1

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ ignore = [
     { id = "RUSTSEC-2021-0141", reason = "migration away from dotenv pending" },
     { id = "RUSTSEC-2021-0145", reason = "the potential security issue only affects Windows, which we do not target" },
     { id = "RUSTSEC-2024-0370", reason = "alternative not yet available" },
+    { id = "RUSTSEC-2024-0375", reason = "unmaintained should be ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 ]

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -77,6 +77,7 @@ comfy-table = { workspace = true }
 human_bytes = { workspace = true }
 mockall.workspace = true
 clio = { workspace = true }
+serde_yaml.workspace = true
 
 [dev-dependencies]
 actix-rt = { workspace = true }

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -204,7 +204,7 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
 
     /// Path to file which contains cordoned features
     #[clap(long, global = true, visible_aliases = &["cf-file", "cfff"])]
-    pub cordone_feature_fallback_file: Option<PathBuf>,
+    pub cordon_feature_fallback_file: Option<PathBuf>,
 }
 
 // Do not use outside of DRE CLI.

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -201,6 +201,10 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
     /// Link to the related forum post, where proposal details can be discussed
     #[clap(long, global = true, visible_aliases = &["forum-link", "forum"])]
     pub forum_post_link: Option<String>,
+
+    /// Path to file which contains cordoned features
+    #[clap(long, global = true, visible_aliases = &["cf-file", "cfff"])]
+    pub cordone_feature_fallback_file: Option<PathBuf>,
 }
 
 // Do not use outside of DRE CLI.

--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -52,7 +52,7 @@ impl ExecutableCommand for Replace {
             _ => SubnetTarget::FromNodesIds(self.nodes.clone()),
         };
 
-        let subnet_manager = ctx.subnet_manager().await;
+        let subnet_manager = ctx.subnet_manager().await?;
         let subnet_change_response = subnet_manager
             .with_target(subnet_target)
             .membership_replace(

--- a/rs/cli/src/commands/subnet/resize.rs
+++ b/rs/cli/src/commands/subnet/resize.rs
@@ -44,7 +44,7 @@ impl ExecutableCommand for Resize {
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let runner = ctx.runner().await?;
 
-        let subnet_manager = ctx.subnet_manager().await;
+        let subnet_manager = ctx.subnet_manager().await?;
 
         let subnet_change_response = subnet_manager
             .subnet_resize(

--- a/rs/cli/src/cordoned_feature_fetcher.rs
+++ b/rs/cli/src/cordoned_feature_fetcher.rs
@@ -1,0 +1,126 @@
+use std::{path::PathBuf, time::Duration};
+
+use decentralization::network::NodeFeaturePair;
+use futures::future::BoxFuture;
+use ic_management_types::NodeFeature;
+use itertools::Itertools;
+use log::warn;
+use mockall::automock;
+use reqwest::{Client, ClientBuilder};
+use strum::VariantNames;
+
+#[automock]
+pub trait CordonedFeatureFetcher: Sync + Send {
+    fn fetch(&self) -> BoxFuture<'_, anyhow::Result<Vec<NodeFeaturePair>>>;
+}
+
+pub struct CordonedFeatureFetcherImpl {
+    client: Client,
+    fallback_file: Option<PathBuf>,
+    offline: bool,
+}
+
+const CORDONED_FEATURES_FILE_URL: &str = "https://raw.githubusercontent.com/dfinity/dre/refs/heads/main/cordoned_features.yaml";
+
+impl CordonedFeatureFetcherImpl {
+    pub fn new(offline: bool, fallback_file: Option<PathBuf>) -> anyhow::Result<Self> {
+        let client = ClientBuilder::new().timeout(Duration::from_secs(10)).build()?;
+
+        Ok(Self {
+            client,
+            fallback_file,
+            offline,
+        })
+    }
+
+    async fn fetch_from_git(&self) -> anyhow::Result<Vec<NodeFeaturePair>> {
+        let bytes = self
+            .client
+            .get(CORDONED_FEATURES_FILE_URL)
+            .send()
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?;
+
+        self.parse(&bytes)
+    }
+
+    fn fetch_from_file(&self, path: &PathBuf) -> anyhow::Result<Vec<NodeFeaturePair>> {
+        let contents = std::fs::read(path)?;
+
+        self.parse(&contents)
+    }
+
+    // Write tests for this
+    fn parse(&self, contents: &[u8]) -> anyhow::Result<Vec<NodeFeaturePair>> {
+        let valid_yaml = serde_yaml::from_slice::<serde_yaml::Value>(contents)?;
+
+        let features = match valid_yaml.get("features") {
+            Some(serde_yaml::Value::Sequence(features)) => features,
+            n => anyhow::bail!(
+                "Failed to parse contents. Expected to have top-level key `features` with an array of node features. Got: \n{:?}",
+                n
+            ),
+        };
+
+        let mut valid_features = vec![];
+        for feature in features {
+            valid_features.push(NodeFeaturePair {
+                feature: feature
+                    .get("feature")
+                    .map(|value| {
+                        serde_yaml::from_value(value.clone()).map_err(|_| {
+                            anyhow::anyhow!(
+                                "Failed to parse feature `{}`. Expected one of: [{}]",
+                                serde_yaml::to_string(value).unwrap(),
+                                NodeFeature::VARIANTS.iter().join(",")
+                            )
+                        })
+                    })
+                    .ok_or(anyhow::anyhow!("Expected `feature` key to be present. Got: \n{:?}", feature))??,
+                value: feature
+                    .get("value")
+                    .map(|value| {
+                        value
+                            .as_str()
+                            .ok_or(anyhow::anyhow!(
+                                "Failed to parse value `{}`. Expected string",
+                                serde_yaml::to_string(value).unwrap(),
+                            ))
+                            .map(|s| s.to_string())
+                    })
+                    .ok_or(anyhow::anyhow!("Expected `value` key to be present. Got: \n{:?}", feature))??,
+            });
+        }
+
+        Ok(valid_features)
+    }
+}
+
+impl CordonedFeatureFetcher for CordonedFeatureFetcherImpl {
+    fn fetch(&self) -> BoxFuture<'_, anyhow::Result<Vec<NodeFeaturePair>>> {
+        Box::pin(async {
+            match (self.offline, self.fallback_file.as_ref()) {
+                (true, Some(path)) => self.fetch_from_file(path),
+                (true, None) => Err(anyhow::anyhow!("Cannot fetch cordoned features offline without a fallback file")),
+                (false, Some(path)) => match self.fetch_from_git().await {
+                    Ok(from_git) => Ok(from_git),
+                    Err(e_from_git) => {
+                        warn!("Failed to fetch cordoned features from git: {:?}", e_from_git);
+                        warn!("Falling back to fetching from file");
+                        match self.fetch_from_file(path) {
+                            Ok(from_file) => Ok(from_file),
+                            Err(e_from_file) => Err(anyhow::anyhow!(
+                                "Failed to fetch cordoned features both from file and from git.\nError from git: {:?}\nError from file: {:?}",
+                                e_from_git,
+                                e_from_file
+                            )),
+                        }
+                    }
+                },
+                (false, None) => self.fetch_from_git().await,
+            }
+        })
+    }
+}

--- a/rs/cli/src/cordoned_feature_fetcher.rs
+++ b/rs/cli/src/cordoned_feature_fetcher.rs
@@ -124,3 +124,36 @@ impl CordonedFeatureFetcher for CordonedFeatureFetcherImpl {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_parsing() {
+        let contents = br#"
+features:
+    - feature: data_center
+      value: mu1
+    - feature: node_provider
+      value: some-np
+    - feature: data_center_owner
+      value: some-dco
+    - feature: city
+      value: some-city
+    - feature: city
+      value: another-city
+    - feature: country
+      value: some-country
+    - feature: continent
+      value: some-continent"#;
+
+        let fetcher = CordonedFeatureFetcherImpl::new(true, None).unwrap();
+
+        let maybe_parsed = fetcher.parse(contents);
+        assert!(maybe_parsed.is_ok());
+        let parsed = maybe_parsed.unwrap();
+
+        assert_eq!(parsed.len(), 7)
+    }
+}

--- a/rs/cli/src/cordoned_feature_fetcher.rs
+++ b/rs/cli/src/cordoned_feature_fetcher.rs
@@ -57,7 +57,8 @@ impl CordonedFeatureFetcherImpl {
         let valid_yaml = serde_yaml::from_slice::<serde_yaml::Value>(contents)?;
 
         let features = match valid_yaml.get("features") {
-            Some(serde_yaml::Value::Sequence(features)) => features,
+            Some(serde_yaml::Value::Sequence(features)) => features.clone(),
+            Some(serde_yaml::Value::Null) => vec![],
             n => anyhow::bail!(
                 "Failed to parse contents. Expected to have top-level key `features` with an array of node features. Got: \n{:?}",
                 n
@@ -155,5 +156,19 @@ features:
         let parsed = maybe_parsed.unwrap();
 
         assert_eq!(parsed.len(), 7)
+    }
+
+    #[test]
+    fn valid_empty_file() {
+        let contents = br#"
+features:"#;
+
+        let fetcher = CordonedFeatureFetcherImpl::new(true, None).unwrap();
+
+        let maybe_parsed = fetcher.parse(contents);
+        assert!(maybe_parsed.is_ok());
+        let parsed = maybe_parsed.unwrap();
+
+        assert_eq!(parsed.len(), 0)
     }
 }

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -48,6 +48,7 @@ pub struct DreContext {
     health_client: Arc<dyn HealthStatusQuerier>,
 }
 
+#[allow(clippy::too_many_arguments)]
 impl DreContext {
     pub async fn new(
         network: String,

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -117,7 +117,7 @@ impl DreContext {
             args.subcommands.require_auth(),
             args.forum_post_link.clone(),
             args.ic_admin_version.clone(),
-            Arc::new(CordonedFeatureFetcherImpl::new(args.offline, args.cordone_feature_fallback_file.clone())?) as Arc<dyn CordonedFeatureFetcher>,
+            Arc::new(CordonedFeatureFetcherImpl::new(args.offline, args.cordon_feature_fallback_file.clone())?) as Arc<dyn CordonedFeatureFetcher>,
             Arc::new(health::HealthClient::new(
                 ic_management_types::Network::new(args.network.clone(), &args.nns_urls).await?,
             )),

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -223,7 +223,7 @@ impl DreContext {
         Ok(SubnetManager::new(
             registry,
             self.network().clone(),
-            self.cordoned_features_fetcher.fetch().await?,
+            self.cordoned_features_fetcher.clone(),
         ))
     }
 
@@ -244,7 +244,7 @@ impl DreContext {
             self.verbose_runner,
             self.ic_repo.clone(),
             self.artifact_downloader.clone(),
-            self.cordoned_features_fetcher.fetch().await?,
+            self.cordoned_features_fetcher.clone(),
         ));
         *self.runner.borrow_mut() = Some(runner.clone());
         Ok(runner)
@@ -263,7 +263,7 @@ pub mod tests {
     use ic_management_backend::{lazy_git::LazyGit, lazy_registry::LazyRegistry, proposal::ProposalAgent};
     use ic_management_types::Network;
 
-    use crate::{artifact_downloader::ArtifactDownloader, auth::Neuron, ic_admin::IcAdmin};
+    use crate::{artifact_downloader::ArtifactDownloader, auth::Neuron, cordoned_feature_fetcher::CordonedFeatureFetcher, ic_admin::IcAdmin};
 
     use super::DreContext;
 
@@ -275,6 +275,7 @@ pub mod tests {
         git: Arc<dyn LazyGit>,
         proposal_agent: Arc<dyn ProposalAgent>,
         artifact_downloader: Arc<dyn ArtifactDownloader>,
+        cordoned_features_fetcher: Arc<dyn CordonedFeatureFetcher>,
     ) -> DreContext {
         DreContext {
             network,
@@ -291,6 +292,7 @@ pub mod tests {
             neuron,
             proceed_without_confirmation: true,
             version: crate::commands::IcAdminVersion::Strict("Shouldn't reach this because of mock".to_string()),
+            cordoned_features_fetcher,
         }
     }
 }

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -215,7 +215,7 @@ impl DreContext {
     pub async fn subnet_manager(&self) -> SubnetManager {
         let registry = self.registry().await;
 
-        SubnetManager::new(registry, self.network().clone())
+        SubnetManager::new(registry, self.network().clone(), vec![])
     }
 
     pub fn proposals_agent(&self) -> Arc<dyn ProposalAgent> {
@@ -235,6 +235,7 @@ impl DreContext {
             self.verbose_runner,
             self.ic_repo.clone(),
             self.artifact_downloader.clone(),
+            vec![],
         ));
         *self.runner.borrow_mut() = Some(runner.clone());
         Ok(runner)

--- a/rs/cli/src/lib.rs
+++ b/rs/cli/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod artifact_downloader;
 pub mod auth;
 pub mod commands;
+mod cordoned_feature_fetcher;
 pub mod ctx;
 mod desktop_notify;
 pub mod ic_admin;

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -10,6 +10,7 @@ use log::{info, warn};
 mod artifact_downloader;
 mod auth;
 mod commands;
+mod cordoned_feature_fetcher;
 mod ctx;
 mod desktop_notify;
 mod ic_admin;

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -532,7 +532,7 @@ impl Runner {
             try_join(self.registry.available_nodes().map_err(anyhow::Error::from), self.health_client.nodes()).await?;
 
         let subnets_change_response = NetworkHealRequest::new(subnets_without_proposals)
-            .heal_and_optimize(available_nodes, &health_of_nodes)
+            .heal_and_optimize(available_nodes, &health_of_nodes, self.cordoned_features_fetcher.fetch().await?)
             .await?;
 
         for change in &subnets_change_response {

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use decentralization::network::DecentralizedSubnet;
 use decentralization::network::NetworkHealRequest;
+use decentralization::network::NodeFeaturePair;
 use decentralization::network::SubnetChange;
 use decentralization::network::SubnetQueryBy;
 use decentralization::network::{generate_added_node_description, generate_removed_nodes_description};
@@ -51,6 +52,7 @@ pub struct Runner {
     proposal_agent: Arc<dyn ProposalAgent>,
     verbose: bool,
     artifact_downloader: Arc<dyn ArtifactDownloader>,
+    cordoned_features: Vec<NodeFeaturePair>,
 }
 
 impl Runner {
@@ -62,6 +64,7 @@ impl Runner {
         verbose: bool,
         ic_repo: RefCell<Option<Arc<dyn LazyGit>>>,
         artifact_downloader: Arc<dyn ArtifactDownloader>,
+        cordoned_features: Vec<NodeFeaturePair>,
     ) -> Self {
         Self {
             ic_admin,
@@ -71,6 +74,7 @@ impl Runner {
             proposal_agent: agent,
             verbose,
             artifact_downloader,
+            cordoned_features,
         }
     }
 
@@ -149,6 +153,7 @@ impl Runner {
                 request.exclude.clone().unwrap_or_default(),
                 request.only.clone().unwrap_or_default(),
                 &health_of_nodes,
+                self.cordoned_features.clone(),
             )
             .await?;
         let subnet_creation_data = SubnetChangeResponse::from(&subnet_creation_data).with_health_of_nodes(health_of_nodes.clone());
@@ -599,7 +604,8 @@ impl Runner {
             .registry
             .modify_subnet_nodes(SubnetQueryBy::SubnetId(*subnet))
             .await
-            .map_err(|e| anyhow::anyhow!(e))?;
+            .map_err(|e| anyhow::anyhow!(e))?
+            .with_cordoned_features(self.cordoned_features.clone());
 
         let change_request = match keep_nodes {
             Some(n) => change_request.keeping_from_used(n),

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -603,8 +603,7 @@ impl Runner {
             .registry
             .modify_subnet_nodes(SubnetQueryBy::SubnetId(*subnet))
             .await
-            .map_err(|e| anyhow::anyhow!(e))?
-            .with_cordoned_features(self.cordoned_features_fetcher.fetch().await?);
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         let change_request = match keep_nodes {
             Some(n) => change_request.keeping_from_used(n),
@@ -613,7 +612,8 @@ impl Runner {
 
         let health_of_nodes = self.health_of_nodes().await?;
 
-        let change = SubnetChangeResponse::from(&change_request.rescue(&health_of_nodes)?).with_health_of_nodes(health_of_nodes);
+        let change = SubnetChangeResponse::from(&change_request.rescue(&health_of_nodes, self.cordoned_features_fetcher.fetch().await?)?)
+            .with_health_of_nodes(health_of_nodes);
 
         if change.added_with_desc.is_empty() && change.removed_with_desc.is_empty() {
             return Ok(());

--- a/rs/cli/src/subnet_manager.rs
+++ b/rs/cli/src/subnet_manager.rs
@@ -8,10 +8,9 @@ use decentralization::{
     network::{DecentralizedSubnet, Node as DecentralizedNode, SubnetQueryBy},
     SubnetChangeResponse,
 };
-use ic_management_backend::health::{self, HealthStatusQuerier};
+use ic_management_backend::health::HealthStatusQuerier;
 use ic_management_backend::lazy_registry::LazyRegistry;
 use ic_management_types::HealthStatus;
-use ic_management_types::Network;
 use ic_types::PrincipalId;
 use indexmap::IndexMap;
 use log::{info, warn};
@@ -42,16 +41,20 @@ pub struct SubnetManager {
     subnet_target: Option<SubnetTarget>,
     registry_instance: Arc<dyn LazyRegistry>,
     cordoned_features_fetcher: Arc<dyn CordonedFeatureFetcher>,
-    network: Network,
+    health_client: Arc<dyn HealthStatusQuerier>,
 }
 
 impl SubnetManager {
-    pub fn new(registry_instance: Arc<dyn LazyRegistry>, network: Network, cordoned_features_fetcher: Arc<dyn CordonedFeatureFetcher>) -> Self {
+    pub fn new(
+        registry_instance: Arc<dyn LazyRegistry>,
+        cordoned_features_fetcher: Arc<dyn CordonedFeatureFetcher>,
+        health_client: Arc<dyn HealthStatusQuerier>,
+    ) -> Self {
         Self {
             subnet_target: None,
             registry_instance,
-            network,
             cordoned_features_fetcher,
+            health_client,
         }
     }
 
@@ -69,8 +72,7 @@ impl SubnetManager {
     }
 
     async fn unhealthy_nodes(&self, subnet: DecentralizedSubnet) -> anyhow::Result<Vec<(DecentralizedNode, ic_management_types::HealthStatus)>> {
-        let health_client = health::HealthClient::new(self.network.clone());
-        let subnet_health = health_client.subnet(subnet.id).await?;
+        let subnet_health = self.health_client.subnet(subnet.id).await?;
 
         let unhealthy = subnet
             .nodes
@@ -158,8 +160,7 @@ impl SubnetManager {
             to_be_replaced.extend(subnet_unhealthy_without_included);
         }
 
-        let health_client = health::HealthClient::new(self.network.clone());
-        let health_of_nodes = health_client.nodes().await?;
+        let health_of_nodes = self.health_client.nodes().await?;
 
         let change = subnet_change_request.optimize(optimize.unwrap_or(0), &to_be_replaced, &health_of_nodes)?;
 

--- a/rs/cli/src/unit_tests/ctx_init.rs
+++ b/rs/cli/src/unit_tests/ctx_init.rs
@@ -1,8 +1,9 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use crate::{
     auth::{Auth, Neuron, STAGING_KEY_PATH_FROM_HOME, STAGING_NEURON_ID},
     commands::{AuthOpts, AuthRequirement, HsmOpts},
+    cordoned_feature_fetcher::MockCordonedFeatureFetcher,
 };
 use clio::{ClioPath, InputPath};
 use ic_canisters::governance::governance_canister_version;
@@ -45,6 +46,7 @@ async fn get_context(network: &Network, version: IcAdminVersion) -> anyhow::Resu
         crate::commands::AuthRequirement::Anonymous,
         None,
         version,
+        Arc::new(MockCordonedFeatureFetcher::new()),
     )
     .await
 }
@@ -180,6 +182,7 @@ async fn get_ctx_for_neuron_test(
         requirement,
         None,
         IcAdminVersion::Strict("Shouldn't get to here".to_string()),
+        Arc::new(MockCordonedFeatureFetcher::new()),
     )
     .await
 }

--- a/rs/cli/src/unit_tests/ctx_init.rs
+++ b/rs/cli/src/unit_tests/ctx_init.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use clio::{ClioPath, InputPath};
 use ic_canisters::governance::governance_canister_version;
+use ic_management_backend::health::MockHealthStatusQuerier;
 use ic_management_types::Network;
 use itertools::Itertools;
 
@@ -47,6 +48,7 @@ async fn get_context(network: &Network, version: IcAdminVersion) -> anyhow::Resu
         None,
         version,
         Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
     )
     .await
 }
@@ -183,6 +185,7 @@ async fn get_ctx_for_neuron_test(
         None,
         IcAdminVersion::Strict("Shouldn't get to here".to_string()),
         Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
     )
     .await
 }

--- a/rs/cli/src/unit_tests/mod.rs
+++ b/rs/cli/src/unit_tests/mod.rs
@@ -1,3 +1,4 @@
 mod ctx_init;
+mod replace;
 mod update_unassigned_nodes;
 mod version;

--- a/rs/cli/src/unit_tests/mod.rs
+++ b/rs/cli/src/unit_tests/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 mod ctx_init;
 mod replace;
 mod update_unassigned_nodes;

--- a/rs/cli/src/unit_tests/mod.rs
+++ b/rs/cli/src/unit_tests/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 mod ctx_init;
 mod replace;
 mod update_unassigned_nodes;

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -1,0 +1,13 @@
+use std::sync::Arc;
+
+use ic_management_backend::{health::MockHealthStatusQuerier, lazy_registry::MockLazyRegistry};
+
+use crate::{cordoned_feature_fetcher::MockCordonedFeatureFetcher, subnet_manager::SubnetManager};
+
+#[test]
+fn should_skip_cordoned_nodes() {
+    let registry = MockLazyRegistry::new();
+    let health_client = MockHealthStatusQuerier::new();
+    let cordoned_feature_fetcher = MockCordonedFeatureFetcher::new();
+    let subnet_manager = SubnetManager::new(Arc::new(registry), Arc::new(cordoned_feature_fetcher), Arc::new(health_client));
+}

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -7,83 +7,224 @@ use decentralization::{
 use ic_management_backend::{health::MockHealthStatusQuerier, lazy_registry::MockLazyRegistry};
 use ic_management_types::NodeFeature;
 use ic_types::PrincipalId;
-use indexmap::IndexMap;
+use indexmap::{Equivalent, IndexMap};
+use itertools::Itertools;
 
 use crate::{cordoned_feature_fetcher::MockCordonedFeatureFetcher, subnet_manager::SubnetManager};
 
+fn node_principal(id: u64) -> PrincipalId {
+    PrincipalId::new_node_test_id(id)
+}
+
+fn node(id: u64, dfinity_owned: bool, features: &[(NodeFeature, &str)]) -> Node {
+    Node {
+        id: node_principal(id),
+        dfinity_owned,
+        features: NodeFeatures {
+            feature_map: {
+                let mut map = IndexMap::new();
+
+                features.iter().for_each(|(feature, value)| {
+                    map.insert(feature.clone(), value.to_string());
+                });
+
+                // Insert mandatory features
+                for feature in &[NodeFeature::NodeProvider, NodeFeature::DataCenter, NodeFeature::DataCenterOwner] {
+                    map.insert(feature.clone(), "Some value".to_string());
+                }
+
+                map
+            },
+        },
+    }
+}
+
+fn subnet(id: u64, nodes: &[Node]) -> DecentralizedSubnet {
+    DecentralizedSubnet {
+        id: PrincipalId::new_subnet_test_id(id),
+        nodes: nodes.to_vec(),
+        added_nodes_desc: vec![],
+        removed_nodes_desc: vec![],
+        comment: None,
+        run_log: vec![],
+    }
+}
+
+fn cordoned_feature(feature: NodeFeature, value: &str) -> NodeFeaturePair {
+    NodeFeaturePair {
+        feature,
+        value: value.to_string(),
+    }
+}
+
 #[test]
 fn should_skip_cordoned_nodes() {
+    // World setup
+    let available_nodes = vec![
+        node(1, true, &[(NodeFeature::Country, "Country 1"), (NodeFeature::City, "City 1")]),
+        node(2, true, &[(NodeFeature::Country, "Country 1"), (NodeFeature::City, "City 2")]),
+        node(3, true, &[(NodeFeature::Country, "Country 2"), (NodeFeature::City, "City 3")]),
+        node(4, true, &[(NodeFeature::Country, "Country 2"), (NodeFeature::City, "City 4")]),
+    ];
+
+    let subnet = subnet(
+        1,
+        &[
+            node(5, true, &[(NodeFeature::Country, "Country 1"), (NodeFeature::City, "City 1")]),
+            node(6, true, &[(NodeFeature::Country, "Country 2"), (NodeFeature::City, "City 3")]),
+        ],
+    );
+
+    // Services setup
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let mut registry = MockLazyRegistry::new();
-    registry.expect_available_nodes().returning(|| {
-        Box::pin(async {
-            Ok(vec![Node {
-                dfinity_owned: true,
-                features: NodeFeatures {
-                    feature_map: {
-                        let mut map = IndexMap::new();
-
-                        map.insert(NodeFeature::Country, "Cambodia".to_string());
-
-                        map
-                    },
-                },
-                id: PrincipalId::new_node_test_id(1),
-            }])
+    let available_nodes_clone = available_nodes.clone();
+    registry.expect_available_nodes().returning(move || {
+        Box::pin({
+            let local_clone = available_nodes_clone.clone();
+            async move { Ok(local_clone) }
         })
     });
-    registry.expect_subnet().returning(|_| {
-        Box::pin(async {
-            Ok(DecentralizedSubnet {
-                id: PrincipalId::new_subnet_test_id(1),
-                nodes: vec![Node {
-                    dfinity_owned: true,
-                    features: NodeFeatures {
-                        feature_map: {
-                            let mut map = IndexMap::new();
-
-                            map.insert(NodeFeature::Country, "This".to_string());
-
-                            map
-                        },
-                    },
-                    id: PrincipalId::new_node_test_id(2),
-                }],
-                added_nodes_desc: vec![],
-                removed_nodes_desc: vec![],
-                comment: None,
-                run_log: vec![],
-            })
+    let subnet_clone = subnet.clone();
+    registry.expect_get_nodes().returning(move |_| {
+        Box::pin({
+            let nodes = subnet_clone.nodes.clone();
+            async { Ok(nodes) }
+        })
+    });
+    let subnet_clone = subnet.clone();
+    registry.expect_subnet().returning(move |_| {
+        Box::pin({
+            let local_clone = subnet_clone.clone();
+            async { Ok(local_clone) }
         })
     });
 
     let mut health_client = MockHealthStatusQuerier::new();
-    health_client.expect_nodes().returning(|| {
-        Box::pin(async {
-            Ok({
-                let mut nodes = IndexMap::new();
-                nodes.insert(PrincipalId::new_node_test_id(1), ic_management_types::HealthStatus::Healthy);
-                nodes
+    // All nodes in the world are healthy for this test
+    let nodes_health = available_nodes
+        .iter()
+        .map(|n| n.id)
+        .chain(subnet.nodes.iter().map(|n| n.id))
+        .map(|node_id| (node_id, ic_management_types::HealthStatus::Healthy))
+        .collect::<IndexMap<PrincipalId, ic_management_types::HealthStatus>>();
+    health_client.expect_nodes().returning(move || {
+        Box::pin({
+            let local_nodes_healht = nodes_health.clone();
+            async move { Ok(local_nodes_healht) }
+        })
+    });
+
+    // Scenarios
+    let scenarios = vec![(
+        [
+            cordoned_feature(NodeFeature::Country, "Random new country"),
+            cordoned_feature(NodeFeature::City, "Random new city"),
+        ],
+        true,
+    )];
+
+    let mut failed_scenarios = vec![];
+
+    let registry = Arc::new(registry);
+    let health_client = Arc::new(health_client);
+    for (cordoned_features, should_succeed) in scenarios {
+        let cordoned_features_clone = cordoned_features.clone();
+        let mut cordoned_feature_fetcher = MockCordonedFeatureFetcher::new();
+        cordoned_feature_fetcher.expect_fetch().returning(move || {
+            Box::pin({
+                let local_clone = cordoned_features_clone.to_vec();
+                async move { Ok(local_clone) }
             })
-        })
-    });
-    let mut cordoned_feature_fetcher = MockCordonedFeatureFetcher::new();
-    cordoned_feature_fetcher.expect_fetch().returning(|| {
-        Box::pin(async {
-            Ok(vec![NodeFeaturePair {
-                feature: NodeFeature::Country,
-                value: "Other".to_string(),
-            }])
-        })
-    });
-    let subnet_manager = SubnetManager::new(Arc::new(registry), Arc::new(cordoned_feature_fetcher), Arc::new(health_client));
+        });
+        let subnet_manager = SubnetManager::new(registry.clone(), Arc::new(cordoned_feature_fetcher), health_client.clone());
 
-    let response = runtime.block_on(
-        subnet_manager
-            .with_target(crate::subnet_manager::SubnetTarget::FromId(PrincipalId::new_subnet_test_id(1)))
-            .membership_replace(false, None, None, None, vec![], None),
-    );
-    assert!(response.is_ok());
+        // Act
+        let response = runtime.block_on(
+            subnet_manager
+                .with_target(crate::subnet_manager::SubnetTarget::FromNodesIds(vec![subnet.nodes.first().unwrap().id]))
+                .membership_replace(false, None, None, None, vec![], None),
+        );
 
-    let response = response.unwrap();
+        // Assert
+        if !should_succeed {
+            if response.is_ok() {
+                failed_scenarios.push((response, "Expected outcome to have an error".to_string()));
+            }
+            // If it failed, don't check the exact error
+            // assume it is the correct error. ATM this
+            // is not ideal but since we use anyhow its
+            // hard to test exact expected errors
+            continue;
+        }
+
+        let response = response.unwrap();
+        if response.removed_with_desc.len() != 1 {
+            failed_scenarios.push((Ok(response), "Expected only one node to be removed".to_string()));
+            continue;
+        }
+
+        if response.added_with_desc.len() != 1 {
+            failed_scenarios.push((Ok(response), "Expected only one node to be added".to_string()));
+            continue;
+        }
+
+        let mut failed_features = vec![];
+        for (feature, value_diff) in response.feature_diff.iter() {
+            let cordoned_values_for_feature = cordoned_features
+                .iter()
+                .filter(|c_feature_pair| c_feature_pair.feature.equivalent(feature))
+                .map(|c_feature_pair| c_feature_pair.value.clone())
+                .collect_vec();
+
+            if cordoned_features.is_empty() {
+                // This feature is not cordoned so doesn't have to
+                // be validated
+                continue;
+            }
+
+            let diff_for_cordoned_features = value_diff
+                .iter()
+                .filter(|(value, _)| cordoned_values_for_feature.contains(value))
+                .collect_vec();
+
+            if diff_for_cordoned_features.is_empty() {
+                // Feature is cordoned but for a different value
+                // Example cordoned:       `NodeFeature::City`, value: `City 1`
+                // Found for this replace: `NodeFeature::City`, value: `City 2`
+                continue;
+            }
+            let mut failed_for_feature = vec![];
+            for (value, (_, in_nodes)) in diff_for_cordoned_features {
+                if in_nodes.gt(&0) {
+                    failed_for_feature.push((value, in_nodes));
+                    continue;
+                }
+            }
+
+            if !failed_for_feature.is_empty() {
+                failed_features.push(format!(
+                    "Feature {} has cordoned values but still found some nodes added:\n{}",
+                    feature,
+                    failed_for_feature
+                        .iter()
+                        .map(|(value, in_nodes)| format!("\tValue: {}, New nodes with that value: {}", value, in_nodes))
+                        .join("\n")
+                ));
+            }
+        }
+
+        if !failed_features.is_empty() {
+            failed_scenarios.push((Ok(response), format!("All failed features:\n{}", failed_features.iter().join("\n"))));
+        }
+    }
+
+    assert!(
+        failed_scenarios.is_empty(),
+        "Failed scenarios:\n{}",
+        failed_scenarios
+            .iter()
+            .map(|(outcome, explaination)| format!("Reason why it failed: {}\nFull test output:\n{:?}", explaination, outcome))
+            .join("\n############")
+    )
 }

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -287,7 +287,8 @@ fn should_skip_cordoned_nodes() {
             continue;
         }
 
-        if !response.is_ok() {
+        // Here we know it should have succeeded
+        if response.is_err() {
             failed_scenarios.push((response, cordoned_features, "Expected outcome to be successful".to_string()));
             continue;
         }

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -99,7 +99,7 @@ fn test_pretty_format_response(response: &Result<SubnetChangeResponse, anyhow::E
                 ))
                 .join("\n")
         ),
-        Err(r) => format!("Response was ERR: {}", r.to_string()),
+        Err(r) => format!("Response was ERR: {}", r),
     }
 }
 
@@ -287,7 +287,7 @@ fn should_skip_cordoned_nodes() {
             continue;
         }
 
-        if response.is_ok() == false {
+        if !response.is_ok() {
             failed_scenarios.push((response, cordoned_features, "Expected outcome to be successful".to_string()));
             continue;
         }

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -184,13 +184,39 @@ fn should_skip_cordoned_nodes() {
     // Scenarios
     let scenarios = vec![
         (
+            // No available nodes contain cordoned features.
+            // All of them should be suitable for replacements.
             vec![
                 cordoned_feature(NodeFeature::Country, "Random new country"),
                 cordoned_feature(NodeFeature::City, "Random new city"),
             ],
             true,
         ),
-        (vec![cordoned_feature(NodeFeature::Country, "Country 1")], true),
+        (
+            // First two nodes from available pool must not
+            // be selected for replacement. Also node 5 could
+            // be replaced if it increases decentralization.
+            vec![cordoned_feature(NodeFeature::Country, "Country 1")],
+            true,
+        ),
+        (
+            // Second and third nodes from available pool must
+            // not be selected for replacement. Also node with
+            // id 6 could be replaced if it increases decentralization
+            vec![
+                cordoned_feature(NodeFeature::City, "City 2"),
+                cordoned_feature(NodeFeature::City, "City 3"),
+            ],
+            true,
+        ),
+        (
+            // All available nodes are unavailable
+            vec![
+                cordoned_feature(NodeFeature::Country, "Country 1"),
+                cordoned_feature(NodeFeature::Country, "Country 2"),
+            ],
+            false,
+        ),
     ];
 
     let mut failed_scenarios = vec![];

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -229,12 +229,12 @@ fn should_skip_cordoned_nodes() {
 
         let response = response.unwrap();
         if response.removed_with_desc.is_empty() {
-            failed_scenarios.push((Ok(response), cordoned_features, "Expected only one node to be removed".to_string()));
+            failed_scenarios.push((Ok(response), cordoned_features, "Expected nodes to be removed".to_string()));
             continue;
         }
 
         if response.added_with_desc.is_empty() {
-            failed_scenarios.push((Ok(response), cordoned_features, "Expected only one node to be added".to_string()));
+            failed_scenarios.push((Ok(response), cordoned_features, "Expected nodes to be added".to_string()));
             continue;
         }
 

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -336,7 +336,7 @@ Test output:
                 explaination,
                 cordoned_features
                     .iter()
-                    .map(|pair| format!("({}, {})", pair.feature.to_string(), pair.value))
+                    .map(|pair| format!("({}, {})", pair.feature, pair.value))
                     .join(", "),
                 test_pretty_format_response(outcome)
             ))

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -1,13 +1,89 @@
 use std::sync::Arc;
 
+use decentralization::{
+    nakamoto::NodeFeatures,
+    network::{DecentralizedSubnet, Node, NodeFeaturePair},
+};
 use ic_management_backend::{health::MockHealthStatusQuerier, lazy_registry::MockLazyRegistry};
+use ic_management_types::NodeFeature;
+use ic_types::PrincipalId;
+use indexmap::IndexMap;
 
 use crate::{cordoned_feature_fetcher::MockCordonedFeatureFetcher, subnet_manager::SubnetManager};
 
 #[test]
 fn should_skip_cordoned_nodes() {
-    let registry = MockLazyRegistry::new();
-    let health_client = MockHealthStatusQuerier::new();
-    let cordoned_feature_fetcher = MockCordonedFeatureFetcher::new();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let mut registry = MockLazyRegistry::new();
+    registry.expect_available_nodes().returning(|| {
+        Box::pin(async {
+            Ok(vec![Node {
+                dfinity_owned: true,
+                features: NodeFeatures {
+                    feature_map: {
+                        let mut map = IndexMap::new();
+
+                        map.insert(NodeFeature::Country, "Cambodia".to_string());
+
+                        map
+                    },
+                },
+                id: PrincipalId::new_node_test_id(1),
+            }])
+        })
+    });
+    registry.expect_subnet().returning(|_| {
+        Box::pin(async {
+            Ok(DecentralizedSubnet {
+                id: PrincipalId::new_subnet_test_id(1),
+                nodes: vec![Node {
+                    dfinity_owned: true,
+                    features: NodeFeatures {
+                        feature_map: {
+                            let mut map = IndexMap::new();
+
+                            map.insert(NodeFeature::Country, "This".to_string());
+
+                            map
+                        },
+                    },
+                    id: PrincipalId::new_node_test_id(2),
+                }],
+                added_nodes_desc: vec![],
+                removed_nodes_desc: vec![],
+                comment: None,
+                run_log: vec![],
+            })
+        })
+    });
+
+    let mut health_client = MockHealthStatusQuerier::new();
+    health_client.expect_nodes().returning(|| {
+        Box::pin(async {
+            Ok({
+                let mut nodes = IndexMap::new();
+                nodes.insert(PrincipalId::new_node_test_id(1), ic_management_types::HealthStatus::Healthy);
+                nodes
+            })
+        })
+    });
+    let mut cordoned_feature_fetcher = MockCordonedFeatureFetcher::new();
+    cordoned_feature_fetcher.expect_fetch().returning(|| {
+        Box::pin(async {
+            Ok(vec![NodeFeaturePair {
+                feature: NodeFeature::Country,
+                value: "Other".to_string(),
+            }])
+        })
+    });
     let subnet_manager = SubnetManager::new(Arc::new(registry), Arc::new(cordoned_feature_fetcher), Arc::new(health_client));
+
+    let response = runtime.block_on(
+        subnet_manager
+            .with_target(crate::subnet_manager::SubnetTarget::FromId(PrincipalId::new_subnet_test_id(1)))
+            .membership_replace(false, None, None, None, vec![], None),
+    );
+    assert!(response.is_ok());
+
+    let response = response.unwrap();
 }

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -108,18 +108,17 @@ fn pretty_print_node(node: &Node, num_ident: usize) -> String {
     )
 }
 
-fn pretty_print_world(available_nodes: &Vec<Node>, subnet: &DecentralizedSubnet) -> String {
+fn pretty_print_world(available_nodes: &[Node], subnet: &DecentralizedSubnet) -> String {
     format!(
         r#"Available nodes:
 {}
 Observed subnet:
+    - id: {}
+      nodes:
 {}"#,
         available_nodes.iter().map(|node| pretty_print_node(node, 1)).join("\n"),
-        format!(
-            "\t- id: {}\n\t- nodes:\n{}",
-            subnet.id,
-            subnet.nodes.iter().map(|node| pretty_print_node(node, 2)).join("\n")
-        )
+        subnet.id,
+        subnet.nodes.iter().map(|node| pretty_print_node(node, 2)).join("\n")
     )
 }
 
@@ -337,7 +336,7 @@ Test output:
                 explaination,
                 cordoned_features
                     .iter()
-                    .map(|pair| format!("({}, {})", pair.feature.to_string(), pair.value.to_string()))
+                    .map(|pair| format!("({}, {})", pair.feature.to_string(), pair.value))
                     .join(", "),
                 test_pretty_format_response(outcome)
             ))

--- a/rs/cli/src/unit_tests/update_unassigned_nodes.rs
+++ b/rs/cli/src/unit_tests/update_unassigned_nodes.rs
@@ -5,6 +5,7 @@ use crate::auth::Neuron;
 use crate::commands::{update_unassigned_nodes::UpdateUnassignedNodes, ExecutableCommand};
 use crate::cordoned_feature_fetcher::MockCordonedFeatureFetcher;
 use crate::ic_admin::MockIcAdmin;
+use ic_management_backend::health::MockHealthStatusQuerier;
 use ic_management_backend::{lazy_git::MockLazyGit, lazy_registry::MockLazyRegistry, proposal::MockProposalAgent};
 use ic_management_types::{Network, Subnet};
 use ic_types::PrincipalId;
@@ -51,6 +52,7 @@ async fn should_skip_update_same_version_nns_not_provided() {
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
     );
 
     let cmd = UpdateUnassignedNodes { nns_subnet_id: None };
@@ -86,6 +88,7 @@ async fn should_skip_update_same_version_nns_provided() {
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
     );
 
     let cmd = UpdateUnassignedNodes {
@@ -126,6 +129,7 @@ async fn should_update_unassigned_nodes() {
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
     );
 
     let cmd = UpdateUnassignedNodes {
@@ -164,6 +168,7 @@ async fn should_fail_nns_not_found() {
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
     );
 
     let cmd = UpdateUnassignedNodes {

--- a/rs/cli/src/unit_tests/update_unassigned_nodes.rs
+++ b/rs/cli/src/unit_tests/update_unassigned_nodes.rs
@@ -3,6 +3,7 @@ use std::{str::FromStr, sync::Arc};
 use crate::artifact_downloader::MockArtifactDownloader;
 use crate::auth::Neuron;
 use crate::commands::{update_unassigned_nodes::UpdateUnassignedNodes, ExecutableCommand};
+use crate::cordoned_feature_fetcher::MockCordonedFeatureFetcher;
 use crate::ic_admin::MockIcAdmin;
 use ic_management_backend::{lazy_git::MockLazyGit, lazy_registry::MockLazyRegistry, proposal::MockProposalAgent};
 use ic_management_types::{Network, Subnet};
@@ -49,6 +50,7 @@ async fn should_skip_update_same_version_nns_not_provided() {
         Arc::new(MockLazyGit::new()),
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
+        Arc::new(MockCordonedFeatureFetcher::new()),
     );
 
     let cmd = UpdateUnassignedNodes { nns_subnet_id: None };
@@ -83,6 +85,7 @@ async fn should_skip_update_same_version_nns_provided() {
         Arc::new(MockLazyGit::new()),
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
+        Arc::new(MockCordonedFeatureFetcher::new()),
     );
 
     let cmd = UpdateUnassignedNodes {
@@ -122,6 +125,7 @@ async fn should_update_unassigned_nodes() {
         Arc::new(MockLazyGit::new()),
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
+        Arc::new(MockCordonedFeatureFetcher::new()),
     );
 
     let cmd = UpdateUnassignedNodes {
@@ -159,6 +163,7 @@ async fn should_fail_nns_not_found() {
         Arc::new(MockLazyGit::new()),
         Arc::new(MockProposalAgent::new()),
         Arc::new(MockArtifactDownloader::new()),
+        Arc::new(MockCordonedFeatureFetcher::new()),
     );
 
     let cmd = UpdateUnassignedNodes {

--- a/rs/cli/src/unit_tests/version.rs
+++ b/rs/cli/src/unit_tests/version.rs
@@ -10,6 +10,7 @@ use crate::{
     artifact_downloader::MockArtifactDownloader,
     auth::Neuron,
     commands::ExecutableCommand,
+    cordoned_feature_fetcher::MockCordonedFeatureFetcher,
     ctx::tests::get_mocked_ctx,
     ic_admin::{MockIcAdmin, ProposeCommand, ProposeOptions},
     runner::{format_regular_version_upgrade_summary, format_security_hotfix},
@@ -69,6 +70,7 @@ async fn guest_os_elect_version_tests() {
         Arc::new(git),
         Arc::new(proposal_agent),
         Arc::new(artifact_downloader),
+        Arc::new(MockCordonedFeatureFetcher::new()),
     );
 
     for (name, expected_title, cmd) in [

--- a/rs/cli/src/unit_tests/version.rs
+++ b/rs/cli/src/unit_tests/version.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::sync::{Arc, RwLock};
 
 use futures::future::ok;
-use ic_management_backend::{lazy_git::MockLazyGit, lazy_registry::MockLazyRegistry, proposal::MockProposalAgent};
+use ic_management_backend::{health::MockHealthStatusQuerier, lazy_git::MockLazyGit, lazy_registry::MockLazyRegistry, proposal::MockProposalAgent};
 use ic_management_types::{Artifact, ArtifactReleases, Network};
 use itertools::Itertools;
 
@@ -71,6 +71,7 @@ async fn guest_os_elect_version_tests() {
         Arc::new(proposal_agent),
         Arc::new(artifact_downloader),
         Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
     );
 
     for (name, expected_title, cmd) in [

--- a/rs/decentralization/src/nakamoto/mod.rs
+++ b/rs/decentralization/src/nakamoto/mod.rs
@@ -784,8 +784,8 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
-        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
-        let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes).unwrap();
+        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new());
+        let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes, vec![]).unwrap();
         for log in subnet_change.after().run_log.iter() {
             println!("{}", log);
         }
@@ -841,8 +841,8 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
-        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
-        let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes).unwrap();
+        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new());
+        let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes, vec![]).unwrap();
         println!("Replacement run log:");
         for line in subnet_change.after().run_log.iter() {
             println!("{}", line);
@@ -899,8 +899,8 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
-        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
-        let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes).unwrap();
+        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new());
+        let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes, vec![]).unwrap();
 
         println!("Replacement run log:");
         for line in subnet_change.after().run_log.iter() {
@@ -1105,7 +1105,7 @@ mod tests {
         important.insert(subnet.principal, subnet);
 
         let network_heal_response = NetworkHealRequest::new(important.clone())
-            .heal_and_optimize(nodes_available.clone(), &health_of_nodes)
+            .heal_and_optimize(nodes_available.clone(), &health_of_nodes, vec![])
             .await
             .unwrap();
         let result = network_heal_response.first().unwrap().clone();
@@ -1126,12 +1126,12 @@ mod tests {
             .map(|n| (n.id, HealthStatus::Healthy))
             .collect::<IndexMap<_, _>>();
 
-        let change_initial = SubnetChangeRequest::new(subnet_initial.clone(), nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
+        let change_initial = SubnetChangeRequest::new(subnet_initial.clone(), nodes_available, Vec::new(), Vec::new(), Vec::new());
 
         let with_keeping_features = change_initial
             .clone()
             .keeping_from_used(vec!["CH".to_string()])
-            .rescue(&health_of_nodes)
+            .rescue(&health_of_nodes, vec![])
             .unwrap();
 
         assert_eq!(with_keeping_features.added().len(), 6);
@@ -1149,7 +1149,7 @@ mod tests {
         let with_keeping_principals = change_initial
             .clone()
             .keeping_from_used(vec!["CH".to_string()])
-            .rescue(&health_of_nodes)
+            .rescue(&health_of_nodes, vec![])
             .unwrap();
 
         assert_eq!(with_keeping_principals.added().len(), 6);
@@ -1163,7 +1163,7 @@ mod tests {
             1
         );
 
-        let rescue_all = change_initial.clone().rescue(&health_of_nodes).unwrap();
+        let rescue_all = change_initial.clone().rescue(&health_of_nodes, vec![]).unwrap();
 
         assert_eq!(rescue_all.added().len(), 7);
         assert_eq!(rescue_all.removed().len(), 7);

--- a/rs/decentralization/src/nakamoto/mod.rs
+++ b/rs/decentralization/src/nakamoto/mod.rs
@@ -784,7 +784,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
-        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new());
+        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
         let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes).unwrap();
         for log in subnet_change.after().run_log.iter() {
             println!("{}", log);
@@ -841,7 +841,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
-        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new());
+        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
         let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes).unwrap();
         println!("Replacement run log:");
         for line in subnet_change.after().run_log.iter() {
@@ -899,7 +899,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
-        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new());
+        let subnet_change_req = SubnetChangeRequest::new(subnet_initial, nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
         let subnet_change = subnet_change_req.optimize(2, &[], &health_of_nodes).unwrap();
 
         println!("Replacement run log:");
@@ -1126,7 +1126,7 @@ mod tests {
             .map(|n| (n.id, HealthStatus::Healthy))
             .collect::<IndexMap<_, _>>();
 
-        let change_initial = SubnetChangeRequest::new(subnet_initial.clone(), nodes_available, Vec::new(), Vec::new(), Vec::new());
+        let change_initial = SubnetChangeRequest::new(subnet_initial.clone(), nodes_available, Vec::new(), Vec::new(), Vec::new(), vec![]);
 
         let with_keeping_features = change_initial
             .clone()

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -1252,10 +1252,10 @@ impl NetworkHealRequest {
         &self,
         mut available_nodes: Vec<Node>,
         health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
+        cordoned_features: Vec<NodeFeaturePair>,
     ) -> Result<Vec<SubnetChangeResponse>, NetworkError> {
         let mut subnets_changed = Vec::new();
         let subnets_to_heal = unhealthy_with_nodes(&self.subnets, health_of_nodes)
-            .await
             .iter()
             .flat_map(|(subnet_id, unhealthy_nodes)| {
                 let unhealthy_nodes = unhealthy_nodes.iter().map(Node::from).collect::<Vec<_>>();
@@ -1305,6 +1305,7 @@ impl NetworkHealRequest {
             let change_req = SubnetChangeRequest {
                 subnet: subnet.decentralized_subnet.clone(),
                 available_nodes: available_nodes.clone(),
+                cordoned_features: cordoned_features.clone(),
                 ..Default::default()
             };
 

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -1051,15 +1051,12 @@ impl SubnetChangeRequest {
             .into_iter()
             .filter(|n| {
                 for cordoned_feature in &self.cordoned_features {
-                    match n.features.get(&cordoned_feature.feature) {
-                        Some(node_feature) => {
-                            if PartialEq::eq(&node_feature, &cordoned_feature.value) {
-                                // Node contains cordoned feature
-                                // exclude it from available pool
-                                return false;
-                            }
+                    if let Some(node_feature) = n.features.get(&cordoned_feature.feature) {
+                        if PartialEq::eq(&node_feature, &cordoned_feature.value) {
+                            // Node contains cordoned feature
+                            // exclude it from available pool
+                            return false;
                         }
-                        None => {}
                     }
                 }
                 // Node doesn't contain any cordoned features
@@ -1097,15 +1094,12 @@ impl SubnetChangeRequest {
             .filter(|n| health_of_nodes.get(&n.id).unwrap_or(&HealthStatus::Unknown) == &HealthStatus::Healthy)
             .filter(|n| {
                 for cordoned_feature in &self.cordoned_features {
-                    match n.features.get(&cordoned_feature.feature) {
-                        Some(node_feature) => {
-                            if PartialEq::eq(&node_feature, &cordoned_feature.value) {
-                                // Node contains cordoned feature
-                                // exclude it from available pool
-                                return false;
-                            }
+                    if let Some(node_feature) = n.features.get(&cordoned_feature.feature) {
+                        if PartialEq::eq(&node_feature, &cordoned_feature.value) {
+                            // Node contains cordoned feature
+                            // exclude it from available pool
+                            return false;
                         }
-                        None => {}
                     }
                 }
                 // Node doesn't contain any cordoned features

--- a/rs/decentralization/src/subnets.rs
+++ b/rs/decentralization/src/subnets.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use std::sync::Arc;
 
-pub async fn unhealthy_with_nodes(
+pub fn unhealthy_with_nodes(
     subnets: &IndexMap<PrincipalId, Subnet>,
     nodes_health: &IndexMap<PrincipalId, HealthStatus>,
 ) -> IndexMap<PrincipalId, Vec<ic_management_types::Node>> {

--- a/rs/ic-management-backend/src/health.rs
+++ b/rs/ic-management-backend/src/health.rs
@@ -1,4 +1,6 @@
+use futures::future::BoxFuture;
 use indexmap::IndexMap;
+use mockall::automock;
 use std::{collections::HashSet, str::FromStr};
 
 use ic_base_types::PrincipalId;
@@ -24,17 +26,17 @@ impl HealthClient {
 }
 
 impl HealthStatusQuerier for HealthClient {
-    async fn subnet(&self, subnet: PrincipalId) -> anyhow::Result<IndexMap<PrincipalId, HealthStatus>> {
+    fn subnet(&self, subnet: PrincipalId) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> {
         match &self.implementation {
-            HealthStatusQuerierImplementations::Dashboard(c) => c.subnet(subnet).await,
-            HealthStatusQuerierImplementations::Prometheus(c) => c.subnet(subnet).await,
+            HealthStatusQuerierImplementations::Dashboard(c) => c.subnet(subnet),
+            HealthStatusQuerierImplementations::Prometheus(c) => c.subnet(subnet),
         }
     }
 
-    async fn nodes(&self) -> anyhow::Result<IndexMap<PrincipalId, HealthStatus>> {
+    fn nodes(&self) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> {
         match &self.implementation {
-            HealthStatusQuerierImplementations::Dashboard(c) => c.nodes().await,
-            HealthStatusQuerierImplementations::Prometheus(c) => c.nodes().await,
+            HealthStatusQuerierImplementations::Dashboard(c) => c.nodes(),
+            HealthStatusQuerierImplementations::Prometheus(c) => c.nodes(),
         }
     }
 }
@@ -54,10 +56,11 @@ impl From<Network> for HealthStatusQuerierImplementations {
     }
 }
 
+#[automock]
 #[allow(dead_code)]
-pub trait HealthStatusQuerier {
-    fn subnet(&self, subnet: PrincipalId) -> impl std::future::Future<Output = anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> + Send;
-    fn nodes(&self) -> impl std::future::Future<Output = anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> + Send;
+pub trait HealthStatusQuerier: Send + Sync {
+    fn subnet(&self, subnet: PrincipalId) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>>;
+    fn nodes(&self) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>>;
 }
 
 pub struct PublicDashboardHealthClient {
@@ -186,21 +189,23 @@ struct ShortNodeInfo {
 }
 
 impl HealthStatusQuerier for PublicDashboardHealthClient {
-    async fn subnet(&self, subnet: PrincipalId) -> anyhow::Result<IndexMap<PrincipalId, HealthStatus>> {
-        Ok(self
-            .get_all_nodes()
-            .await?
-            .into_iter()
-            .filter(|n| match n.subnet_id {
-                None => false,
-                Some(p) => p.eq(&subnet),
-            })
-            .map(|n| (n.node_id, n.status))
-            .collect())
+    fn subnet(&self, subnet: PrincipalId) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> {
+        Box::pin(async move {
+            Ok(self
+                .get_all_nodes()
+                .await?
+                .into_iter()
+                .filter(|n| match n.subnet_id {
+                    None => false,
+                    Some(p) => p.eq(&subnet),
+                })
+                .map(|n| (n.node_id, n.status))
+                .collect())
+        })
     }
 
-    async fn nodes(&self) -> anyhow::Result<IndexMap<PrincipalId, HealthStatus>> {
-        Ok(self.get_all_nodes().await?.into_iter().map(|n| (n.node_id, n.status)).collect())
+    fn nodes(&self) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> {
+        Box::pin(async { Ok(self.get_all_nodes().await?.into_iter().map(|n| (n.node_id, n.status)).collect()) })
     }
 }
 
@@ -219,65 +224,69 @@ impl PrometheusHealthClient {
 }
 
 impl HealthStatusQuerier for PrometheusHealthClient {
-    async fn subnet(&self, subnet: PrincipalId) -> anyhow::Result<IndexMap<PrincipalId, HealthStatus>> {
-        let ic_name = self.network.legacy_name();
-        let subnet_name = subnet.to_string();
-        let query_up = Selector::new()
-            .metric("up")
-            .eq("ic", ic_name.as_str())
-            .eq("job", "replica")
-            .eq("ic_subnet", subnet_name.as_str());
+    fn subnet(&self, subnet: PrincipalId) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> {
+        Box::pin(async move {
+            let ic_name = self.network.legacy_name();
+            let subnet_name = subnet.to_string();
+            let query_up = Selector::new()
+                .metric("up")
+                .eq("ic", ic_name.as_str())
+                .eq("job", "replica")
+                .eq("ic_subnet", subnet_name.as_str());
 
-        let response_up = self.client.query(query_up).get().await?;
-        let instant_up = response_up.data().as_vector().expect("Expected instant vector");
+            let response_up = self.client.query(query_up).get().await?;
+            let instant_up = response_up.data().as_vector().expect("Expected instant vector");
 
-        // Alerts are synthetic time series and cannot be queries as regular metrics
-        // https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/#inspecting-alerts-during-runtime
-        let query_alert = format!(
-            "ALERTS{{ic=\"{}\", job=\"replica\", ic_subnet=\"{}\", alertstate=\"firing\"}}",
-            self.network.legacy_name(),
-            subnet
-        );
-        let response_alert = self.client.query(query_alert).get().await?;
-        let instant_alert = response_alert.data().as_vector().expect("Expected instant vector");
-        let node_ids_with_alerts: HashSet<PrincipalId> = instant_alert
-            .iter()
-            .filter_map(|r| r.metric().get("ic_node").and_then(|id| PrincipalId::from_str(id).ok()))
-            .collect();
+            // Alerts are synthetic time series and cannot be queries as regular metrics
+            // https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/#inspecting-alerts-during-runtime
+            let query_alert = format!(
+                "ALERTS{{ic=\"{}\", job=\"replica\", ic_subnet=\"{}\", alertstate=\"firing\"}}",
+                self.network.legacy_name(),
+                subnet
+            );
+            let response_alert = self.client.query(query_alert).get().await?;
+            let instant_alert = response_alert.data().as_vector().expect("Expected instant vector");
+            let node_ids_with_alerts: HashSet<PrincipalId> = instant_alert
+                .iter()
+                .filter_map(|r| r.metric().get("ic_node").and_then(|id| PrincipalId::from_str(id).ok()))
+                .collect();
 
-        Ok(instant_up
-            .iter()
-            .filter_map(|r| {
-                r.metric().get("ic_node").and_then(|id| PrincipalId::from_str(id).ok()).map(|id| {
-                    let status = if r.sample().value() == 1.0 {
-                        if node_ids_with_alerts.contains(&id) {
-                            HealthStatus::Degraded
+            Ok(instant_up
+                .iter()
+                .filter_map(|r| {
+                    r.metric().get("ic_node").and_then(|id| PrincipalId::from_str(id).ok()).map(|id| {
+                        let status = if r.sample().value() == 1.0 {
+                            if node_ids_with_alerts.contains(&id) {
+                                HealthStatus::Degraded
+                            } else {
+                                HealthStatus::Healthy
+                            }
                         } else {
-                            HealthStatus::Healthy
-                        }
-                    } else {
-                        HealthStatus::Dead
-                    };
-                    (id, status)
+                            HealthStatus::Dead
+                        };
+                        (id, status)
+                    })
                 })
-            })
-            .collect())
+                .collect())
+        })
     }
 
-    async fn nodes(&self) -> anyhow::Result<IndexMap<PrincipalId, HealthStatus>> {
-        let query = format!(
-            r#"ic_replica_orchestrator:health_state:bottomk_1{{ic="{network}"}}"#,
-            network = self.network.legacy_name(),
-        );
-        let response = self.client.query(query).get().await?;
-        let results = response.data().as_vector().expect("Expected instant vector");
-        Ok(results
-            .iter()
-            .filter_map(|r| {
-                let status = HealthStatus::from_str(r.metric().get("state").expect("all vectors should have a state label"))
-                    .expect("all vectors should have a valid label");
-                r.metric().get("ic_node").map(|id| (PrincipalId::from_str(id).unwrap(), status))
-            })
-            .collect())
+    fn nodes(&self) -> BoxFuture<'_, anyhow::Result<IndexMap<PrincipalId, HealthStatus>>> {
+        Box::pin(async {
+            let query = format!(
+                r#"ic_replica_orchestrator:health_state:bottomk_1{{ic="{network}"}}"#,
+                network = self.network.legacy_name(),
+            );
+            let response = self.client.query(query).get().await?;
+            let results = response.data().as_vector().expect("Expected instant vector");
+            Ok(results
+                .iter()
+                .filter_map(|r| {
+                    let status = HealthStatus::from_str(r.metric().get("state").expect("all vectors should have a state label"))
+                        .expect("all vectors should have a valid label");
+                    r.metric().get("ic_node").map(|id| (PrincipalId::from_str(id).unwrap(), status))
+                })
+                .collect())
+        })
     }
 }


### PR DESCRIPTION
This PR adds the ability to cordon features by adding entries to the new `cordoned_features.yaml` file. Currently it will exclude from the pool of available nodes all the nodes with the cordoned feature. It will not attempt to remove all healthy nodes (in the subnet) that have said feature, it will just prevent entering of the new nodes with those features.

When removing nodes from the subnet and when they are added back to the available pool, if the removed node contains cordoned features it will not be added to the available pool. It means that some of the nodes containing cordoned features _could_ be removed if the business rules are met.