### PR TITLE
feat: adding workarounds if post creation fails.

### DIFF
--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -138,6 +138,11 @@ pub struct DiscourseOpts {
     /// Api url used to interact with the forum
     #[clap(long, env = "DISCOURSE_API_URL")]
     pub(crate) discourse_api_url: Option<String>,
+
+    /// Skip forum post creation all together, also will not
+    /// prompt user for the link
+    #[clap(long, env = "DISCOURSE_SKIP_POST_CREATION")]
+    pub(crate) discourse_skip_post_creation: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -123,7 +123,7 @@ impl ExecutableCommand for Replace {
 
             if let Some(topic) = maybe_topic {
                 discourse_client
-                    .add_proposal_url_to_post(topic.id, parse_proposal_id_from_governance_response(proposal_response)?)
+                    .add_proposal_url_to_post(topic.update_id, parse_proposal_id_from_governance_response(proposal_response)?)
                     .await?
             }
         }

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -274,6 +274,7 @@ impl DreContext {
             // `offline` for discourse client means that it shouldn't try and create posts.
             // It can happen because the tool runs in offline mode, or if its a dry run.
             self.store.is_offline() || self.dry_run,
+            self.discourse_opts.discourse_skip_post_creation,
         )?);
         *self.discourse_client.borrow_mut() = Some(client.clone());
         Ok(client)
@@ -350,6 +351,7 @@ pub mod tests {
                 discourse_api_key: None,
                 discourse_api_url: None,
                 discourse_api_user: None,
+                discourse_skip_post_creation: true,
             },
             discourse_client: RefCell::new(Some(discourse_client)),
         }

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -1,7 +1,9 @@
-use std::time::Duration;
+use std::{fmt::Display, time::Duration};
 
 use futures::{future::BoxFuture, TryFutureExt};
 use ic_types::PrincipalId;
+use itertools::Itertools;
+use log::warn;
 use mockall::automock;
 use regex::Regex;
 use reqwest::{Client, Method};
