### PR TITLE
fix: using different api for pagination

### DIFF
--- a/release-controller/mock_requests_post_fecher.py
+++ b/release-controller/mock_requests_post_fecher.py
@@ -1,0 +1,21 @@
+from forum import RequestsPostFetcher
+
+
+class MockRequestsPostFetcher(RequestsPostFetcher):
+    """A mock requests post fetcher client."""
+
+    def __init__(self, created_posts):
+        """Create mock post fetcher."""
+        self.created_posts = created_posts
+
+    def fetch_topics_posts(self, topic_id):
+        """Fetch mocked topics."""
+        return {
+            "post_stream": {
+                "posts": [
+                    p
+                    for p in [{"id": i + 1} | p for i, p in enumerate(self.created_posts)]
+                    if p["topic_id"] == topic_id
+                ]
+            }
+        }

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -18,7 +18,7 @@ import __fix_import_paths  # isort:skip  # noqa: F401 # pylint: disable=W0611
 import release_index
 import requests
 from dotenv import load_dotenv
-from forum import ReleaseCandidateForumClient
+from forum import ReleaseCandidateForumClient, RequestsPostFetcher
 from git_repo import GitRepo
 from git_repo import push_release_tags
 from github import Auth
@@ -354,9 +354,11 @@ def main():
     )
     forum_client = ReleaseCandidateForumClient(
         discourse_client,
-        discourse_api_key=os.environ["DISCOURSE_KEY"],
-        discourse_url=os.environ["DISCOURSE_URL"],
-        discourse_username=os.environ["DISCOURSE_USER"],
+        RequestsPostFetcher(
+            discourse_api_key=os.environ["DISCOURSE_KEY"],
+            discourse_url=os.environ["DISCOURSE_URL"],
+            discourse_username=os.environ["DISCOURSE_USER"],
+        ),
     )
     github_token = os.environ["GITHUB_TOKEN"]
     github_client = Github(auth=Auth.Token(github_token))

--- a/release-controller/test_forum.py
+++ b/release-controller/test_forum.py
@@ -1,6 +1,7 @@
 import httpretty.utils
 from forum import ReleaseCandidateForumClient
 from mock_discourse import DiscourseClientMock
+from mock_requests_post_fecher import MockRequestsPostFetcher
 from release_index import Release
 from release_index import Version
 
@@ -155,9 +156,7 @@ release notes for version test2...
     discourse_client.created_topics = [existing_topic]
     forum_client = ReleaseCandidateForumClient(
         discourse_client=discourse_client,
-        discourse_api_key="",
-        discourse_url="https://forum.dfinity.org",
-        discourse_username="",
+        post_fetcher=MockRequestsPostFetcher(created_posts=discourse_client.created_posts),
     )
     post = forum_client.get_or_create(
         Release(

--- a/release-controller/test_forum.py
+++ b/release-controller/test_forum.py
@@ -26,9 +26,7 @@ def test_create_release_notes_on_new_release():
     assert discourse_client.created_topics == []
     forum_client = ReleaseCandidateForumClient(
         discourse_client=discourse_client,
-        discourse_api_key="",
-        discourse_url="https://forum.dfinity.org",
-        discourse_username="",
+        post_fetcher=MockRequestsPostFetcher(created_posts=discourse_client.created_posts),
     )
     post = forum_client.get_or_create(
         Release(

--- a/release-controller/test_forum.py
+++ b/release-controller/test_forum.py
@@ -23,7 +23,9 @@ def test_create_release_notes_on_new_release():
     )
     assert discourse_client.created_posts == []
     assert discourse_client.created_topics == []
-    forum_client = ReleaseCandidateForumClient(discourse_client=discourse_client)
+    forum_client = ReleaseCandidateForumClient(
+        discourse_client=discourse_client, discourse_api_key="", discourse_url="", discourse_username=""
+    )
     post = forum_client.get_or_create(
         Release(
             rc_name="rc--2024-02-21_23-06",
@@ -148,7 +150,9 @@ release notes for version test2...
         "title": "Proposal to elect new release rc--2024-02-21_23-06",
     }
     discourse_client.created_topics = [existing_topic]
-    forum_client = ReleaseCandidateForumClient(discourse_client=discourse_client)
+    forum_client = ReleaseCandidateForumClient(
+        discourse_client=discourse_client, discourse_api_key="", discourse_url="", discourse_username=""
+    )
     post = forum_client.get_or_create(
         Release(
             rc_name="rc--2024-02-21_23-06",

--- a/release-controller/test_forum.py
+++ b/release-controller/test_forum.py
@@ -24,7 +24,10 @@ def test_create_release_notes_on_new_release():
     assert discourse_client.created_posts == []
     assert discourse_client.created_topics == []
     forum_client = ReleaseCandidateForumClient(
-        discourse_client=discourse_client, discourse_api_key="", discourse_url="", discourse_username=""
+        discourse_client=discourse_client,
+        discourse_api_key="",
+        discourse_url="https://forum.dfinity.org",
+        discourse_username="",
     )
     post = forum_client.get_or_create(
         Release(
@@ -151,7 +154,10 @@ release notes for version test2...
     }
     discourse_client.created_topics = [existing_topic]
     forum_client = ReleaseCandidateForumClient(
-        discourse_client=discourse_client, discourse_api_key="", discourse_url="", discourse_username=""
+        discourse_client=discourse_client,
+        discourse_api_key="",
+        discourse_url="https://forum.dfinity.org",
+        discourse_username="",
     )
     post = forum_client.get_or_create(
         Release(

--- a/release-controller/test_reconciler.py
+++ b/release-controller/test_reconciler.py
@@ -13,7 +13,8 @@ from mock_discourse import DiscourseClientMock
 from mock_google_docs import ReleaseNotesClientMock
 from publish_notes import PublishNotesClient
 from pydantic_yaml import parse_yaml_raw_as
-from reconciler import find_base_release, oldest_active_release
+from reconciler import find_base_release
+from reconciler import oldest_active_release
 from reconciler import Reconciler
 from reconciler import ReconcilerState
 from reconciler import version_package_checksum
@@ -38,7 +39,9 @@ class TestReconcilerState(ReconcilerState):
 def test_e2e_mock_new_release(mocker):
     """Test the workflow when a new release is added to the index."""
     discourse_client = DiscourseClientMock()
-    forum_client = ReleaseCandidateForumClient(discourse_client)
+    forum_client = ReleaseCandidateForumClient(
+        discourse_client, discourse_api_key="", discourse_url="", discourse_username=""
+    )
     notes_client = ReleaseNotesClientMock()
     github_client = Github()
     mocker.patch.object(github_client, "get_repo")


### PR DESCRIPTION
At the moment we have an issue with the discourse client fetching only 20 posts (which is the default). This results in crashing and recreating the same message
> We’re preparing a new IC release. The changelog will be announced soon.

Sadly the [DiscourseClient](https://github.com/pydiscourse/pydiscourse/blob/master/src/pydiscourse/client.py) we use doesn't allow for using any suggestions from [this blog post about pagination](https://meta.discourse.org/t/fetch-all-posts-from-a-topic-using-the-api/260886) so I had to tweak the code and use standard `requests` for this.