### PR TITLE
chore(release): Pass --guestos to repro-check.sh in proposal summaries

### DIFF
--- a/release-controller/release_index_loader.py
+++ b/release-controller/release_index_loader.py
@@ -20,7 +20,7 @@ To build and verify the IC-OS disk image, run:
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c {version}
+sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c {version} --guestos
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.

--- a/release-controller/release_index_loader.py
+++ b/release-controller/release_index_loader.py
@@ -24,6 +24,8 @@ sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://ra
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.
+
+While not required for this NNS proposal, as we are only electing a new GuestOS version here, you have the option to verify the build reproducibility of the HostOS by passing `--hostos` to the script above instead of `--guestos`, or the SetupOS by passing `--setupos`.
 """
 
 

--- a/release-controller/test_release_index_loader.py
+++ b/release-controller/test_release_index_loader.py
@@ -107,7 +107,7 @@ To build and verify the IC-OS disk image, run:
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-sudo apt-get install -y curl && curl --proto \'=https\' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/35bfcadd0f2a474057e42393917b8b3ac269627a/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c 35bfcadd0f2a474057e42393917b8b3ac269627a
+sudo apt-get install -y curl && curl --proto \'=https\' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/35bfcadd0f2a474057e42393917b8b3ac269627a/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c 35bfcadd0f2a474057e42393917b8b3ac269627a --guestos
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.

--- a/release-controller/test_release_index_loader.py
+++ b/release-controller/test_release_index_loader.py
@@ -111,5 +111,7 @@ sudo apt-get install -y curl && curl --proto \'=https\' --tlsv1.2 -sSLO https://
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.
+
+While not required for this NNS proposal, as we are only electing a new GuestOS version here, you have the option to verify the build reproducibility of the HostOS by passing `--hostos` to the script above instead of `--guestos`, or the SetupOS by passing `--setupos`.
 """
         )

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -882,7 +882,7 @@ pub fn format_regular_version_upgrade_summary(
 
     ```
     # From https://github.com/dfinity/ic#verifying-releases
-    sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c {version}
+    sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c {version} --guestos
     ```
 
     The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image,

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -888,6 +888,8 @@ pub fn format_regular_version_upgrade_summary(
     The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image,
     must be identical, and must match the SHA256 from the payload of the NNS proposal.
 
+    While not required for this NNS proposal, as we are only electing a new GuestOS version here, you have the option to verify the build reproducibility of the HostOS by passing `--hostos` to the script above instead of `--guestos`, or the SetupOS by passing `--setupos`.
+
     Forum post link: {forum_post_link}
     "#
     );


### PR DESCRIPTION
Since https://github.com/dfinity/ic/pull/2148, repro-check.sh accepts a `--guestos` argument to verify build reproducibility of GuestOS only.
Since build reproducibility of HostOS and SetupOS isn't of critical importance for GuestOS proposals, let's omit the checks of those two in the version elect proposals.