### PR TITLE
Only consider available nodes for network operator assignment

### DIFF
--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -1140,8 +1140,8 @@ impl SubnetChangeRequest {
             .collect_vec();
 
         info!(
-            "Resizing subnet {} by removing {} healthy and {} unhealthy nodes, and adding {}. Total available {} healthy nodes.",
-            self.subnet.id,
+            "Evaluating change in subnet {} membership: removing ({} healthy + {} unhealthy) and adding {} node. Total available {} healthy nodes.",
+            self.subnet.id.to_string().split_once('-').expect("subnet id is expected to have a -").0,
             how_many_nodes_to_remove,
             how_many_nodes_unhealthy,
             how_many_nodes_to_add + self.include_nodes.len(),

--- a/rs/ic-management-backend/src/lazy_registry.rs
+++ b/rs/ic-management-backend/src/lazy_registry.rs
@@ -71,7 +71,7 @@ pub trait LazyRegistry:
 
     fn subnets(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Subnet>>>>;
 
-    fn nodes_with_proposals(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Node>>>>;
+    fn nodes_and_proposals(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Node>>>>;
 
     fn nns_replica_version(&self) -> BoxFuture<'_, anyhow::Result<Option<String>>> {
         Box::pin(async {
@@ -683,7 +683,7 @@ impl LazyRegistry for LazyRegistryImpl {
         })
     }
 
-    fn nodes_with_proposals(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Node>>>> {
+    fn nodes_and_proposals(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Node>>>> {
         Box::pin(async {
             let nodes = self.nodes().await?;
             if nodes.iter().any(|(_, n)| n.proposal.is_some()) {
@@ -897,15 +897,15 @@ impl decentralization::network::TopologyManager for LazyRegistryImpl {}
 impl AvailableNodesQuerier for LazyRegistryImpl {
     fn available_nodes(&self) -> BoxFuture<'_, Result<Vec<decentralization::network::Node>, ic_management_types::NetworkError>> {
         Box::pin(async {
-            let (nodes, healths) = try_join!(self.nodes_with_proposals(), self.health_client.nodes())
+            let (nodes_and_proposals, healths) = try_join!(self.nodes_and_proposals(), self.health_client.nodes())
                 .map_err(|e| ic_management_types::NetworkError::DataRequestError(e.to_string()))?;
-            let nodes = nodes
+            let available_nodes = nodes_and_proposals
                 .values()
                 .filter(|n| n.subnet_id.is_none() && n.proposal.is_none() && n.duplicates.is_none() && !n.is_api_boundary_node)
                 .cloned()
                 .collect_vec();
 
-            Ok(nodes
+            Ok(available_nodes
                 .iter()
                 .filter(|n| {
                     // Keep only healthy nodes.
@@ -940,7 +940,7 @@ mock! {
 
         fn subnets(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Subnet>>>>;
 
-        fn nodes_with_proposals(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Node>>>>;
+        fn nodes_and_proposals(&self) -> BoxFuture<'_, anyhow::Result<Arc<IndexMap<PrincipalId, Node>>>>;
 
         fn unassigned_nodes_replica_version(&self) -> BoxFuture<'_, anyhow::Result<Arc<String>>>;
 


### PR DESCRIPTION
Refactor the code to ensure only available nodes are considered for network operator assignments, improving clarity and functionality. Minor adjustments enhance variable naming for better understanding.