### PR TITLE
feat: adding forum post creations for heal

### DIFF
--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -128,20 +128,20 @@ impl TryFrom<String> for AuthOpts {
 #[derive(ClapArgs, Debug, Clone)]
 pub struct DiscourseOpts {
     /// Api key used to interact with the forum
-    #[clap(long, env = "DISCOURSE_API_KEY")]
+    #[clap(long, env = "DISCOURSE_API_KEY", global = true, hide_env_values = true)]
     pub(crate) discourse_api_key: Option<String>,
 
     /// Api user that will interact with the forum
-    #[clap(long, env = "DISCOURSE_API_USER")]
+    #[clap(long, env = "DISCOURSE_API_USER", global = true)]
     pub(crate) discourse_api_user: Option<String>,
 
     /// Api url used to interact with the forum
-    #[clap(long, env = "DISCOURSE_API_URL")]
+    #[clap(long, env = "DISCOURSE_API_URL", global = true)]
     pub(crate) discourse_api_url: Option<String>,
 
     /// Skip forum post creation all together, also will not
     /// prompt user for the link
-    #[clap(long, env = "DISCOURSE_SKIP_POST_CREATION")]
+    #[clap(long, env = "DISCOURSE_SKIP_POST_CREATION", global = true)]
     pub(crate) discourse_skip_post_creation: bool,
 }
 

--- a/rs/cli/src/commands/network.rs
+++ b/rs/cli/src/commands/network.rs
@@ -1,5 +1,8 @@
 use clap::Args;
-use log::info;
+use itertools::Itertools;
+use log::{info, warn};
+
+use crate::{discourse_client::parse_proposal_id_from_governance_response, ic_admin::ProposeOptions, runner::RunnerProposal};
 
 use super::{AuthRequirement, ExecutableCommand};
 
@@ -39,51 +42,184 @@ impl ExecutableCommand for Network {
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let runner = ctx.runner().await?;
-        let ic_admin = ctx.ic_admin().await?;
         let mut errors = vec![];
         let network_heal = self.heal || std::env::args().any(|arg| arg == "heal");
+
+        let mut proposals = vec![];
+
         if network_heal || self.optimize_decentralization {
             info!("Healing the network by replacing unhealthy nodes and optimizing decentralization in subnets that have unhealthy nodes");
-            let proposals = runner
+            let maybe_proposals = runner
                 .network_heal(ctx.forum_post_link(), &self.skip_subnets, self.optimize_decentralization)
-                .await?;
-            for proposal in proposals {
-                if let Err(e) = ic_admin.propose_run(proposal.cmd, proposal.opts).await {
-                    errors.push(e);
-                }
+                .await;
+            match maybe_proposals {
+                Ok(heal_proposals) => proposals.extend(heal_proposals),
+                Err(e) => errors.push(DetailedError {
+                    proposal: None,
+                    error: anyhow::anyhow!(
+                        "Failed to calculate proposals for healing of the network and they won't be submitted. Error received: {:?}",
+                        e
+                    ),
+                }),
             }
         } else {
             info!("No network healing requested");
         }
         if self.ensure_operator_nodes_assigned {
             info!("Ensuring some operator nodes are assigned, for every node operator");
-            let proposals = runner
+            let maybe_proposals = runner
                 .network_ensure_operator_nodes_assigned(ctx.forum_post_link(), &self.skip_subnets)
-                .await?;
-            for proposal in proposals {
-                if let Err(e) = ic_admin.propose_run(proposal.cmd, proposal.opts).await {
-                    errors.push(e);
-                }
+                .await;
+            match maybe_proposals {
+                Ok(operator_assigned_proposals) => proposals.extend(operator_assigned_proposals),
+                Err(e) => errors.push(DetailedError { proposal: None, error: anyhow::anyhow!("Failed to calculate proposals for ensuring each operator has some nodes assigned and they won't be submitted. Error received: {:?}", e) }),
             }
         } else {
             info!("No network ensure operator nodes assigned requested");
         }
         if self.ensure_operator_nodes_unassigned {
             info!("Ensuring some operator nodes are unassigned, for every node operator");
-            let proposals = runner
+            let maybe_proposals = runner
                 .network_ensure_operator_nodes_unassigned(ctx.forum_post_link(), &self.skip_subnets)
-                .await?;
-            for proposal in proposals {
-                if let Err(e) = ic_admin.propose_run(proposal.cmd, proposal.opts).await {
-                    errors.push(e);
-                }
+                .await;
+            match maybe_proposals {
+                Ok(operator_unassigned_proposals) => proposals.extend(operator_unassigned_proposals),
+                Err(e) => errors.push(DetailedError { proposal: None, error: anyhow::anyhow!("Failed to calculate proposals for ensuring each operator has some nodes unassigned and they won't be submitted. Error received: {:?}", e) }),
             }
         } else {
             info!("No network ensure operator nodes unassigned requested");
         }
+
+        // This check saves time if there are no proposals to be submitted
+        // because it won't check for new versions of ic admin
+        if !proposals.is_empty() {
+            let ic_admin = ctx.ic_admin().await?;
+            let discourse_client = ctx.discourse_client()?;
+            for proposal in proposals {
+                let subnet_id = match &proposal.cmd {
+                    crate::ic_admin::ProposeCommand::ChangeSubnetMembership {
+                        subnet_id,
+                        node_ids_add: _,
+                        node_ids_remove: _,
+                    } => subnet_id,
+                    _ => {
+                        errors.push(DetailedError {
+                            proposal: Some(proposal.clone()),
+                            error: anyhow::anyhow!("Expected all proposals to be of type `ChangeSubnetMembership`"),
+                        });
+                        continue;
+                    }
+                };
+
+                match ic_admin
+                    .propose_print_and_confirm(
+                        proposal.cmd.clone(),
+                        ProposeOptions {
+                            forum_post_link: Some("[comment]: <> (Link will be added on actual execution)".to_string()),
+                            ..proposal.opts.clone()
+                        },
+                    )
+                    .await
+                {
+                    Ok(should_proceed) => {
+                        if !should_proceed {
+                            // Said "no" to the prompt in cli, just abort this proposal
+                            // but this is not an error
+                            continue;
+                        }
+                        // Said "yes" to the prompt in cli
+                    }
+                    Err(e) => {
+                        errors.push(DetailedError {
+                            proposal: Some(proposal.clone()),
+                            error: anyhow::anyhow!("Received error when prompting user for confirmation. Error: {:?}", e),
+                        });
+                        continue;
+                    }
+                }
+
+                let body = match (&proposal.opts.motivation, &proposal.opts.summary) {
+                    (Some(motivation), None) => motivation.to_string(),
+                    (Some(motivation), Some(summary)) => format!("{}\nMotivation:\n{}", summary, motivation),
+                    (None, Some(summary)) => summary.to_string(),
+                    (None, None) => anyhow::bail!("Expected to have `motivation` or `summary` for this proposal"),
+                };
+
+                let maybe_topic = match discourse_client.create_replace_nodes_forum_post(subnet_id.clone(), body).await {
+                    Ok(maybe_topic) => maybe_topic,
+                    Err(e) => {
+                        errors.push(DetailedError {
+                            proposal: Some(proposal.clone()),
+                            error: anyhow::anyhow!("Got error when creating a forum post: {:?}", e),
+                        });
+                        continue;
+                    }
+                };
+
+                let proposal_response = match ic_admin
+                    .propose_submit(
+                        proposal.cmd.clone(),
+                        ProposeOptions {
+                            forum_post_link: match (maybe_topic.as_ref(), proposal.opts.forum_post_link.as_ref()) {
+                                (Some(discourse_response), _) => Some(discourse_response.url.clone()),
+                                (None, Some(from_cli_or_auto_formated)) => Some(from_cli_or_auto_formated.clone()),
+                                _ => {
+                                    warn!("Didn't find a link to forum post from discourse or cli and couldn't auto-format it.");
+                                    warn!("Will not add forum post to the proposal");
+                                    None
+                                }
+                            },
+                            ..proposal.opts.clone()
+                        },
+                    )
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(e) => {
+                        errors.push(DetailedError {
+                            proposal: Some(proposal.clone()),
+                            error: anyhow::anyhow!("Received error when submitting proposal: {:?}", e),
+                        });
+                        continue;
+                    }
+                };
+
+                if let Some(topic) = maybe_topic {
+                    if let Err(e) = discourse_client
+                        .add_proposal_url_to_post(topic.update_id, parse_proposal_id_from_governance_response(proposal_response)?)
+                        .await
+                    {
+                        errors.push(DetailedError {
+                            proposal: Some(proposal.clone()),
+                            error: anyhow::anyhow!("Received error when updating forum post: {:?}", e),
+                        });
+                    }
+                }
+            }
+        }
+
         match errors.is_empty() {
             true => Ok(()),
-            false => Err(anyhow::anyhow!("All errors received:\n{:?}", errors)),
+            false => Err(anyhow::anyhow!(
+                r#"All errors received:{}"#,
+                errors
+                    .iter()
+                    .enumerate()
+                    .map(|(i, detailed_error)| format!(
+                        r#"
+Error {}.:
+  - {}
+  - Error: {:?}"#,
+                        i + 1,
+                        match &detailed_error.proposal {
+                            Some(proposal) => format!("Proposal: {:?}", proposal),
+                            None => "Error is linked to a calculation of proposals to be submitted".to_string(),
+                        },
+                        detailed_error.error.to_string()
+                    ))
+                    // Doesn't need a `\n` because of the way the whole error is formatted.
+                    .join("")
+            )),
         }
     }
 
@@ -98,4 +234,9 @@ impl ExecutableCommand for Network {
             .exit()
         }
     }
+}
+
+struct DetailedError {
+    proposal: Option<RunnerProposal>,
+    error: anyhow::Error,
 }

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -261,8 +261,14 @@ impl DreContext {
             self.discourse_opts.discourse_api_url.clone(),
         ) {
             (Some(api_key), Some(api_user), Some(forum_url)) => (api_key, api_user, forum_url),
+            // Actual api won't be called so these values don't matter
+            _ if self.discourse_opts.discourse_skip_post_creation => (
+                "placeholder_key".to_string(),
+                "placeholder_user".to_string(),
+                "https://placeholder_url.com".to_string(),
+            ),
             _ => anyhow::bail!(
-                "Expected to have both `api_key` and `forum_url`. Instead found: {:?}",
+                "Expected to have `api_key`, `forum_url` and `api_user`. Instead found: {:?}",
                 self.discourse_opts
             ),
         };


### PR DESCRIPTION
This PR refactors the `heal` command to create posts for each proposal that would be created within the command. Furthermore it doesn't error out on the first failed proposal but tries to finish the everything and groups the errors and prints it nicely afterwords.
Example of the error printing of grouped errors at the end of execution:
<details>

~~~bash
Error: All errors received:
Error 1.:
  - Proposal: RunnerProposal { cmd: ChangeSubnetMembership { subnet_id: tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe, node_ids_add: [dbpb7-eze6y-jdemh-2zemb-nuwhl-75ia7-xpwbf-26quj-2q4ok-u4ado-tqe], node_ids_remove: [onv2n-rm4ad-mgpnn-iiheu-6a76r-crgmo-wxpwt-dqf6y-n7gcf-5po4q-2qe] }, opts: ProposeOptions { title: Some("Replace a node in subnet tdb26"), summary: Some("# Replace a node in subnet tdb26"), motivation: Some("\n - replacing dead node onv2n-rm4ad-mgpnn-iiheu-6a76r-crgmo-wxpwt-dqf6y-n7gcf-5po4q-2qe\n\nCalculated potential impact on subnet decentralization if replacing:\n\n- 1 additional node would result in: (gets better) the average log2 of Nakamoto Coefficients across all features increases from 3.2999 to 3.3303 (solution penalty: 30)\n- 2 additional nodes would result in: (gets better) the average log2 of Nakamoto Coefficients across all features increases from 3.3303 to 3.3578 (solution penalty: 30)\n- 3 additional nodes would result in: equal decentralization across all features (solution penalty: 30)\n- 4 additional nodes would result in: equal decentralization across all features (solution penalty: 30)\n- 5 additional nodes would result in: (gets worse) the number of different Country actors decreases from 27 to 26 (solution penalty: 30)\n\nBased on the calculated potential impact, not replacing additional nodes to improve optimization.\n\nNote: the information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.\nHere is [an explaination of how decentralization is currently calculated](https://dfinity.github.io/dre/decentralization.html), \nand there are also [instructions for performing what-if analysis](https://dfinity.github.io/dre/subnet-decentralization-whatif.html) if you are wondering if another node would have improved decentralization more.\n\n\n\nDecentralization Nakamoto coefficient changes for subnet `tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe`:\n```\n  node_provider: 11.00 -> 11.00    (+0%)\n    data_center: 13.00 -> 13.00    (+0%)\ndata_center_owner: 12.00 -> 12.00    (+0%)\n             area: 9.00 -> 9.00    (+0%)\n          country: 6.00 -> 6.00    (+0%)\n```\n\n**Mean Nakamoto comparison:** 10.20 -> 10.20  (+0%)\n\nOverall replacement impact: (gets better) the number of different Country actors increases from 26 to 27\n\nImpact on business rules penalties: 30 -> 30\n\n\n# Details\n\nNodes removed:\n- `onv2n-rm4ad-mgpnn-iiheu-6a76r-crgmo-wxpwt-dqf6y-n7gcf-5po4q-2qe` [health: dead]\n\nNodes added:\n- `dbpb7-eze6y-jdemh-2zemb-nuwhl-75ia7-xpwbf-26quj-2q4ok-u4ado-tqe` [health: healthy]\n\n\n```\n    node_provider                                                              data_center            data_center_owner                                    area                             country        \n    -------------                                                              -----------            -----------------                                    ----                             -------        \n    3oqw6-vmpk2-mlwlx-52z5x-e3p7u-fjlcw-yxc34-lf2zq-6ub2f-v63hk-lae       1    ar1               1    Africa Data Centres                             1    Barreiro                    1    AR            1\n    4dibr-2alzr-h6kva-bvwn2-yqgsl-o577t-od46o-v275p-a2zov-tcw4f-eae       1    ba1               1    Anonstake                                       1    British Columbia            1    AU       2 -> 1\n    4fedi-eu6ue-nd7ts-vnof5-hzg66-hgzl7-liy5n-3otyp-h7ipw-owycg-uae       1    bc1               1    Baltneta                                        1    Brussels Capital            1    BE            1\n    4jjya-hlyyc-s766p-fd6gr-d6tvv-vo3ah-j5ptx-i73gw-mwgyd-rw6w2-rae       1    bn1               1    Celeste                                         1    Bucuresti                   1    CA            2\n    4r6qy-tljxg-slziw-zoteo-pboxh-vlctz-hkv2d-7zior-u3pxm-mmuxb-cae       1    bo1               1    Cloud9                                          1    CABA                        1    CH            3\n    6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe       2    br1               1    CyrusOne                                        1    Cape Town                   1    CR            1\n    6sq7t-knkul-fko6h-xzvnf-ktbvr-jhx7r-hapzr-kjlek-whugy-zt6ip-xqe       2    bt1               1    Cyxtera                                         1    Colombo                     1    CZ            2\n    7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae       1    bu1               1    DataHouse                                       1    Gauteng                     2    DE       0 -> 1\n    7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe       1    cm1               1    Digital Realty                                  1    Geneva                      1    EE            1\n    7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe       1    cr1               1    Equinix                                    1 -> 2    Hesse                  0 -> 1    FR            1\n    bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe       2    ct2               1    Everyware                                       2    HongKong                    2    GE            1\n    cgmhq-c4zja-yov4u-zeyao-64ua5-idlhb-ezcgr-cultv-3vqjs-dhwo7-rqe       1    fr2          0 -> 1    HighDC                                          1    Ljubljana                   1    HK            2\n    dhywe-eouw6-hstpj-ahsnw-xnjxq-cmqks-47mrg-nnncb-3sr5d-rac6m-nae       1    ge1               1    INAP                                            1    London                      1    IL            1\n    diyay-s4rfq-xnx23-zczwi-nptra-5254n-e4zn6-p7tqe-vqhzr-sd4gd-bqe       1    hk3               1    InfonetDC                                       1    Maribor                     1    IN            2\n    efem5-kmwaw-xose7-zzhgg-6bfif-twmcw-csg7a-lmqvn-wrdou-mjwlb-vqe       1    hk4               1    Interhost                                       1    Massachusetts               1    JP            1\n    eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe       1    hu1               1    KT                                              1    Melbourne              1 -> 0    KR            2\n    i3cfo-s2tgu-qe5ym-wk7e6-y7ura-pptgu-kevuf-2feh7-z4enq-5hz4s-mqe       1    jb2               1    Latitude.sh                                     1    Navi Mumbai                 1    LK            1\n    i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae       1    jb3               1    Leaseweb                                        1    Panvel                      1    LT            1\n    ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe  1 -> 0    kr1               1    M247                                            1    Paris                       1    LV            1\n    ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae       1    ld1               1    Master Internet                                 1    Praha                       1    PL            1\n    izmhk-lpjum-uo4oy-lviba-yctpc-arg4b-2ywim-vgoiu-gqaj2-gskmw-2qe       1    lj2               1    MasterDC                                        1    Quebec                      1    PT            1\n    kos24-5xact-6aror-uofg2-tnvt6-dq3bk-c2c5z-jtptt-jbqvc-lmegy-qae       1    mb1               1    Megazone Cloud                                  1    Queensland                  1    RO            1\n    lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe       1    mn2          1 -> 0    NEXTDC                                     2 -> 1    Riga                        1    SG            2\n    mme7u-zxs3z-jq3un-fbaly-nllcz-toct2-l2kp3-larrb-gti4r-u2bmo-dae       1    mtl1              1    Nano                                            1    San Jose                    1    SI            2\n    nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae       1    nm1               1    Navegalo                                        1    Seoul                       2    UK            1\n    py2kr-ipr2p-ryh66-x3a3v-5ts6u-7rfhf-alkna-ueffh-hz5ox-lt6du-qqe       1    pa1               1    Online                                          1    Singapore                   2    US            3\n    qsdw4-ao5ye-6rtq4-y3zhm-icjbj-lutd2-sbejz-4ajqz-pcflr-xrhsg-jae       1    pl2               1    OrionStellar                                    1    South Moravian Region       1    ZA            3\n    r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae       1    pr1               1    Posita.si                                       1    Tallinn                     1                   \n    rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae       1    rg3               1    Racks Central                                   1    Tbilisi                     1                   \n    s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae       1    sc1               1    Rivram                                          1    Tel Aviv                    1                   \n    sixix-2nyqd-t2k2v-vlsyz-dssko-ls4hl-hyij4-y7mdp-ja6cj-nsmpf-yae       1    sg1               1    SyT - Servicios y Telecomunicaciones S.A.       1    Texas                       1                   \n    sqhxa-h6ili-qkwup-ohzwn-yofnm-vvnp5-kxdhg-saabw-rvua3-xp325-zqe       1    sg3               1    TRG                                             1    Tokyo                       1                   \n    ulyfm-vkxtj-o42dg-e4nam-l4tzf-37wci-ggntw-4ma7y-d267g-ywxi6-iae       1    sl1               1    Telin                                           1    Vilnius                     1                   \n    unqqg-no4b2-vbyad-ytik2-t3vly-3e57q-aje2t-sjb5l-bd4ke-chggn-uqe       1    st1               1    Teraco                                          1    Virginia                    1                   \n    vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe       1    ta1               1    Xneelo                                          1    Warszawa                    1                   \n    wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae       1    tb1               1    Yotta                                           1    Zurich                      2                   \n    wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae  0 -> 1    tv1               1    hkcolo                                          1                                                    \n    zy4m7-z5mhs-zfkpl-zlsjl-blrbx-mvvmq-5z4zu-mf7eq-hhv7o-ezfro-3ae       1    ty3               1    hkntt                                           1                                                    \n                                                                               wa3               1                                                                                                         \n                                                                               zh2               2                                                                                                         \n```\n\n\nBusiness rules check results *before* the membership change:\n- node_provider 6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.\n- data_center zh2 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.\n- data_center_owner Everyware controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.\n\n\nBusiness rules check results *after* the membership change:\n- node_provider 6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.\n- data_center zh2 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.\n- data_center_owner Equinix controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.\n\n"), forum_post_link: Some("https://forum.dfinity.org/t/subnet-management-tdb26-nns") } }
  - Error: "Received error when submitting proposal: ic-admin failed with non-zero exit code 1 stderr ==>\nUsing NNS URLs: [\"https://ic0.app/\"]\nsubmit_proposal for Replace a node in subnet tdb26 response: Err(\"NotFound: Neuron not found: NeuronId { id: 123 }\")\nsubmit_proposal for Replace a node in subnet tdb26 error: \"NotFound: Neuron not found: NeuronId { id: 123 }\"\n"
Error 2.:
  - Proposal: RunnerProposal { cmd: ChangeSubnetMembership { subnet_id: snjp4-xlbw4-mnbog-ddwy6-6ckfd-2w5a2-eipqo-7l436-pxqkh-l6fuv-vae, node_ids_add: [lrc24-ewvts-5ecwr-oitgj-2mrc3-elne2-otvv2-2b2kq-lj24z-jpvqq-eqe], node_ids_remove: [wzr5d-7qa2x-tduot-6mkkq-ou4sc-5ktje-4hxqa-a75d5-gunkc-3xhyt-6qe] }, opts: ProposeOptions { title: Some("Replace a node in subnet snjp4"), summary: Some("# Replace a node in subnet snjp4"), motivation: Some("\n - replacing dead node wzr5d-7qa2x-tduot-6mkkq-ou4sc-5ktje-4hxqa-a75d5-gunkc-3xhyt-6qe\n\nCalculated potential impact on subnet decentralization if replacing:\n\n- 1 additional node would result in: equal decentralization across all features\n\nBased on the calculated potential impact, not replacing additional nodes to improve optimization.\n\nNote: the information below is provided for your convenience. Please independently verify the decentralization changes rather than relying solely on this summary.\nHere is [an explaination of how decentralization is currently calculated](https://dfinity.github.io/dre/decentralization.html), \nand there are also [instructions for performing what-if analysis](https://dfinity.github.io/dre/subnet-decentralization-whatif.html) if you are wondering if another node would have improved decentralization more.\n\n\n\nDecentralization Nakamoto coefficient changes for subnet `snjp4-xlbw4-mnbog-ddwy6-6ckfd-2w5a2-eipqo-7l436-pxqkh-l6fuv-vae`:\n```\n    node_provider: 5.00 -> 5.00    (+0%)\n      data_center: 5.00 -> 5.00    (+0%)\ndata_center_owner: 5.00 -> 5.00    (+0%)\n             area: 5.00 -> 5.00    (+0%)\n          country: 5.00 -> 5.00    (+0%)\n```\n\n**Mean Nakamoto comparison:** 5.00 -> 5.00  (+0%)\n\nOverall replacement impact: equal decentralization across all features\n\nImpact on business rules penalties: 1000 -> 0\n\n\n# Details\n\nNodes removed:\n- `wzr5d-7qa2x-tduot-6mkkq-ou4sc-5ktje-4hxqa-a75d5-gunkc-3xhyt-6qe` [health: dead]\n\nNodes added:\n- `lrc24-ewvts-5ecwr-oitgj-2mrc3-elne2-otvv2-2b2kq-lj24z-jpvqq-eqe` [health: healthy]\n\n\n```\n    node_provider                                                         data_center       data_center_owner                               area                             country   \n    -------------                                                         -----------       -----------------                               ----                             -------   \n    6nbcy-kprg6-ax3db-kh3cz-7jllk-oceyh-jznhs-riguq-fvk6z-6tsds-rqe  1    ar1          1    Africa Data Centres                        1    British Columbia            1    AR       1\n    7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae  1    bc1          1    Cloud9                                     1    CABA                        1    AU       1\n    7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe  1    ct1          1    Cyxtera                                    1    Cape Town                   1    CA       1\n    7uioy-xitfw-yqcko-5gpya-3lpsw-dw7zt-dyyyf-wfqif-jvi76-fdbkg-cqe  1    fr2          1    Digital Realty                             1    Geneva                      1    CH       1\n    bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe  1    ge1          1    Equinix                                    1    Hesse                       1    DE       1\n    eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe  1    hk1          1    Flexential                                 1    HongKong                    1    FR       1\n    fwnmn-zn7yt-5jaia-fkxlr-dzwyu-keguq-npfxq-mc72w-exeae-n5thj-oae  1    lj1          1    HighDC                                     1    Ljubljana                   1    GE       1\n    optdi-nwa4m-hly3k-6ua4n-sqyxf-yahvb-wps77-ddayn-r7zcz-edla5-7qe  1    mr1          1    Marvelous Web3 DC                          1    New Delhi                   1    HK       1\n    r3yjn-kthmg-pfgmb-2fngg-5c7d7-t6kqg-wi37r-j7gy6-iee64-kjdja-jae  1    nd1          1    NEXTDC                                     1    Oregon                      1    IN       1\n    s5nvr-ipdxf-xg6wd-ofacm-7tl4i-nwjzx-uulum-cugwb-kbpsa-wrsgs-cae  1    pl1          1    Posita.si                                  1    Provence-Alpes-Cote d'Azur  1    SG       1\n    vegae-c4chr-aetfj-7gzuh-c23sx-u2paz-vmvbn-bcage-pu7lu-mptnn-eqe  1    sc1          1    SyT - Servicios y Telecomunicaciones S.A.  1    Queensland                  1    SI       1\n    wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae  1    sg1          1    Telin                                      1    Singapore                   1    US       1\n    wdnqm-clqti-im5yf-iapio-avjom-kyppl-xuiza-oaz6z-smmts-52wyg-5ae  1    tb1          1    Unicom                                     1    Tbilisi                     1    ZA       1\n```\n\n\nBusiness rules check results *before* the membership change:\n- Subnet should have 1 DFINITY-owned node(s) for subnet recovery, got 0\n\n"), forum_post_link: Some("https://forum.dfinity.org/t/subnet-management-snjp4-application") } }
  - Error: "Received error when submitting proposal: ic-admin failed with non-zero exit code 1 stderr ==>\nUsing NNS URLs: [\"https://ic0.app/\"]\nsubmit_proposal for Replace a node in subnet snjp4 response: Err(\"NotFound: Neuron not found: NeuronId { id: 123 }\")\nsubmit_proposal for Replace a node in subnet snjp4 error: \"NotFound: Neuron not found: NeuronId { id: 123 }\"\n"
~~~

</details>