### PR TITLE
fix: using correct version for the ubuntu20.04 release

### DIFF
--- a/release-index.yaml
+++ b/release-index.yaml
@@ -10,7 +10,7 @@ releases:
       - name: hashes-in-blocks
         version: cc1319059ee8283cf96481109f98d0b14b967859
       - name: ubuntu20.04
-        version: 372b9a57494a50f7ffd0db595b40d467a16e5ac8
+        version: 51f6f4e4ab7fa2a8ad4cf573e04fc2686e14fa57
       # Qualification pipeline:
       # https://github.com/dfinity/ic/actions/runs/11612372216
       - name: 6.11-kernel


### PR DESCRIPTION
The qualification had issues and there were more reverts.