### PR TITLE
Revert EU country handling in decentralization code

### DIFF
--- a/rs/decentralization/src/nakamoto/mod.rs
+++ b/rs/decentralization/src/nakamoto/mod.rs
@@ -960,14 +960,14 @@ mod tests {
 
     #[test]
     fn test_european_subnet_european_nodes_good() {
-        let subnet_initial = new_test_subnet_with_overrides(0, 0, 7, 1, (&NodeFeature::Country, &["EU", "EU", "EU", "EU", "EU", "EU", "CH"]))
+        let subnet_initial = new_test_subnet_with_overrides(0, 0, 7, 1, (&NodeFeature::Country, &["AT", "BE", "DE", "ES", "FR", "IT", "CH"]))
             .with_subnet_id(PrincipalId::from_str("bkfrj-6k62g-dycql-7h53p-atvkj-zg4to-gaogh-netha-ptybj-ntsgw-rqe").unwrap());
         assert_eq!(subnet_initial.check_business_rules().unwrap(), (0, vec![]));
     }
 
     #[test]
     fn test_european_subnet_european_nodes_bad_1() {
-        let subnet_mix = new_test_subnet_with_overrides(1, 0, 7, 1, (&NodeFeature::Country, &["EU", "China", "CH", "EU", "EU", "EU", "EU"]))
+        let subnet_mix = new_test_subnet_with_overrides(1, 0, 7, 1, (&NodeFeature::Country, &["AT", "BE", "DE", "ES", "FR", "IT", "IN"]))
             .with_subnet_id(PrincipalId::from_str("bkfrj-6k62g-dycql-7h53p-atvkj-zg4to-gaogh-netha-ptybj-ntsgw-rqe").unwrap());
         assert_eq!(
             subnet_mix.check_business_rules().unwrap(),
@@ -976,11 +976,11 @@ mod tests {
     }
     #[test]
     fn test_european_subnet_european_nodes_bad_2() {
-        let subnet_mix = new_test_subnet_with_overrides(1, 0, 7, 1, (&NodeFeature::Country, &["EU", "China", "US", "AU", "EU", "SA", "AR"]))
+        let subnet_mix = new_test_subnet_with_overrides(1, 0, 7, 1, (&NodeFeature::Country, &["AT", "BE", "DE", "ES", "US", "IN", "AR"]))
             .with_subnet_id(PrincipalId::from_str("bkfrj-6k62g-dycql-7h53p-atvkj-zg4to-gaogh-netha-ptybj-ntsgw-rqe").unwrap());
         assert_eq!(
             subnet_mix.check_business_rules().unwrap(),
-            (5000, vec!["European subnet has 5 non-European node(s)".to_string()])
+            (3000, vec!["European subnet has 3 non-European node(s)".to_string()])
         );
     }
 

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -14,7 +14,6 @@ use log::{debug, info, warn};
 use rand::{seq::SliceRandom, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
@@ -83,36 +82,6 @@ impl PartialEq for Node {
 
 impl From<&ic_management_types::Node> for Node {
     fn from(n: &ic_management_types::Node) -> Self {
-        // Work around the current (as of 2024) registry configuration in which the EU countries are not properly marked.
-        let eu_countries: HashMap<&str, &str> = HashMap::from_iter([
-            ("AT", "Austria"),
-            ("BE", "Belgium"),
-            ("BG", "Bulgaria"),
-            ("CY", "Cyprus"),
-            ("CZ", "Czechia"),
-            ("DE", "Germany"),
-            ("DK", "Denmark"),
-            ("EE", "Estonia"),
-            ("ES", "Spain"),
-            ("FI", "Finland"),
-            ("FR", "France"),
-            ("GR", "Greece"),
-            ("HR", "Croatia"),
-            ("HU", "Hungary"),
-            ("IE", "Ireland"),
-            ("IT", "Italy"),
-            ("LT", "Lithuania"),
-            ("LU", "Luxembourg"),
-            ("LV", "Latvia"),
-            ("MT", "Malta"),
-            ("NL", "Netherlands"),
-            ("PL", "Poland"),
-            ("PT", "Portugal"),
-            ("RO", "Romania"),
-            ("SE", "Sweden"),
-            ("SI", "Slovenia"),
-            ("SK", "Slovakia"),
-        ]);
         let country = n
             .operator
             .datacenter
@@ -125,10 +94,40 @@ impl From<&ic_management_types::Node> for Node {
             .as_ref()
             .map(|d| d.area.clone())
             .unwrap_or_else(|| "unknown".to_string());
-        let (country, area) = match eu_countries.get(&country.as_str()) {
-            Some(country) => ("EU".to_string(), country.to_string()),
-            None => (country, area),
-        };
+        // // Work around the current (as of 2024) registry configuration in which the EU countries are not properly marked.
+        // let eu_countries: HashMap<&str, &str> = HashMap::from_iter([
+        //     ("AT", "Austria"),
+        //     ("BE", "Belgium"),
+        //     ("BG", "Bulgaria"),
+        //     ("CY", "Cyprus"),
+        //     ("CZ", "Czechia"),
+        //     ("DE", "Germany"),
+        //     ("DK", "Denmark"),
+        //     ("EE", "Estonia"),
+        //     ("ES", "Spain"),
+        //     ("FI", "Finland"),
+        //     ("FR", "France"),
+        //     ("GR", "Greece"),
+        //     ("HR", "Croatia"),
+        //     ("HU", "Hungary"),
+        //     ("IE", "Ireland"),
+        //     ("IT", "Italy"),
+        //     ("LT", "Lithuania"),
+        //     ("LU", "Luxembourg"),
+        //     ("LV", "Latvia"),
+        //     ("MT", "Malta"),
+        //     ("NL", "Netherlands"),
+        //     ("PL", "Poland"),
+        //     ("PT", "Portugal"),
+        //     ("RO", "Romania"),
+        //     ("SE", "Sweden"),
+        //     ("SI", "Slovenia"),
+        //     ("SK", "Slovakia"),
+        // ]);
+        // let (country, area) = match eu_countries.get(&country.as_str()) {
+        //     Some(country) => ("EU".to_string(), country.to_string()),
+        //     None => (country, area),
+        // };
 
         Self {
             id: n.principal,

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -98,7 +98,7 @@ impl Node {
             ("SI", "Slovenia"),
             ("SK", "Slovakia"),
         ]);
-        eu_countries.get(country).is_some()
+        eu_countries.contains_key(country)
     }
 }
 


### PR DESCRIPTION
The previous replacement of city with the country in the EU countries had unintended consequences on the decentralization calculations. To avoid further issues, this pull request reverts the code back to its original state, where EU countries are handled separately and EU is not included in the calculations.