@@ -12,7 +14,7 @@ use serde_json::json;
 pub trait DiscourseClient: Sync + Send {
     fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, summary: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>>;
 
-    fn add_proposal_url_to_post(&self, post_id: u64, proposal_id: u64) -> BoxFuture<'_, anyhow::Result<()>>;
+    fn add_proposal_url_to_post(&self, post_id: Option<u64>, proposal_id: u64) -> BoxFuture<'_, anyhow::Result<()>>;
 }
 
 pub struct DiscourseClientImp {
@@ -21,10 +23,11 @@ pub struct DiscourseClientImp {
     api_key: String,
     api_user: String,
     offline: bool,
+    skip_forum_post_creation: bool,
 }
 
 impl DiscourseClientImp {
-    pub fn new(url: String, api_key: String, api_user: String, offline: bool) -> anyhow::Result<Self> {
+    pub fn new(url: String, api_key: String, api_user: String, offline: bool, skip_forum_post_creation: bool) -> anyhow::Result<Self> {
         let client = reqwest::Client::builder().timeout(Duration::from_secs(30)).build()?;
 
         Ok(Self {
@@ -33,6 +36,7 @@ impl DiscourseClientImp {
             api_key,
             api_user,
             offline,
+            skip_forum_post_creation,
         })
     }
 
@@ -81,14 +85,14 @@ impl DiscourseClientImp {
             .ok_or(anyhow::anyhow!("Failed to find category with name `{}`", category_name))
     }
 
-    async fn create_topic(&self, title: String, summary: String, category: String, tags: Vec<String>) -> anyhow::Result<DiscourseResponse> {
-        let category = self.get_category_id(category).await?;
+    async fn create_topic(&self, topic: DiscourseTopic) -> anyhow::Result<DiscourseResponse> {
+        let category = self.get_category_id(topic.category).await?;
 
         let payload = json!({
-           "title": title,
+           "title": topic.title,
            "category": category,
-           "raw": summary,
-           "tags": tags
+           "raw": topic.content,
+           "tags": topic.tags
         });
         let payload = serde_json::to_string(&payload)?;
 
@@ -102,7 +106,7 @@ impl DiscourseClientImp {
         };
 
         Ok(DiscourseResponse {
-            id,
+            update_id: Some(id),
             url: format!("{}/t/{}/{}", self.forum_url, topic_slug, topic_id),
         })
     }
@@ -129,42 +133,71 @@ impl DiscourseClientImp {
             .await
             .map(|_resp| ())
     }
+
+    fn request_from_user(&self, err: anyhow::Error, topic: DiscourseTopic) -> anyhow::Result<Option<DiscourseResponse>> {
+        warn!("Received error: {:?}", err);
+        warn!("Please create a topic with the following information");
+        println!("{}", topic);
+        let forum_post_link = dialoguer::Input::<String>::new()
+            .with_prompt("Forum post link")
+            .allow_empty(true)
+            .interact()?;
+        Ok(Some(DiscourseResponse {
+            url: forum_post_link,
+            update_id: None,
+        }))
+    }
 }
+
+const GOVERNANCE_TOPIC: &str = "Governance";
+const SUBNET_MANAGEMENT_TAG: &str = "Subnet-management";
 
 impl DiscourseClient for DiscourseClientImp {
     fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, summary: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>> {
-        Box::pin(async move {
-            if self.offline {
+        let subnet_id = subnet_id.to_string();
+        let (first_part, _rest) = subnet_id
+            .split_once("-")
+            .ok_or(anyhow::anyhow!("Unexpected principal format `{}`", subnet_id))
+            // We don't have any principals that don't have a `-` in them.
+            .unwrap();
+        let post = DiscourseTopic {
+            title: format!("Replacing nodes in subnet {}", first_part),
+            content: summary,
+            tags: vec![SUBNET_MANAGEMENT_TAG.to_string()],
+            category: GOVERNANCE_TOPIC.to_string(),
+        };
+        let post_clone = post.clone();
+
+        let try_call = async move {
+            if self.offline || self.skip_forum_post_creation {
                 return Ok(None);
             }
-            let subnet_id = subnet_id.to_string();
-            let (first_part, _rest) = subnet_id
-                .split_once("-")
-                .ok_or(anyhow::anyhow!("Unexpected principal format `{}`", subnet_id))?;
-            let topic = self
-                .create_topic(
-                    format!("Replacing nodes in subnet {}", first_part),
-                    summary,
-                    "Governance".to_string(),
-                    vec!["Subnet-management".to_string()],
-                )
-                .await?;
+            let topic = self.create_topic(post).await?;
             Ok(Some(topic))
-        })
+        };
+        Box::pin(async move { try_call.await.or_else(|e| self.request_from_user(e, post_clone)) })
     }
 
-    fn add_proposal_url_to_post(&self, post_id: u64, proposal_id: u64) -> BoxFuture<'_, anyhow::Result<()>> {
+    fn add_proposal_url_to_post(&self, post_id: Option<u64>, proposal_id: u64) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
-            if self.offline {
+            if self.offline || self.skip_forum_post_creation {
                 return Ok(());
             }
+
+            let new_content = format!("Proposal id [{0}](https://dashboard.internetcomputer.org/proposal/{0})", proposal_id);
+            if post_id.is_none() {
+                warn!("Update the forum post with the following text");
+                warn!("{}", new_content);
+                return Ok(());
+            }
+            let post_id = post_id.unwrap();
 
             let content = self.get_post_content(post_id).await?;
             let new_content = format!(
                 r#"{0}
 
-Proposal id [{1}](https://dashboard.internetcomputer.org/proposal/{1})"#,
-                content, proposal_id
+{1}"#,
+                content, new_content
             );
             self.update_post_content(post_id, new_content).await
         })
@@ -190,7 +223,32 @@ pub fn parse_proposal_id_from_governance_response(response: String) -> anyhow::R
 #[derive(Debug)]
 pub struct DiscourseResponse {
     pub url: String,
-    pub id: u64,
+    pub update_id: Option<u64>,
+}
+
+#[derive(Clone)]
+pub struct DiscourseTopic {
+    title: String,
+    content: String,
+    tags: Vec<String>,
+    category: String,
+}
+
+impl Display for DiscourseTopic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"Title: {}
+Category: {}
+Tags: [{}]
+Content:
+{}"#,
+            self.title,
+            self.category,
+            self.tags.iter().join(", "),
+            self.content
+        )
+    }
 }
 
 #[cfg(test)]

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 
 #[automock]
 pub trait DiscourseClient: Sync + Send {
-    fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, summary: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>>;
+    fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, body: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>>;
 
     fn add_proposal_url_to_post(&self, post_id: Option<u64>, proposal_id: u64) -> BoxFuture<'_, anyhow::Result<()>>;
 }
@@ -153,16 +153,13 @@ const GOVERNANCE_TOPIC: &str = "Governance";
 const SUBNET_MANAGEMENT_TAG: &str = "Subnet-management";
 
 impl DiscourseClient for DiscourseClientImp {
-    fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, summary: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>> {
+    fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, body: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>> {
         let subnet_id = subnet_id.to_string();
-        let (first_part, _rest) = subnet_id
-            .split_once("-")
-            .ok_or(anyhow::anyhow!("Unexpected principal format `{}`", subnet_id))
-            // We don't have any principals that don't have a `-` in them.
-            .unwrap();
+        // All principals have a `-` in the string from
+        let (first_part, _rest) = subnet_id.split_once("-").unwrap();
         let post = DiscourseTopic {
             title: format!("Replacing nodes in subnet {}", first_part),
-            content: summary,
+            content: body,
             tags: vec![SUBNET_MANAGEMENT_TAG.to_string()],
             category: GOVERNANCE_TOPIC.to_string(),
         };

--- a/rs/cli/src/ic_admin.rs
+++ b/rs/cli/src/ic_admin.rs
@@ -158,7 +158,7 @@ impl IcAdmin for IcAdminImpl {
 
     fn propose_print_and_confirm(&self, cmd: ProposeCommand, opts: ProposeOptions) -> BoxFuture<'_, anyhow::Result<bool>> {
         Box::pin(async move {
-            let _ = self._exec(cmd, opts, true, true, false).await;
+            let _ = self._exec(cmd, opts, true, false, false).await;
 
             if self.proceed_without_confirmation {
                 // Don't ask for confirmation, allow to proceed

--- a/rs/cli/src/unit_tests/ctx_init.rs
+++ b/rs/cli/src/unit_tests/ctx_init.rs
@@ -52,6 +52,7 @@ async fn get_context(network: &Network, version: IcAdminVersion) -> anyhow::Resu
             discourse_api_key: None,
             discourse_api_url: None,
             discourse_api_user: None,
+            discourse_skip_post_creation: true,
         },
     )
     .await
@@ -193,6 +194,7 @@ async fn get_ctx_for_neuron_test(
             discourse_api_key: None,
             discourse_api_url: None,
             discourse_api_user: None,
+            discourse_skip_post_creation: false,
         },
     )
     .await


### PR DESCRIPTION
If discourse client is failing for some reason, one should be able to still use the tool.

This PR adds two ways:
1. Skip the creation of the forum link all together with `--discourse-skip-post-creation`
2. The tool will print out a couple of warning messages saying that it failed to create a topic and it will prompt user for the forum post link after he manually created it.

Example of manual creation request:
<details>

~~~bash
./target/debug/dre --discourse-api-key some --discourse-api-user some --discourse-api-url "https://we.com"  subnet replace --nodes 5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe --no-heal --motivation "testing"
 2024-11-22T10:25:30.134Z INFO  dre > Running version 0.5.6-8f4aeb7f-dirty
 2024-11-22T10:25:30.178Z INFO  dre::store > Using local registry path for network mainnet: /home/nikola/.cache/dre-store/local_registry/mainnet
 2024-11-22T10:26:06.915Z INFO  decentralization::network > Evaluating change in subnet 4ecnw membership: removing (0 healthy + 1 unhealthy) and adding 1 node. Total available 796 healthy nodes.
 2024-11-22T10:26:09.542Z INFO  dre::auth                 > Using requested private key file /run/media/nikola/NikolaHDD/Dfinity/creds/testing.pem
 2024-11-22T10:26:09.542Z INFO  dre::store                > Using cached ic admin version: f5a63fd41933eee24ab3a6c71e43c67c1048e0db
 2024-11-22T10:26:09.542Z INFO  dre::store                > Using ic-admin: /home/nikola/.cache/dre-store/ic-admin.revisions/f5a63fd41933eee24ab3a6c71e43c67c1048e0db/ic-admin
 2024-11-22T10:26:09.543Z INFO  dre::ic_admin             > running ic-admin:
$ /home/nikola/.cache/dre-store/ic-admin.revisions/f5a63fd41933eee24ab3a6c71e43c67c1048e0db/ic-admin \
    --secret-key-pem /run/media/nikola/NikolaHDD/Dfinity/creds/testing.pem \
    --nns-urls https://ic0.app/ \
  propose-to-change-subnet-membership \
    --dry-run \
    --silence-notices \
    --proposal-title 'Replace a node in subnet 4ecnw' \
    --summary '# Replace a node in subnet 4ecnw

Motivation:
 - replacing 5ttnf as per user request: testing

NOTE: The information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.
Code for calculating replacements is at https://github.com/dfinity/dre/blob/79066127f58c852eaf4adda11610e815a426878c/rs/decentralization/src/network.rs#L912

Decentralization Nakamoto coefficient changes for subnet `4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe`:
```
    node_provider: 5.00 -> 5.00    (+0%)
      data_center: 5.00 -> 5.00    (+0%)
data_center_owner: 5.00 -> 5.00    (+0%)
             area: 5.00 -> 5.00    (+0%)
          country: 5.00 -> 5.00    (+0%)
```

**Mean Nakamoto comparison:** 5.00 -> 5.00  (+0%)

Overall replacement impact: equal decentralization across all features


# Details

Nodes removed:
- `5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe` [health: healthy]

Nodes added:
- `mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe` [health: healthy]


```
    node_provider                                                              data_center            data_center_owner            area                   country
    -------------                                                              -----------            -----------------            ----                   -------
    3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae  1 -> 0    an1               1    Bacloud            1 -> 0    Bucuresti         1    AU            1
    5zqo2-omblo-i7knq-qyrfu-mjccn-tljyd-qslab-b7ukn-7tshi-pbeke-pae       1    bu1               1    Central Tower DC   0 -> 1    Flanders          1    BE            1
    6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe       1    ge2               1    Cyxtera                 1    Florida           1    CA            1
    7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae       1    hk1               1    Datacenter United       1    Geneva            1    CH            1
    7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe       1    lj1               1    Digital Realty          1    HongKong          1    HK            1
    bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe       1    nm1               1    Equinix                 1    Ljubljana         1    IN            1
    dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae  0 -> 1    sc1               1    Flexential              1    Navi Mumbai       1    JP            1
    fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae       1    sg1               1    M247                    1    Ontario           1    LT       1 -> 0
    i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae       1    sh1               1    NEXTDC                  1    Queensland        1    PL       0 -> 1
    r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae       1    si1          1 -> 0    Posita.si               1    Siauliai     1 -> 0    RO            1
    rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae       1    to2               1    Rivram                  1    Singapore         1    SE            1
    sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae       1    tp1               1    SafeHost                1    Stockholm         1    SG            1
    ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae       1    ty2               1    Telin                   1    Tokyo             1    SI            1
    wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae       1    wa2          0 -> 1    Unicom                  1    Warszawa     0 -> 1    US            1
```


Forum post link: [comment]: <> (Link will be added on actual exectuion)
' \
    --subnet-id 4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe \
    --node-ids-add mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe \
    --node-ids-remove 5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe \
    --proposer 123
Using NNS URLs: ["https://ic0.app/"]
Title: Replace a node in subnet 4ecnw

Summary: # Replace a node in subnet 4ecnw

Motivation:
 - replacing 5ttnf as per user request: testing

NOTE: The information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.
Code for calculating replacements is at https://github.com/dfinity/dre/blob/79066127f58c852eaf4adda11610e815a426878c/rs/decentralization/src/network.rs#L912

Decentralization Nakamoto coefficient changes for subnet `4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe`:
```
    node_provider: 5.00 -> 5.00    (+0%)
      data_center: 5.00 -> 5.00    (+0%)
data_center_owner: 5.00 -> 5.00    (+0%)
             area: 5.00 -> 5.00    (+0%)
          country: 5.00 -> 5.00    (+0%)
```

**Mean Nakamoto comparison:** 5.00 -> 5.00  (+0%)

Overall replacement impact: equal decentralization across all features


# Details

Nodes removed:
- `5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe` [health: healthy]

Nodes added:
- `mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe` [health: healthy]


```
    node_provider                                                              data_center            data_center_owner            area                   country
    -------------                                                              -----------            -----------------            ----                   -------
    3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae  1 -> 0    an1               1    Bacloud            1 -> 0    Bucuresti         1    AU            1
    5zqo2-omblo-i7knq-qyrfu-mjccn-tljyd-qslab-b7ukn-7tshi-pbeke-pae       1    bu1               1    Central Tower DC   0 -> 1    Flanders          1    BE            1
    6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe       1    ge2               1    Cyxtera                 1    Florida           1    CA            1
    7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae       1    hk1               1    Datacenter United       1    Geneva            1    CH            1
    7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe       1    lj1               1    Digital Realty          1    HongKong          1    HK            1
    bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe       1    nm1               1    Equinix                 1    Ljubljana         1    IN            1
    dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae  0 -> 1    sc1               1    Flexential              1    Navi Mumbai       1    JP            1
    fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae       1    sg1               1    M247                    1    Ontario           1    LT       1 -> 0
    i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae       1    sh1               1    NEXTDC                  1    Queensland        1    PL       0 -> 1
    r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae       1    si1          1 -> 0    Posita.si               1    Siauliai     1 -> 0    RO            1
    rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae       1    to2               1    Rivram                  1    Singapore         1    SE            1
    sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae       1    tp1               1    SafeHost                1    Stockholm         1    SG            1
    ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae       1    ty2               1    Telin                   1    Tokyo             1    SI            1
    wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae       1    wa2          0 -> 1    Unicom                  1    Warszawa     0 -> 1    US            1
```


Forum post link: [comment]: <> (Link will be added on actual exectuion)


Payload: ChangeSubnetMembershipPayload {
    subnet_id: 4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe,
    node_ids_add: [
        mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe,
    ],
    node_ids_remove: [
        5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe,
    ],
}
Do you want to continue? yes
 2024-11-22T10:26:13.326Z WARN  dre::discourse_client     > Received error: error sending request for url (https://we.com/categories.json)

Caused by:
    0: client error (Connect)
    1: dns error: failed to lookup address information: No address associated with hostname
    2: failed to lookup address information: No address associated with hostname
 2024-11-22T10:26:13.326Z WARN  dre::discourse_client     > Please create a topic with the following information
Title: Replacing nodes in subnet 4ecnw
Category: Governance
Tags: [Subnet-management]
Content:
# Replace a node in subnet 4ecnw
Motivation:

 - replacing 5ttnf as per user request: testing

NOTE: The information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.
Code for calculating replacements is at https://github.com/dfinity/dre/blob/79066127f58c852eaf4adda11610e815a426878c/rs/decentralization/src/network.rs#L912

Decentralization Nakamoto coefficient changes for subnet `4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe`:
```
    node_provider: 5.00 -> 5.00    (+0%)
      data_center: 5.00 -> 5.00    (+0%)
data_center_owner: 5.00 -> 5.00    (+0%)
             area: 5.00 -> 5.00    (+0%)
          country: 5.00 -> 5.00    (+0%)
```

**Mean Nakamoto comparison:** 5.00 -> 5.00  (+0%)

Overall replacement impact: equal decentralization across all features


# Details

Nodes removed:
- `5ttnf-xhdip-7e2uw-iuikh-5dlli-r6jdc-nxjp7-bjumm-5usid-rpiqn-jqe` [health: healthy]

Nodes added:
- `mswad-oq7wj-5r4yy-b5qoy-cmv7z-wzfb3-ktn6l-rcnrz-mni2f-lsys6-wqe` [health: healthy]


```
    node_provider                                                              data_center            data_center_owner            area                   country
    -------------                                                              -----------            -----------------            ----                   -------
    3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae  1 -> 0    an1               1    Bacloud            1 -> 0    Bucuresti         1    AU            1
    5zqo2-omblo-i7knq-qyrfu-mjccn-tljyd-qslab-b7ukn-7tshi-pbeke-pae       1    bu1               1    Central Tower DC   0 -> 1    Flanders          1    BE            1
    6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe       1    ge2               1    Cyxtera                 1    Florida           1    CA            1
    7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae       1    hk1               1    Datacenter United       1    Geneva            1    CH            1
    7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe       1    lj1               1    Digital Realty          1    HongKong          1    HK            1
    bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe       1    nm1               1    Equinix                 1    Ljubljana         1    IN            1
    dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae  0 -> 1    sc1               1    Flexential              1    Navi Mumbai       1    JP            1
    fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae       1    sg1               1    M247                    1    Ontario           1    LT       1 -> 0
    i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae       1    sh1               1    NEXTDC                  1    Queensland        1    PL       0 -> 1
    r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae       1    si1          1 -> 0    Posita.si               1    Siauliai     1 -> 0    RO            1
    rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae       1    to2               1    Rivram                  1    Singapore         1    SE            1
    sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae       1    tp1               1    SafeHost                1    Stockholm         1    SG            1
    ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae       1    ty2               1    Telin                   1    Tokyo             1    SI            1
    wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae       1    wa2          0 -> 1    Unicom                  1    Warszawa     0 -> 1    US            1
```


Forum post link: https://some.discourse.com/link-to-post
Error: ic-admin failed with non-zero exit code 1 stderr ==>
Using NNS URLs: ["https://ic0.app/"]
submit_proposal for Replace a node in subnet 4ecnw response: Err("NotFound: Neuron not found: NeuronId { id: 123 }")
submit_proposal for Replace a node in subnet 4ecnw error: "NotFound: Neuron not found: NeuronId { id: 123 }"
~~~

**NOTE**: The error in the command output at the end is due to a fallback neuron being used which doesn't exist on mainnet.

</details>