### PR TITLE
rc--2024-10-03_01-30-canister-overhead-hotfix

### DIFF
--- a/release-index.yaml
+++ b/release-index.yaml
@@ -11,8 +11,9 @@ releases:
         version: f0c923eba09e9c1444501692b0ab4884882bf5bc
       - # This has the same reverts as the prior but rides atop the revert-ubuntu-22-04 release
         # Here is the test battery: https://github.com/dfinity/ic/actions/runs/11243607016
-        name: revert-ubuntu-22-04-canister-overhead-hotfix
-        version: 7c50c0db1e247a25896d77da72c410ff17ef5773
+        # It is just here as a backup:
+        #   name: revert-ubuntu-22-04-canister-overhead-hotfix
+        #   version: 7c50c0db1e247a25896d77da72c410ff17ef5773
   - rc_name: rc--2024-09-26_01-31
     versions:
       # Qualification pipeline:

--- a/release-index.yaml
+++ b/release-index.yaml
@@ -5,9 +5,13 @@ releases:
         version: d2657773d007e1b4c0b2dd715c628d24c0d7b5fb
       - name: revert-ubuntu-22-04
         version: 1ff0e709f0d0984a4f9ab06456db177c4b6e48a0
-      - name: canister-overhead-hotfix
+      - # This has three reverts and rides atop the base release
+        # Here is the successful test: https://github.com/dfinity/ic/actions/runs/11241522710
+        name: canister-overhead-hotfix
         version: f0c923eba09e9c1444501692b0ab4884882bf5bc
-      - name: revert-ubuntu-22-04-canister-overhead-hotfix
+      - # This has the same reverts as the prior but rides atop the revert-ubuntu-22-04 release
+        # Here is the test battery: https://github.com/dfinity/ic/actions/runs/11243607016
+        name: revert-ubuntu-22-04-canister-overhead-hotfix
         version: 7c50c0db1e247a25896d77da72c410ff17ef5773
   - rc_name: rc--2024-09-26_01-31
     versions:

--- a/release-index.yaml
+++ b/release-index.yaml
@@ -7,6 +7,8 @@ releases:
         version: 1ff0e709f0d0984a4f9ab06456db177c4b6e48a0
       - name: canister-overhead-hotfix
         version: f0c923eba09e9c1444501692b0ab4884882bf5bc
+      - name: revert-ubuntu-22-04-canister-overhead-hotfix
+        version: 7c50c0db1e247a25896d77da72c410ff17ef5773
   - rc_name: rc--2024-09-26_01-31
     versions:
       # Qualification pipeline:

--- a/release-index.yaml
+++ b/release-index.yaml
@@ -5,6 +5,8 @@ releases:
         version: d2657773d007e1b4c0b2dd715c628d24c0d7b5fb
       - name: revert-ubuntu-22-04
         version: 1ff0e709f0d0984a4f9ab06456db177c4b6e48a0
+      - name: canister-overhead-hotfix
+        version: f0c923eba09e9c1444501692b0ab4884882bf5bc
   - rc_name: rc--2024-09-26_01-31
     versions:
       # Qualification pipeline:


### PR DESCRIPTION
Reverted three commits on top of the base release to solve the problem of high utilization in subnet `fuqsr`.