### PR TITLE
feat: ensure that there are some publishable changes in release notes

### DIFF
--- a/release-controller/publish_notes.py
+++ b/release-controller/publish_notes.py
@@ -8,6 +8,8 @@ from github import Github
 from github.Repository import Repository
 import markdown
 from itertools import groupby
+from google_docs import ReleaseNotesClient
+import pathlib
 
 REPLICA_RELEASES_DIR = "replica-releases"
 
@@ -121,15 +123,53 @@ class PublishNotesClient:
             return
 
         changelog = changelog[release_notes_start:]
+        if check_number_of_changes(changelog) == 0:
+            logging.warning("release notes for version %s contain no commits that would be published.")
+            return
         # TODO: parse markdown to check formatting is correct
         self.ensure_published(version=version, changelog=changelog)
 
+def check_number_of_changes(changelog: str) -> int:
+    BEGINNING_MARKER = "To see a full list of commits added since last release"
+    ENDING_MARKER = "## Excluded Changes"
+
+    num_changes = 0
+    found_beginning = False
+    for line in changelog.splitlines():
+        print("Processing line whole:", line)
+        if not found_beginning and line.startswith(BEGINNING_MARKER):
+            found_beginning = True
+            continue
+
+        if found_beginning:
+            print("Processing line:", line)
+            if line.startswith(ENDING_MARKER):
+                break
+            if line.startswith("*"):
+                num_changes += 1
+
+    return num_changes
 
 def main():
     load_dotenv()
     github_client = Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"]))
     client = PublishNotesClient(github_client.get_repo("dfinity/dre-testing"))
     client.ensure_published("85bd56a70e55b2cea75cae6405ae11243e5fdad8", "test")
+
+    # For testing the `check_number_of_changes`
+    release_notes_client = ReleaseNotesClient(
+        credentials_file=pathlib.Path(
+            os.environ.get(
+                "GDOCS_CREDENTIALS_PATH",
+                pathlib.Path(__file__).parent.resolve() / "credentials.json",
+            )
+        )
+    )
+    # Would not publish this one
+    version = "c6847128f3a872e0e084b2920bfcd21f881c69fa"
+    # Should publish this one
+    # version = "f88938214b16584075196e13d0af7c50f671131a"
+    client.publish_if_ready(release_notes_client.markdown_file(version), version)
 
 
 if __name__ == "__main__":

--- a/release-controller/publish_notes.py
+++ b/release-controller/publish_notes.py
@@ -105,14 +105,14 @@ class PublishNotesClient:
     def publish_if_ready(self, google_doc_markdownified, version: str):
         """Publish the release notes if they are ready."""
         if not isinstance(google_doc_markdownified, str):
-            logging.info("didn't get markdown notes for %s, skipping", version)
+            logging.warning("didn't get markdown notes for %s, skipping", version)
             return
 
         changelog = post_process_release_notes(google_doc_markdownified)
 
         release_notes_start = changelog.find("Release Notes")
         if release_notes_start == -1:
