### PR TITLE
feat(dre): number of nodes per subnet for node operators

### DIFF
--- a/rs/cli/src/commands/registry.rs
+++ b/rs/cli/src/commands/registry.rs
@@ -186,6 +186,10 @@ async fn get_node_operators(local_registry: &Arc<dyn LazyRegistry>, network: &Ne
             });
             // Find the number of nodes registered by this operator
             let operator_registered_nodes_num = all_nodes.iter().filter(|(nk, _)| nk == &k).count() as u64;
+            let nodes_in_subnets = all_nodes
+                .iter()
+                .filter(|(_, value)| value.operator.principal == record.principal && value.subnet_id.is_some())
+                .count() as u64;
             (
                 record.principal,
                 NodeOperator {
@@ -200,6 +204,7 @@ async fn get_node_operators(local_registry: &Arc<dyn LazyRegistry>, network: &Ne
                     total_up_nodes: 0,
                     nodes_health: Default::default(),
                     rewards_correct: false,
+                    nodes_in_subnets,
                 },
             )
         })
@@ -482,6 +487,7 @@ struct NodeOperator {
     total_up_nodes: u32,
     nodes_health: IndexMap<String, Vec<PrincipalId>>,
     rewards_correct: bool,
+    nodes_in_subnets: u64,
 }
 
 // We re-create the rewards structs here in order to convert the output of get-rewards-table into the format


### PR DESCRIPTION
Equals to jq query:
```bash
dre registry | jq '[.nodes.[] | select(.subnet_id != null) | select(.node_provider_id == "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe")] | length'
```

The zoomed in output of the command for each node_operator will be something like:
```diff
{
  "node_operator_principal_id": "fthz3-5otsb-xppaq-zhlut-dxel6-5fgxj-oz56h-r7zrz-xlq5z-cxpe4-uae",
  "node_allowance_remaining": 0,
  "node_allowance_total": 0,
  "node_provider_principal_id": "sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe",
  "node_provider_name": "43rd Big Idea Films",
  "dc_id": "hu1",
  "rewardable_nodes": {
    "type0": 14
  },
  "ipv6": "",
  "total_up_nodes": 14,
  "nodes_health": {
    "Healthy": [
      "5qmio-5ls3e-yujlz-eqt7k-qk5ys-bscfd-7w2rn-2q3fq-6smjq-n7asc-xae",
      "6pt6z-rdv25-glenj-xvuq3-zdeeu-4c74r-smqeh-tgt34-exgd6-2wxvv-eqe",
      "7r64j-zqmz7-krqtz-zetpm-x56et-wkege-el55a-nbgwx-dffso-lbtob-4qe",
      "akbo3-imbii-tzc4p-swdwz-hh2tg-i2ffj-tnzjy-zycuo-3xjcq-zxbth-aqe",
      "ayugg-n2ex3-azu4v-3sddp-mtbj5-k3ygp-tcmmy-pp2f3-3faes-hw77i-aqe",
      "ghmoa-vaks4-tubtk-z3wml-wglax-lrfzt-6lh7y-uwgzg-ly4iv-zubjh-iqe",
      "ham46-r7u4j-yoyrk-mrnxu-utzq3-c37he-vcns2-gc5yg-jxyv5-mvlhc-gae",
      "m2g5i-bmomq-dyjao-k642i-fsfxg-trxki-6i42q-hm6ec-xu5cd-n5jhq-sqe",
      "wh2dv-njrdv-4xdwd-dflb2-mjoel-l6pkz-e37ap-pkcjx-jyasn-hawsc-wqe",
      "wix7d-hb2a6-2pcsi-xwm54-gmlxk-gfh3d-dtfog-h7o35-vzm56-w7h34-6qe",
      "wqqsg-ww46o-muchq-pty53-amebx-mucdz-ugjkt-fvjqr-5ncmg-knqg4-aqe",
      "wxhcm-5armm-j6fvs-lts6q-waitz-k6t4q-ncfbh-2t6ee-nv2tn-keod2-uae",
      "xcfmt-vumwz-773ew-pvwnt-lgwlu-prfzm-lvitu-bx7ru-ncgqg-srhut-mae",
      "yqbqe-whgvn-teyic-zvtln-rcolf-yztin-ecal6-smlwy-6imph-6isdn-qqe"
    ]
  },
  "rewards_correct": true,
+ "nodes_in_subnets": 2
}
```