### PR TITLE
chore: integrating call cmc to show diff

### DIFF
--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -160,7 +160,7 @@ fn construct_summary(
             .values()
             .map(|s| {
                 let excluded_desc = excluded_subnets.get(&s.principal);
-                let was_public = current_public_subnets.iter().find(|principal| *principal == &s.principal).is_some();
+                let was_public = current_public_subnets.iter().any(|principal| principal == &s.principal);
                 format!(
                     "| {} | {} | {} |",
                     s.principal,
@@ -168,7 +168,7 @@ fn construct_summary(
                         // The state doesn't change
                         (was_public, is_excluded) if was_public == is_excluded => was_public.to_string(),
                         // It changed from `was_public` to `is_excluded`
-                        (was_public, is_excluded) => format!("~~{}~~ {}", was_public, is_excluded),
+                        (was_public, is_excluded) => format!("~~{}~~ ⇒ {}", was_public, is_excluded),
                     },
                     excluded_desc.map(|s| s.to_string()).unwrap_or_default()
                 )

--- a/rs/ic-canisters/src/cycles_minting.rs
+++ b/rs/ic-canisters/src/cycles_minting.rs
@@ -1,0 +1,26 @@
+use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
+use ic_types::{CanisterId, PrincipalId};
+
+use crate::IcAgentCanisterClient;
+
+pub struct CyclesMintingCanisterWrapper {
+    agent: IcAgentCanisterClient,
+    canister_id: CanisterId,
+}
+
+impl From<IcAgentCanisterClient> for CyclesMintingCanisterWrapper {
+    fn from(value: IcAgentCanisterClient) -> Self {
+        Self {
+            agent: value,
+            canister_id: CYCLES_MINTING_CANISTER_ID.clone(),
+        }
+    }
+}
+
+impl CyclesMintingCanisterWrapper {
+    pub async fn get_authorized_subnets(&self) -> anyhow::Result<Vec<PrincipalId>> {
+        self.agent
+            .query(&self.canister_id.into(), "get_default_subnets", candid::encode_one(())?)
+            .await
+    }
+}

--- a/rs/ic-canisters/src/cycles_minting.rs
+++ b/rs/ic-canisters/src/cycles_minting.rs
@@ -12,7 +12,7 @@ impl From<IcAgentCanisterClient> for CyclesMintingCanisterWrapper {
     fn from(value: IcAgentCanisterClient) -> Self {
         Self {
             agent: value,
-            canister_id: CYCLES_MINTING_CANISTER_ID.clone(),
+            canister_id: CYCLES_MINTING_CANISTER_ID,
         }
     }
 }

--- a/rs/ic-canisters/src/lib.rs
+++ b/rs/ic-canisters/src/lib.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use url::Url;
 
+pub mod cycles_minting;
 pub mod governance;
 pub mod ledger;
 pub mod management;


### PR DESCRIPTION
The new summary will have a table that looks like the following:


| Subnet id | Public | Description |
| --------- | ------ | ----------- |
| 2fq7c-slacv-26cgz-vzbx2-2jrcs-5edph-i5s2j-tck77-c3rlz-iobzx-mqe | false | Subnet has more than 60000 canisters |
| 3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe | ~~true~~ ⇒ false | Subnet has more than 300 GiB state size |
| 4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe | true |  |
| 4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe | false | Verified App subnet |
| 5kdm2-62fc6-fwnja-hutkz-ycsnm-4z33i-woh43-4cenu-ev7mi-gii6t-4ae | false | Verified App subnet |
| 6pbhf-qzpdk-kuqbr-pklfa-5ehhf-jfjps-zsj6q-57nrl-kzhpd-mu7hc-vae | ~~true~~ ⇒ false | Subnet has more than 300 GiB state size |
| bkfrj-6k62g-dycql-7h53p-atvkj-zg4to-gaogh-netha-ptybj-ntsgw-rqe | false | [Explicitly removed] European subnet |
| brlsh-zidhj-3yy3e-6vqbz-7xnih-xeq2l-as5oc-g32c4-i5pdn-2wwof-oae | true |  |
| csyj4-zmann-ys6ge-3kzi6-onexi-obayx-2fvak-zersm-euci4-6pslt-lae | false | Verified App subnet |
| cv73p-6v7zi-u67oy-7jc3h-qspsz-g5lrj-4fn7k-xrax3-thek2-sl46v-jae | true |  |
| e66qm-3cydn-nkf4i-ml4rb-4ro6o-srm5s-x5hwq-hnprz-3meqp-s7vks-5qe | true |  |
| ejbmu-grnam-gk6ol-6irwa-htwoj-7ihfl-goimw-hlnvh-abms4-47v2e-zqe | false | Verified App subnet |
| eq6en-6jqla-fbu5s-daskr-h6hx2-376n5-iqabl-qgrng-gfqmv-n3yjr-mqe | false | Verified App subnet |
| fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae | true |  |
| gmq5v-hbozq-uui6y-o55wc-ihop3-562wb-3qspg-nnijg-npqp5-he3cj-3ae | true |  |
| io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe | false | Verified App subnet |
| jtdsg-3h6gi-hs7o5-z2soi-43w3z-soyl3-ajnp3-ekni5-sw553-5kw67-nqe | true |  |
| k44fs-gm4pv-afozh-rs7zw-cg32n-u7xov-xqyx3-2pw5q-eucnu-cosd4-uqe | false | Subnet has more than 300 GiB state size |
| lhg73-sax6z-2zank-6oer2-575lz-zgbxx-ptudx-5korm-fy7we-kh4hl-pqe | false | Subnet has more than 300 GiB state size |
| lspz2-jx4pu-k3e7p-znm7j-q4yum-ork6e-6w4q6-pijwq-znehu-4jabe-kqe | true |  |
| mpubz-g52jc-grhjo-5oze5-qcj74-sex34-omprz-ivnsm-qvvhr-rfzpv-vae | true |  |
| nl6hn-ja4yw-wvmpy-3z2jx-ymc34-pisx3-3cp5z-3oj4a-qzzny-jbsv3-4qe | true |  |
| o3ow2-2ipam-6fcjo-3j5vt-fzbge-2g7my-5fz2m-p4o2t-dwlc4-gt2q7-5ae | true |  |
| opn46-zyspe-hhmyp-4zu6u-7sbrh-dok77-m7dch-im62f-vyimr-a3n2c-4ae | true |  |
| pae4o-o6dxf-xki7q-ezclx-znyd6-fnk6w-vkv5z-5lfwh-xym2i-otrrw-fqe | false | Verified App subnet |
| pjljw-kztyl-46ud4-ofrj6-nzkhm-3n4nt-wi3jt-ypmav-ijqkt-gjf66-uae | true |  |
| pzp6e-ekpqk-3c5x7-2h6so-njoeq-mt45d-h3h6c-q3mxf-vpeq5-fk5o7-yae | false | [Explicitly removed] Fiduciary subnet |
| qdvhd-os4o2-zzrdw-xrcv4-gljou-eztdp-bj326-e6jgr-tkhuc-ql6v2-yqe | true |  |
| qxesv-zoxpm-vc64m-zxguk-5sj74-35vrb-tbgwg-pcird-5gr26-62oxl-cae | false | Verified App subnet |
| shefu-t3kr5-t5q3w-mqmdq-jabyv-vyvtf-cyyey-3kmo4-toyln-emubw-4qe | false | Verified App subnet |
| snjp4-xlbw4-mnbog-ddwy6-6ckfd-2w5a2-eipqo-7l436-pxqkh-l6fuv-vae | false | Verified App subnet |
| tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe | false | System subnet |
| uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe | false | System subnet |
| w4asl-4nmyj-qnr7c-6cqq4-tkwmt-o26di-iupkq-vx4kt-asbrx-jzuxh-4ae | false | Verified App subnet |
| w4rem-dv5e3-widiz-wbpea-kbttk-mnzfm-tzrc7-svcj3-kbxyb-zamch-hqe | false | System subnet |
| x33ed-h457x-bsgyx-oqxqf-6pzwv-wkhzr-rm2j3-npodi-purzm-n66cg-gae | false | [Explicitly removed] SNS subnet |
| yinp6-35cfo-wgcd2-oc4ty-2kqpf-t4dul-rfk33-fsq3r-mfmua-m2ngh-jqe | ~~true~~ ⇒ false | Subnet has more than 300 GiB state size |