-            logging.warning("could not find release notes section for version %s", version)
+            logging.error("could not find release notes section for version %s", version)
             return
 
         if not re.match(
@@ -124,7 +124,7 @@ class PublishNotesClient:
 
         changelog = changelog[release_notes_start:]
         if check_number_of_changes(changelog) == 0:
-            logging.warning("release notes for version %s contain no commits that would be published.")
+            logging.error("release notes for version %s contain no commits that would be published.")
             return
         # TODO: parse markdown to check formatting is correct
         self.ensure_published(version=version, changelog=changelog)

--- a/release-controller/test_publish_notes.py
+++ b/release-controller/test_publish_notes.py
@@ -173,6 +173,10 @@ Release Notes for [**rc--2024-02-21\\_23-01**](https://github.com/dfinity/ic/tre
 
 Changelog since git revision [8d4b6898d878fa3db4028b316b78b469ed29f293](https://dashboard.internetcomputer.org/release/8d4b6898d878fa3db4028b316b78b469ed29f293)
 
+Please note that some commits may be excluded from this release if they're not relevant, or not modifying the GuestOS image. Additionally, descriptions of some changes might have been slightly modified to fit the release notes format.
+
+To see a full list of commits added since last release, compare the revisions on GitHub.
+
 Bugfixes:
 ---------
 
@@ -200,6 +204,9 @@ Something:
 
 Other:
 ------
+
+## Excluded Changes:
+------
 """,
         "2e921c9adfc71f3edc96a9eb5d85fc742e7d8a9f",
     )
@@ -212,6 +219,10 @@ Release Notes for [**rc--2024-02-21\\_23-01**](https://github.com/dfinity/ic/tre
 =================================================================================================================================================
 
 Changelog since git revision [8d4b6898d878fa3db4028b316b78b469ed29f293](https://dashboard.internetcomputer.org/release/8d4b6898d878fa3db4028b316b78b469ed29f293)
+
+Please note that some commits may be excluded from this release if they're not relevant, or not modifying the GuestOS image. Additionally, descriptions of some changes might have been slightly modified to fit the release notes format.
+
+To see a full list of commits added since last release, compare the revisions on GitHub.
 
 Features:
 ---------
@@ -263,6 +274,10 @@ Release Notes for [**rc--2024-02-21\\_23-01**](https://github.com/dfinity/ic/tre
 
 Changelog since git revision [8d4b6898d878fa3db4028b316b78b469ed29f293](https://dashboard.internetcomputer.org/release/8d4b6898d878fa3db4028b316b78b469ed29f293)
 
+Please note that some commits may be excluded from this release if they're not relevant, or not modifying the GuestOS image. Additionally, descriptions of some changes might have been slightly modified to fit the release notes format.
+
+To see a full list of commits added since last release, compare the revisions on GitHub.
+
 Features:
 ---------
 
@@ -308,6 +323,10 @@ Release Notes for [**rc--2024-02-21\\_23-01**](https://github.com/dfinity/ic/tre
 
 Changelog since git revision [8d4b6898d878fa3db4028b316b78b469ed29f293](https://dashboard.internetcomputer.org/release/8d4b6898d878fa3db4028b316b78b469ed29f293)
 
+Please note that some commits may be excluded from this release if they're not relevant, or not modifying the GuestOS image. Additionally, descriptions of some changes might have been slightly modified to fit the release notes format.
+
+To see a full list of commits added since last release, compare the revisions on GitHub.
+
 Features:
 ---------
 
@@ -319,8 +338,59 @@ Features:
 * ~~author: Leo Eich | [6a4d8962c](https://github.com/dfinity/ic/commit/6a4d8962c) Consensus(ecdsa): Make masked kappa config optional~~
 * author: Leo Eich | [e76c5a374](https://github.com/dfinity/ic/commit/e76c5a374) Consensus(ecdsa): Stop relaying tECDSA signature shares
 * author: Leo Eich | [2d63da24c](https://github.com/dfinity/ic/commit/2d63da24c) Consensus(ecdsa): Add optional kappa\\_unmasked config to QuadrupleInCreation
+
+## Excluded Changes:
+---------
 """,
         "2e921c9adfc71f3edc96a9eb5d85fc742e7d8a9f",
+    )
+
+    assert publish_client.ensure_published.call_count == 0  # pylint: disable=no-member
+
+def test_publish_if_ready__ready_no_changes(mocker):
+    github_client = Github()
+    mocker.patch.object(github_client, "get_repo")
+    repo = github_client.get_repo("dfinity/non-existent-mock")
+    publish_client = PublishNotesClient(repo)
+    mocker.patch.object(publish_client, "ensure_published")
+
+    publish_client.publish_if_ready(
+        """\
+Review checklist
+================
+
+Please cross-out your team once you finished the review
+
+* ~~@team-consensus~~
+* ~~@team-crypto~~
+* ~~@team-execution~~
+* ~~@team-messaging~~
+* ~~@team-networking~~
+* ~~@node-team~~
+* ~~@team-runtime~~
+
+Release Notes for [**rc--2024-02-21\\_23-01**](https://github.com/dfinity/ic/tree/rc--2024-02-21_23-01) (2e921c9adfc71f3edc96a9eb5d85fc742e7d8a9f)
+=================================================================================================================================================
+
+Changelog since git revision [8d4b6898d878fa3db4028b316b78b469ed29f293](https://dashboard.internetcomputer.org/release/8d4b6898d878fa3db4028b316b78b469ed29f293)
+
+Please note that some commits may be excluded from this release if they're not relevant, or not modifying the GuestOS image. Additionally, descriptions of some changes might have been modified to fit the release notes format.
+
+To see a full list of commits added since last release, compare the revisions on GitHub.
+
+## Features:
+---------
+
+* ~~author: Igor Novg |~~ [5f9e639d1](https://github.com/dfinity/ic/commit/5f9e639d1) ~~Boundary Nodes: remove njs~~
+* ~~author: Igor Novg |~~ [eb7f3dc5c](https://github.com/dfinity/ic/commit/eb7f3dc5c) ~~Boundary Nodes: improve nginx performance~~
+* ~~author: Kami Popi |~~ [26f30f055](https://github.com/dfinity/ic/commit/26f30f055) Consensus: Purge non-finalized blocks and notarizations below the finalized height
+* ~~author: Leo Eich |~~ [b4673936a](https://github.com/dfinity/ic/commit/b4673936a) Consensus(ecdsa): Make key\\_unmasked\\_ref in PreSignatureQuadrupleRef required
+* ~~author: Leo Eich |~~ [b733f7043](https://github.com/dfinity/ic/commit/b733f7043) Consensus(ecdsa): Extend Quadruple state machine in preparation for random unmasked kappa
+* ~~author: Leo Eich | [6a4d8962c](https://github.com/dfinity/ic/commit/6a4d8962c) Consensus(ecdsa): Make masked kappa config optional~~
+* ~~author: Leo Eich |~~ [e76c5a374](https://github.com/dfinity/ic/commit/e76c5a374) Consensus(ecdsa): Stop relaying tECDSA signature shares
+* ~~author: Leo Eich |~~ [2d63da24c](https://github.com/dfinity/ic/commit/2d63da24c) Consensus(ecdsa): Add optional kappa\\_unmasked config to QuadrupleInCreation
+""",
+        "2e921c9adfc71f3edc96a9eb5d85fc742e7d8a9f"
     )
 
     assert publish_client.ensure_published.call_count == 0  # pylint: disable=no-member


### PR DESCRIPTION
This PR modifies the step before creating a PR on our repository for reviewing changes. Previously the only criteria we checked was if all the teams reviewed the notes (by crossing their name out). With this PR we will check how many changes are publishable. 

Change is publishable if its not: 
* Manually excluded by developers
* Automatically excluded by release controller