### PR TITLE
Add NP rewards computation algorithm

### DIFF
--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/App.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/App.tsx
@@ -25,7 +25,7 @@ const darkTheme = createTheme({
 
 const App: React.FC = () => {
   const [infoBanner, setInfoBanner] = useState<boolean | null>(true);
-  const [providers, setProviders] = useState<Set<string>>(new Set());
+  const [providers, setProviders] = useState<Map<string, string>>(new Map());
   const [nodeMetadata, setNodeMetadata] = useState<NodeMetadata[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -38,7 +38,12 @@ const App: React.FC = () => {
       try {
         setIsLoading(true);
         const nodeMetadata = await trustworthy_node_metrics.nodes_metadata();
-        const providers = new Set(nodeMetadata.flatMap(metadata => metadata.node_metadata_stored.node_provider_id.toText()));
+        const providers = new Map<string, string>(
+          nodeMetadata.map(metadata => [
+            metadata.node_metadata_stored.node_provider_id.toText(),
+            metadata.node_metadata_stored.node_provider_name[0] ? metadata.node_metadata_stored.node_provider_name[0] : ""
+          ])
+        );
 
         setProviders(providers);
         setNodeMetadata(nodeMetadata);

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/Drawer.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/Drawer.tsx
@@ -14,7 +14,7 @@ import Logo from '../assets/icp_logo.svg';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 
 interface DrawerProps {
-  providers: Set<string>;
+  providers: Map<string, string>;
   drawerWidth: number;
   temporary: boolean;
   drawerOpen: boolean;
@@ -23,10 +23,11 @@ interface DrawerProps {
 
 const Drawer: React.FC<DrawerProps> = ({ providers, drawerWidth, temporary, drawerOpen, onClosed }) => {
   const [isNodeProvidersOpen, setIsNodeProvidersOpen] = React.useState(false);
-  
+  const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null);
+
   const renderCollapsibleList = (
     title: string,
-    items: Set<string>,
+    items: Map<string, string>,
     isOpen: boolean,
     toggleOpen: React.Dispatch<React.SetStateAction<boolean>>,
     basePath: string
@@ -42,9 +43,13 @@ const Drawer: React.FC<DrawerProps> = ({ providers, drawerWidth, temporary, draw
         <Collapse in={isOpen} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
             {itemList.map((item, index) => (
-              <Link key={index} to={`/${basePath}/${item}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-                <ListItemButton>
-                  <ListItemText primary={item.split("-")[0]} />
+              <Link key={index} to={`/${basePath}/${item[0]}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+                <ListItemButton
+                  key={index}
+                  selected={selectedIndex === index}
+                  onClick={() => setSelectedIndex(index)}
+                >
+                  <ListItemText primary={item[1]} />
                 </ListItemButton>
               </Link>
             ))}

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/Drawer.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/Drawer.tsx
@@ -33,7 +33,7 @@ const Drawer: React.FC<DrawerProps> = ({ providers, drawerWidth, temporary, draw
     basePath: string
   ) => {
     const itemList = items 
-    ? Array.from(items).sort((a, b) => a[1].localeCompare(b[1])) 
+    ? Array.from(items).sort((a, b) => a[0].localeCompare(b[0])) 
     : [];
 
     return (

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/Drawer.tsx
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics-frontend/src/components/Drawer.tsx
@@ -32,7 +32,9 @@ const Drawer: React.FC<DrawerProps> = ({ providers, drawerWidth, temporary, draw
     toggleOpen: React.Dispatch<React.SetStateAction<boolean>>,
     basePath: string
   ) => {
-    const itemList = items ? Array.from(items) : [];
+    const itemList = items 
+    ? Array.from(items).sort((a, b) => a[1].localeCompare(b[1])) 
+    : [];
 
     return (
       <>

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -165,11 +165,6 @@ fn get_node_rate(region: &String, node_type: &String) -> NodeRewardRate {
     }
 }
 
-fn get_region_node_type_key(region: &str, node_type: &str) -> String {
-    let region_key = region.splitn(3, ',').take(2).collect::<Vec<&str>>().join(":");
-    format!("{}:{}", region_key, if node_type.starts_with("type3") { "type3" } else { node_type })
-}
-
 fn coumpute_node_provider_rewards(
     nodes_multiplier: &[NodeRewardsMultiplier],
     rewardable_nodes: collections::BTreeMap<RegionNodeTypeCategory, u32>,
@@ -284,7 +279,7 @@ fn coumpute_node_provider_rewards(
             if node_type.starts_with("type3") {
                 let region_key = region.splitn(3, ',').take(2).collect::<Vec<&str>>().join(":");
                 let xdr_permyriad_avg_based = type3_rewards.get(&region_key).expect("Type3 rewards should have been filled already");
-                
+
                 rewards_xdr_no_reduction_total += *xdr_permyriad_avg_based;
                 rewards_xdr += *xdr_permyriad_avg_based * *multiplier;
             } else {

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -194,7 +194,7 @@ fn coumpute_node_provider_rewards(
 
             computation_logger.execute(
                 &format!(
-                    "Setting count of nodes in region {} with type {}, with coefficient {}, with rewards {} XDRths\n",
+                    "Setting count of nodes in region {} with type {}, with coefficient {}, with rewards {} XDR * 10'000\n",
                     region, node_type, regional_coeff, regional_rewards
                 ),
                 Operation::Set(Decimal::from(node_count)),
@@ -292,14 +292,14 @@ fn coumpute_node_provider_rewards(
         }
 
         computation_logger.execute(
-            &format!("Rewards contribution XDRths for nodes in region {} with type: {}\n", region, node_type),
+            &format!("Rewards contribution XDR * 10'000 for nodes in region {} with type: {}\n", region, node_type),
             Operation::Set(rewards_xdr),
         );
 
         rewards_xdr_total += rewards_xdr;
     }
 
-    computation_logger.execute("Total rewards XDRths\n", Operation::Set(rewards_xdr_total));
+    computation_logger.execute("Total rewards XDR * 10'000\n", Operation::Set(rewards_xdr_total));
 
     NodeProviderRewardsComputation {
         rewards_xdr: rewards_xdr_total.to_u64().unwrap(),

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -292,7 +292,10 @@ fn coumpute_node_provider_rewards(
         }
 
         computation_logger.execute(
-            &format!("Rewards contribution XDR * 10'000 for nodes in region {} with type: {}\n", region, node_type),
+            &format!(
+                "Rewards contribution XDR * 10'000 for nodes in region {} with type: {}\n",
+                region, node_type
+            ),
             Operation::Set(rewards_xdr),
         );
 

--- a/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
+++ b/rs/dre-canisters/trustworthy-node-metrics/src/trustworthy-node-metrics/src/rewards_manager.rs
@@ -4,7 +4,7 @@ use ic_nns_governance_api::pb::v1::MonthlyNodeProviderRewards;
 use ic_protobuf::registry::node_rewards::{v2::NodeRewardRate, v2::NodeRewardsTable};
 use ic_registry_keys::NODE_REWARDS_TABLE_KEY;
 use itertools::Itertools;
-use num_traits::{ToPrimitive, Zero};
+use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::collections::{self, HashMap};
@@ -165,68 +165,141 @@ fn get_node_rate(region: &String, node_type: &String) -> NodeRewardRate {
     }
 }
 
-#[allow(unused_variables)]
+fn get_region_node_type_key(region: &str, node_type: &str) -> String {
+    let region_key = region.splitn(3, ',').take(2).collect::<Vec<&str>>().join(":");
+    format!("{}:{}", region_key, if node_type.starts_with("type3") { "type3" } else { node_type })
+}
+
 fn coumpute_node_provider_rewards(
     nodes_multiplier: &[NodeRewardsMultiplier],
     rewardable_nodes: collections::BTreeMap<RegionNodeTypeCategory, u32>,
 ) -> NodeProviderRewardsComputation {
-    let rewards_xdr_total = dec!(0);
-    let rewards_xdr_no_reduction_total = dec!(0);
-    let computation_logger = ComputationLogger::new();
+    let mut rewards_xdr_total = dec!(0);
+    let mut rewards_xdr_no_reduction_total = dec!(0);
+    let mut computation_logger = ComputationLogger::new();
 
-    // 1 - Compute rewards and coefficients average for all nodes type3 and type3.1 in the same region
-    let mut type3_coefficients: HashMap<String, Vec<Decimal>> = HashMap::new();
-    let mut type3_rewards: HashMap<String, Vec<Decimal>> = HashMap::new();
+    let mut multipliers_group: HashMap<String, Vec<Decimal>> = HashMap::new();
 
-    for ((region, node_type), count) in rewardable_nodes {
-        if node_type.starts_with("type3") && count > 0 {
+    // 1.1 - Extract coefficients and rewards for type3* nodes in all regions
+
+    let mut type3_coefficients_rewards: HashMap<String, (Vec<Decimal>, Vec<Decimal>)> = HashMap::new();
+
+    for ((region, node_type), node_count) in rewardable_nodes.clone() {
+        if node_type.starts_with("type3") && node_count > 0 {
             let rate = get_node_rate(&region, &node_type);
-            let current_coefficients = vec![Decimal::from(rate.reward_coefficient_percent.unwrap_or(80)) / dec!(100); count as usize];
-            let current_rewards = vec![Decimal::from(rate.xdr_permyriad_per_node_per_month); count as usize];
+            let regional_coeff = Decimal::from(rate.reward_coefficient_percent.unwrap_or(80)) / dec!(100);
+            let regional_rewards = Decimal::from(rate.xdr_permyriad_per_node_per_month);
+            let coefficients = vec![regional_coeff; node_count as usize];
+            let rewards = vec![regional_rewards; node_count as usize];
 
-            let region_key = region.splitn(3, ',').take(2).collect::<Vec<&str>>().join(":");
+            computation_logger.execute(
+                &format!(
+                    "Setting count of nodes in region {} with type {}, with coefficient {}, with rewards {} XDRths\n",
+                    region, node_type, regional_coeff, regional_rewards
+                ),
+                Operation::Set(Decimal::from(node_count)),
+            );
 
-            type3_coefficients
-                .entry(region_key.clone())
-                .and_modify(|c| c.extend(current_coefficients.clone()))
-                .or_insert(current_coefficients);
-            type3_rewards
-                .entry(region_key)
-                .and_modify(|c| c.extend(current_rewards.clone()))
-                .or_insert(current_rewards);
+            type3_coefficients_rewards
+                .entry(region)
+                .and_modify(|(entry_coefficients, entry_rewards)| {
+                    entry_coefficients.extend(&coefficients);
+                    entry_rewards.extend(&rewards);
+                })
+                .or_insert((coefficients, rewards));
         }
     }
-    let type3_coefficients_avg: HashMap<String, Decimal> = type3_coefficients
-        .iter()
-        .map(|(key, coefficients)| {
-            let sum: Decimal = coefficients.iter().cloned().fold(Decimal::zero(), |acc, val| acc + val);
-            let avg = sum / Decimal::from(coefficients.len());
-            (key.clone(), avg)
+
+    // 1.2 - Compute node rewards for type3* nodes in all regions
+
+    let type3_rewards: HashMap<String, Decimal> = type3_coefficients_rewards
+        .clone()
+        .into_iter()
+        .map(|(region, (coefficients, rewards))| {
+            let mut running_coefficient = dec!(1);
+            let mut region_rewards = dec!(0);
+            let coefficients_avg = computation_logger.execute(
+                &format!("Coefficient average in region {} for type3* nodes\n", region),
+                Operation::Set(coefficients.iter().fold(Decimal::zero(), |acc, val| acc + val) / Decimal::from(coefficients.len())),
+            );
+            let rewards_avg = computation_logger.execute(
+                &format!("Rewards average in region {} for type3* nodes\n", region),
+                Operation::Set(rewards.iter().fold(Decimal::zero(), |acc, val| acc + val) / Decimal::from(rewards.len())),
+            );
+
+            for _ in 0..rewards.len() {
+                region_rewards += rewards_avg * running_coefficient;
+                running_coefficient *= coefficients_avg;
+            }
+            let region_rewards_avg = computation_logger.execute(
+                &format!(
+                    "Computing rewards average after coefficient reduction in region {} for type3* nodes\n",
+                    region
+                ),
+                Operation::Divide(region_rewards, Decimal::from(rewards.len())),
+            );
+
+            (region, region_rewards_avg)
         })
         .collect();
 
-    let type3_rewards_avg: HashMap<String, Decimal> = type3_rewards
-        .iter()
-        .map(|(key, rewards)| {
-            let sum: Decimal = rewards.iter().cloned().fold(Decimal::zero(), |acc, val| acc + val);
-            let avg = sum / Decimal::from(rewards.len());
-            (key.clone(), avg)
-        })
-        .collect();
+    // 2 - For assigned nodes map to region and node_type the reward multipliers
+    for node in nodes_multiplier {
+        let metadata = stable_memory::get_node_metadata(&node.node_id).expect("Node should have one node provider");
+        let key = get_region_node_type_key(&metadata.region, &metadata.node_type);
 
-    let type3_rewards_reduced = type3_rewards.into_iter().map(|(region, individual_rewards)| {
-        let mut coefficient = dec!(1);
-        let mut rewards_reduced_by_coeff = dec!(0);
-        let region_coefficient_avg = type3_coefficients_avg.get(&region).unwrap();
-        let region_rewards_avg = type3_coefficients_avg.get(&region).unwrap();
+        let rewards_multiplier = Decimal::from_f64(node.rewards_multiplier.rewards_multiplier).unwrap();
 
-        for _ in individual_rewards.clone() {
-            rewards_reduced_by_coeff += region_rewards_avg * coefficient;
-            coefficient *= region_coefficient_avg;
+        computation_logger.execute(
+            &format!(
+                "Set rewards multiplier for Node {}, in region {} with type {}\n",
+                node.node_id, metadata.region, metadata.node_type
+            ),
+            Operation::Set(Decimal::from_f64(node.rewards_multiplier.rewards_multiplier).unwrap()),
+        );
+
+        multipliers_group.entry(key).or_default().push(rewards_multiplier);
+    }
+
+    // 3 - Now compute total rewards with reductions
+
+    for ((region, node_type), node_count) in rewardable_nodes {
+        // Fetch the key used by all node_types to get the multiplier
+        let key = get_region_node_type_key(&region, &node_type);
+        let rewards_multipliers = multipliers_group.entry(key).or_default();
+        let mut rewards_xdr = dec!(0);
+        rewards_multipliers.resize(node_count as usize, dec!(1));
+
+        computation_logger.execute(
+            &format!(
+                "Rewards multipliers len for nodes in region {} with type {}: {:?}\n",
+                region, node_type, rewards_multipliers
+            ),
+            Operation::Set(Decimal::from(rewards_multipliers.len())),
+        );
+
+        for multiplier in rewards_multipliers {
+            if node_type.starts_with("type3") {
+                let xdr_permyriad_avg_based = type3_rewards.get(&region).expect("Type3 rewards should have been filled already");
+                rewards_xdr_no_reduction_total += *xdr_permyriad_avg_based;
+                rewards_xdr += *xdr_permyriad_avg_based * *multiplier;
+            } else {
+                let rate = get_node_rate(&region, &node_type);
+                let xdr_permyriad = Decimal::from(rate.xdr_permyriad_per_node_per_month);
+                rewards_xdr_no_reduction_total += xdr_permyriad;
+                rewards_xdr += xdr_permyriad * *multiplier;
+            }
         }
 
-        let rewards_reduced_by_coeff_avg = rewards_reduced_by_coeff / Decimal::from(individual_rewards.len());
-    });
+        computation_logger.execute(
+            &format!("Rewards contribution XDRths for nodes in region {} with type: {}\n", region, node_type),
+            Operation::Set(rewards_xdr),
+        );
+
+        rewards_xdr_total += rewards_xdr;
+    }
+
+    computation_logger.execute("Total rewards XDRths\n", Operation::Set(rewards_xdr_total));
 
     NodeProviderRewardsComputation {
         rewards_xdr: rewards_xdr_total.to_u64().unwrap(),


### PR DESCRIPTION
- Add Node Provider rewards computation algorithm based on avg. rewards and coefficients for `type3*` nodes, all other types rewarded without coefficient
- Added reduction for underperforming nodes
- Display computation log in the dashboard
- Display NP names instead of ids in dropdown menu