### PR TITLE
feat(dre): Discourse client for automatic forum post management around proposals.

### DIFF
--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -131,7 +131,7 @@ pub struct DiscourseOpts {
     #[clap(long, env = "DISCOURSE_API_KEY")]
     pub(crate) discourse_api_key: Option<String>,
 
-    /// Api key used to interact with the forum
+    /// Api user that will interact with the forum
     #[clap(long, env = "DISCOURSE_API_USER")]
     pub(crate) discourse_api_user: Option<String>,
 

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -130,6 +130,10 @@ pub struct DiscourseOpts {
     #[clap(long, env = "DISCOURSE_API_KEY")]
     pub(crate) discourse_api_key: Option<String>,
 
+    /// Api key used to interact with the forum
+    #[clap(long, env = "DISCOURSE_API_USER")]
+    pub(crate) discourse_api_user: Option<String>,
+
     /// Api url used to interact with the forum
     #[clap(long, env = "DISCOURSE_API_URL")]
     pub(crate) discourse_api_url: Option<String>,

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -124,11 +124,25 @@ impl TryFrom<String> for AuthOpts {
     }
 }
 
+#[derive(ClapArgs, Debug, Clone)]
+pub struct DiscourseOpts {
+    /// Api key used to interact with the forum
+    #[clap(long, env = "DISCOURSE_API_KEY")]
+    pub(crate) discourse_api_key: Option<String>,
+
+    /// Api url used to interact with the forum
+    #[clap(long, env = "DISCOURSE_API_URL")]
+    pub(crate) discourse_api_url: Option<String>,
+}
+
 #[derive(Parser, Debug)]
 #[clap(version = env!("CARGO_PKG_VERSION"), about, author)]
 pub struct Args {
     #[clap(flatten)]
     pub(crate) auth_opts: AuthOpts,
+
+    #[clap(flatten)]
+    pub(crate) discourse_opts: DiscourseOpts,
 
     /// Neuron ID
     #[clap(long, global = true, env = "NEURON_ID")]

--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -1,5 +1,6 @@
 use clap::{error::ErrorKind, Args};
 use ic_types::PrincipalId;
+use log::warn;
 
 use crate::{
     commands::{AuthRequirement, ExecutableCommand},
@@ -101,7 +102,15 @@ impl ExecutableCommand for Replace {
                 .propose_submit(
                     runner_proposal.cmd,
                     ProposeOptions {
-                        forum_post_link: maybe_topic.as_ref().map(|topic| topic.url.clone()),
+                        forum_post_link: match (maybe_topic.as_ref(), runner_proposal.opts.forum_post_link.as_ref()) {
+                            (Some(discourse_response), _) => Some(discourse_response.url.clone()),
+                            (None, Some(from_cli_or_auto_formated)) => Some(from_cli_or_auto_formated.clone()),
+                            _ => {
+                                warn!("Didn't find a link to forum post from discourse, cli and couldn't auto-format it.");
+                                warn!("Will not add forum post to the proposal");
+                                None
+                            }
+                        },
                         ..runner_proposal.opts
                     },
                 )

--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -70,7 +70,7 @@ impl ExecutableCommand for Replace {
 
         let runner = ctx.runner().await?;
 
-        let subnet_id = subnet_change_response.subnet_id.clone();
+        let subnet_id = subnet_change_response.subnet_id;
         // Should be refactored to not require forum post links like this.
         if let Some(runner_proposal) = runner.propose_subnet_change(subnet_change_response, ctx.forum_post_link()).await? {
             let ic_admin = ctx.ic_admin().await?;

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -269,7 +269,14 @@ impl DreContext {
             ),
         };
 
-        let client = Arc::new(DiscourseClientImp::new(forum_url, api_key, api_user)?);
+        let client = Arc::new(DiscourseClientImp::new(
+            forum_url,
+            api_key,
+            api_user,
+            // `offline` for discourse client means that it shouldn't try and create posts.
+            // It can happen because the tool runs in offline mode, or if its a dry run.
+            self.store.is_offline() || self.dry_run,
+        )?);
         *self.discourse_client.borrow_mut() = Some(client.clone());
         Ok(client)
     }

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -257,18 +257,19 @@ impl DreContext {
             return Ok(client.clone());
         }
 
-        let (api_key, forum_url) = match (
+        let (api_key, api_user, forum_url) = match (
             self.discourse_opts.discourse_api_key.clone(),
+            self.discourse_opts.discourse_api_user.clone(),
             self.discourse_opts.discourse_api_url.clone(),
         ) {
-            (Some(api_key), Some(forum_url)) => (api_key, forum_url),
+            (Some(api_key), Some(api_user), Some(forum_url)) => (api_key, api_user, forum_url),
             _ => anyhow::bail!(
                 "Expected to have both `api_key` and `forum_url`. Instead found: {:?}",
                 self.discourse_opts
             ),
         };
 
-        let client = Arc::new(DiscourseClientImp::new(forum_url, api_key)?);
+        let client = Arc::new(DiscourseClientImp::new(forum_url, api_key, api_user)?);
         *self.discourse_client.borrow_mut() = Some(client.clone());
         Ok(client)
     }
@@ -343,6 +344,7 @@ pub mod tests {
             discourse_opts: DiscourseOpts {
                 discourse_api_key: None,
                 discourse_api_url: None,
+                discourse_api_user: None,
             },
             discourse_client: RefCell::new(Some(discourse_client)),
         }

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -1,0 +1,85 @@
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use ic_protobuf::types::v1::PrincipalId;
+use mockall::automock;
+use reqwest::Client;
+
+#[automock]
+pub trait DiscourseClient: Sync + Send {
+    fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, summary: String) -> BoxFuture<'_, anyhow::Result<DiscourseResponse>>;
+
+    fn add_proposal_url_to_post(&self, id: String, proposal_url: String) -> BoxFuture<'_, anyhow::Result<()>>;
+}
+
+pub struct DiscourseClientImp {
+    client: Client,
+    forum_url: String,
+    api_key: String,
+}
+
+impl DiscourseClientImp {
+    pub fn new(url: String, api_key: String) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(30)).build()?;
+
+        Ok(Self {
+            client,
+            forum_url: url,
+            api_key,
+        })
+    }
+
+    async fn get_category_id(&self, category: String) -> anyhow::Result<u8> {
+        Ok(0)
+    }
+
+    async fn create_post(&self, title: String, summary: String, category: String, tags: Vec<String>) -> anyhow::Result<DiscourseResponse> {
+        Ok(DiscourseResponse {
+            id: "123".to_string(),
+            url: "123".to_string(),
+        })
+    }
+}
+
+impl DiscourseClient for DiscourseClientImp {
+    fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, summary: String) -> BoxFuture<'_, anyhow::Result<DiscourseResponse>> {
+        todo!()
+    }
+
+    fn add_proposal_url_to_post(&self, id: String, proposal_url: String) -> BoxFuture<'_, anyhow::Result<()>> {
+        todo!()
+    }
+}
+
+pub struct DiscourseResponse {
+    pub url: String,
+    pub id: String,
+}
+
+struct CreateTopicPayload {
+    title: String,
+    raw: String,
+    category: u8,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_client() -> DiscourseClientImp {
+        DiscourseClientImp::new(
+            "http://localhost:3000".to_string(),
+            "37e522a546506f9e3751265669de2576896491b0a3c39d0524be8689736c8722".to_string(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_categories() {
+        let client = get_client();
+
+        let category = client.get_category_id("governance".to_string()).await.unwrap();
+
+        println!("{}", category)
+    }
+}

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -172,7 +172,7 @@ Proposal id [{1}](https://dashboard.internetcomputer.org/proposal/{1})"#,
 }
 
 pub fn parse_proposal_id_from_governance_response(response: String) -> anyhow::Result<u64> {
-    let re = Regex::new(r"proposal\s+(\d+)")?;
+    let re = Regex::new(r"\s*(\d+)\s*")?;
 
     re.captures(&response.to_lowercase())
         .ok_or(anyhow::anyhow!("Expected some captures while parsing id from governance canister"))?
@@ -199,16 +199,16 @@ mod tests {
 
     #[test]
     fn parse_proposal_id_test() {
-        let text = "propoSAL 123456".to_string();
+        let text = " 123456   ".to_string();
         let parsed = parse_proposal_id_from_governance_response(text).unwrap();
         assert_eq!(parsed, 123456);
 
-        let text = "Proposal 222222".to_string();
+        let text = "222222".to_string();
         let parsed = parse_proposal_id_from_governance_response(text).unwrap();
         assert_eq!(parsed, 222222);
 
         let text = "Proposal id 123456".to_string();
-        let parsed = parse_proposal_id_from_governance_response(text);
-        assert!(parsed.is_err())
+        let parsed = parse_proposal_id_from_governance_response(text).unwrap();
+        assert_eq!(parsed, 123456)
     }
 }

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -74,7 +74,7 @@ impl DiscourseClientImp {
                     if name == category_name {
                         return Some(id);
                     }
-                    return None;
+                    None
                 }
                 _ => None,
             })

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -146,7 +146,7 @@ impl DiscourseClient for DiscourseClientImp {
                     format!("Replacing nodes in subnet {}", first_part),
                     summary,
                     "Governance".to_string(),
-                    vec!["nns".to_string()],
+                    vec!["Subnet-management".to_string()],
                 )
                 .await?;
             Ok(Some(topic))

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -197,26 +197,6 @@ pub struct DiscourseResponse {
 mod tests {
     use super::*;
 
-    fn get_client() -> DiscourseClientImp {
-        DiscourseClientImp::new(
-            "http://localhost:3000".to_string(),
-            "37e522a546506f9e3751265669de2576896491b0a3c39d0524be8689736c8722".to_string(),
-            "nikolamilosa20".to_string(),
-        )
-        .unwrap()
-    }
-
-    // #[tokio::test]
-    async fn discourse_test() {
-        let client = get_client();
-
-        let response = client
-            .create_replace_nodes_forum_post(PrincipalId::new_subnet_test_id(0), "testing".to_string())
-            .await
-            .unwrap();
-        client.add_proposal_url_to_post(response.id, 132225).await.unwrap();
-    }
-
     #[test]
     fn parse_proposal_id_test() {
         let text = "propoSAL 123456".to_string();

--- a/rs/cli/src/lib.rs
+++ b/rs/cli/src/lib.rs
@@ -5,6 +5,7 @@ pub mod commands;
 mod cordoned_feature_fetcher;
 pub mod ctx;
 mod desktop_notify;
+pub mod discourse_client;
 pub mod ic_admin;
 mod operations;
 mod qualification;

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -13,6 +13,7 @@ mod commands;
 mod cordoned_feature_fetcher;
 mod ctx;
 mod desktop_notify;
+mod discourse_client;
 mod ic_admin;
 mod operations;
 mod qualification;

--- a/rs/cli/src/unit_tests/ctx_init.rs
+++ b/rs/cli/src/unit_tests/ctx_init.rs
@@ -51,6 +51,7 @@ async fn get_context(network: &Network, version: IcAdminVersion) -> anyhow::Resu
         crate::commands::DiscourseOpts {
             discourse_api_key: None,
             discourse_api_url: None,
+            discourse_api_user: None,
         },
     )
     .await
@@ -191,6 +192,7 @@ async fn get_ctx_for_neuron_test(
         crate::commands::DiscourseOpts {
             discourse_api_key: None,
             discourse_api_url: None,
+            discourse_api_user: None,
         },
     )
     .await

--- a/rs/cli/src/unit_tests/ctx_init.rs
+++ b/rs/cli/src/unit_tests/ctx_init.rs
@@ -48,6 +48,10 @@ async fn get_context(network: &Network, version: IcAdminVersion) -> anyhow::Resu
         Arc::new(MockCordonedFeatureFetcher::new()),
         Arc::new(MockHealthStatusQuerier::new()),
         Store::new(false)?,
+        crate::commands::DiscourseOpts {
+            discourse_api_key: None,
+            discourse_api_url: None,
+        },
     )
     .await
 }
@@ -184,6 +188,10 @@ async fn get_ctx_for_neuron_test(
         Arc::new(MockCordonedFeatureFetcher::new()),
         Arc::new(MockHealthStatusQuerier::new()),
         Store::new(offline)?,
+        crate::commands::DiscourseOpts {
+            discourse_api_key: None,
+            discourse_api_url: None,
+        },
     )
     .await
 }

--- a/rs/cli/src/unit_tests/update_unassigned_nodes.rs
+++ b/rs/cli/src/unit_tests/update_unassigned_nodes.rs
@@ -4,6 +4,7 @@ use crate::artifact_downloader::MockArtifactDownloader;
 use crate::auth::Neuron;
 use crate::commands::{update_unassigned_nodes::UpdateUnassignedNodes, ExecutableCommand};
 use crate::cordoned_feature_fetcher::MockCordonedFeatureFetcher;
+use crate::discourse_client::MockDiscourseClient;
 use crate::ic_admin::MockIcAdmin;
 use ic_management_backend::health::MockHealthStatusQuerier;
 use ic_management_backend::{lazy_git::MockLazyGit, lazy_registry::MockLazyRegistry, proposal::MockProposalAgent};
@@ -53,6 +54,7 @@ async fn should_skip_update_same_version_nns_not_provided() {
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
         Arc::new(MockHealthStatusQuerier::new()),
+        Arc::new(MockDiscourseClient::new()),
     );
 
     let cmd = UpdateUnassignedNodes { nns_subnet_id: None };
@@ -89,6 +91,7 @@ async fn should_skip_update_same_version_nns_provided() {
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
         Arc::new(MockHealthStatusQuerier::new()),
+        Arc::new(MockDiscourseClient::new()),
     );
 
     let cmd = UpdateUnassignedNodes {
@@ -130,6 +133,7 @@ async fn should_update_unassigned_nodes() {
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
         Arc::new(MockHealthStatusQuerier::new()),
+        Arc::new(MockDiscourseClient::new()),
     );
 
     let cmd = UpdateUnassignedNodes {
@@ -169,6 +173,7 @@ async fn should_fail_nns_not_found() {
         Arc::new(MockArtifactDownloader::new()),
         Arc::new(MockCordonedFeatureFetcher::new()),
         Arc::new(MockHealthStatusQuerier::new()),
+        Arc::new(MockDiscourseClient::new()),
     );
 
     let cmd = UpdateUnassignedNodes {

--- a/rs/cli/src/unit_tests/version.rs
+++ b/rs/cli/src/unit_tests/version.rs
@@ -1,3 +1,4 @@
+use crate::discourse_client::MockDiscourseClient;
 use indexmap::IndexMap;
 use std::sync::{Arc, RwLock};
 
@@ -72,6 +73,7 @@ async fn guest_os_elect_version_tests() {
         Arc::new(artifact_downloader),
         Arc::new(MockCordonedFeatureFetcher::new()),
         Arc::new(MockHealthStatusQuerier::new()),
+        Arc::new(MockDiscourseClient::new()),
     );
 
     for (name, expected_title, cmd) in [


### PR DESCRIPTION
This pull request adds an initial discourse client. The discourse client takes care of low level calls and high level coordination should be implemented into a Trait which exposes a clear api.

At the moment only the `subnet replace` command is changed to use the discourse api. If this was to be merged, further code changes for relevant proposal types would be added in a separate PR.

Still thinking about how to reliably test it. 