### PR TITLE
chore(IDX): replace PAT with GitHub App

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,6 +27,12 @@ jobs:
     # This image is based on ubuntu:20.04
     container: ghcr.io/dfinity/dre/actions-runner:3dd4f38f076cad73fdcc68ad37fd29bed4fa3e4d
     steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
@@ -41,7 +47,7 @@ jobs:
       - name: "🚀 Building"
         uses: ./.github/workflows/build
         with:
-          GITHUB_TOKEN: "${{ secrets.GIX_CREATE_PR_PAT }}"
+          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
       - name: "🚀 Testing"
         env:
           STAGING_PRIVATE_KEY_PEM: "${{ secrets.STAGING_PRIVATE_KEY_PEM }}"

--- a/.github/workflows/pull-request-update.yaml
+++ b/.github/workflows/pull-request-update.yaml
@@ -9,9 +9,15 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-22.04
     steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - uses: chinthakagodawita/autoupdate@v1.7.0
         env:
-          GITHUB_TOKEN: "${{ secrets.GIX_CREATE_PR_PAT }}"
+          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
           MERGE_MSG: "Branch was auto-updated."
           RETRY_COUNT: "5"
           RETRY_SLEEP: "1000"

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -10,6 +10,12 @@ jobs:
     runs-on: ubuntu-20.04
     container: ghcr.io/dfinity/dre/actions-runner:3dd4f38f076cad73fdcc68ad37fd29bed4fa3e4d
     steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - uses: actions/checkout@v4
       - name: "🔧 Setup runner"
         uses: ./.github/workflows/manage-runner-pre
@@ -56,7 +62,7 @@ jobs:
           branch: bot-update-deps
           title: "chore: Update dependencies"
           body: "This PR updates Python, Rust crates, and IC repository dependencies"
-          token: ${{ secrets.GIX_CREATE_PR_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "🪓 Tear down runner"
         uses: ./.github/workflows/manage-runner-post


### PR DESCRIPTION
This is part of a larger effort to remove the need for PATs generated by service accounts and use GitHub apps instead.