### PR TITLE
feat: update cordoned features handling and support for local file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@ exports_files([
     "archive_canister.wasm.gz",
     "clippy.toml",
     "rustfmt.toml",
+    "cordoned_features.yaml",
     "WORKSPACE.bazel",
 ])
 

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@crate_index_dre//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test", "rust_library")
-load("@rules_rust//cargo:defs.bzl", "cargo_build_script", "cargo_dep_env")
+load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 DEPS = [
     "//rs/ic-canisters",
@@ -34,7 +34,10 @@ rust_binary(
     ),
     deps = all_crate_deps(
         normal = True,
-    ) + DEPS + ["//rs/cli:dre-lib", ":build_script"]
+    ) + DEPS + ["//rs/cli:dre-lib", ":build_script"],
+    data = [
+        "//:cordoned_features.yaml",
+    ]
 )
 
 rust_library(

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use crate::commands::subnet::Subnet;
 use api_boundary_nodes::ApiBoundaryNodes;
 use clap::Args as ClapArgs;
@@ -212,7 +210,7 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
 
     /// Path to file which contains cordoned features
     #[clap(long, global = true, visible_aliases = &["cf-file", "cfff"])]
-    pub cordon_feature_fallback_file: Option<PathBuf>,
+    pub cordoned_features_file: Option<String>,
 }
 
 // Do not use outside of DRE CLI.

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -116,7 +116,7 @@ impl DreContext {
             args.subcommands.require_auth(),
             args.forum_post_link.clone(),
             args.ic_admin_version.clone(),
-            store.cordoned_features_fetcher()?,
+            store.cordoned_features_fetcher(args.cordoned_features_file.clone())?,
             store.health_client(&network)?,
             store,
             args.discourse_opts.clone(),

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use ahash::AHashMap;
+use decentralization::network::CordonedFeature;
 use decentralization::network::DecentralizedSubnet;
 use decentralization::network::NetworkHealRequest;
-use decentralization::network::NodeFeaturePair;
 use decentralization::network::SubnetChange;
 use decentralization::network::SubnetChangeRequest;
 use decentralization::network::SubnetQueryBy;
@@ -648,7 +648,7 @@ impl Runner {
         health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
         node: &Node,
         ensure_assigned: bool,
-        cordoned_features: Vec<NodeFeaturePair>,
+        cordoned_features: Vec<CordonedFeature>,
         all_nodes: &[Node],
     ) -> Option<SubnetChangeResponse> {
         let mut best_change: Option<SubnetChangeResponse> = None;

--- a/rs/cli/src/unit_tests/replace.rs
+++ b/rs/cli/src/unit_tests/replace.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use decentralization::{
-    network::{DecentralizedSubnet, NodeFeaturePair},
+    network::{CordonedFeature, DecentralizedSubnet},
     SubnetChangeResponse,
 };
 use ic_management_backend::{health::MockHealthStatusQuerier, lazy_registry::MockLazyRegistry};
@@ -54,10 +54,11 @@ fn subnet(id: u64, nodes: &[Node]) -> DecentralizedSubnet {
     }
 }
 
-fn cordoned_feature(feature: NodeFeature, value: &str) -> NodeFeaturePair {
-    NodeFeaturePair {
+fn cordoned_feature(feature: NodeFeature, value: &str) -> CordonedFeature {
+    CordonedFeature {
         feature,
         value: value.to_string(),
+        explanation: None,
     }
 }
 

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -824,7 +824,7 @@ pub trait TopologyManager: SubnetQuerier + AvailableNodesQuerier + Sync {
         exclude_nodes: Vec<String>,
         only_nodes: Vec<String>,
         health_of_nodes: &'a IndexMap<PrincipalId, HealthStatus>,
-        cordoned_features: Vec<NodeFeaturePair>,
+        cordoned_features: Vec<CordonedFeature>,
         all_nodes: &'a [Node],
     ) -> BoxFuture<'a, Result<SubnetChange, NetworkError>> {
         Box::pin(async move {
@@ -883,9 +883,10 @@ impl<T: Identifies<Node>> MatchAnyNode<T> for std::slice::Iter<'_, T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct NodeFeaturePair {
+pub struct CordonedFeature {
     pub feature: NodeFeature,
     pub value: String,
+    pub explanation: Option<String>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -980,7 +981,7 @@ impl SubnetChangeRequest {
         optimize_count: usize,
         replacements_unhealthy: &[Node],
         health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
-        cordoned_features: Vec<NodeFeaturePair>,
+        cordoned_features: Vec<CordonedFeature>,
         all_nodes: &[Node],
     ) -> Result<SubnetChange, NetworkError> {
         let old_nodes = self.subnet.nodes.clone();
@@ -999,7 +1000,7 @@ impl SubnetChangeRequest {
     pub fn rescue(
         mut self,
         health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
-        cordoned_features: Vec<NodeFeaturePair>,
+        cordoned_features: Vec<CordonedFeature>,
         all_nodes: &[Node],
     ) -> Result<SubnetChange, NetworkError> {
         let old_nodes = self.subnet.nodes.clone();
@@ -1031,7 +1032,7 @@ impl SubnetChangeRequest {
         how_many_nodes_to_remove: usize,
         how_many_nodes_unhealthy: usize,
         health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
-        cordoned_features: Vec<NodeFeaturePair>,
+        cordoned_features: Vec<CordonedFeature>,
         all_nodes: &[Node],
     ) -> Result<SubnetChange, NetworkError> {
         let old_nodes = self.subnet.nodes.clone();
@@ -1133,7 +1134,7 @@ impl SubnetChangeRequest {
     pub fn evaluate(
         self,
         health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
-        cordoned_features: Vec<NodeFeaturePair>,
+        cordoned_features: Vec<CordonedFeature>,
         all_nodes: &[Node],
     ) -> Result<SubnetChange, NetworkError> {
         self.resize(0, 0, 0, health_of_nodes, cordoned_features, all_nodes)
@@ -1254,7 +1255,7 @@ impl NetworkHealRequest {
         &self,
         mut available_nodes: Vec<Node>,
         health_of_nodes: &IndexMap<PrincipalId, HealthStatus>,
-        cordoned_features: Vec<NodeFeaturePair>,
+        cordoned_features: Vec<CordonedFeature>,
         all_nodes: &[Node],
         optimize_for_business_rules_compliance: bool,
     ) -> Result<Vec<SubnetChangeResponse>, NetworkError> {


### PR DESCRIPTION
Previous implementation was using the local file for cordoned features *only if* --offline was provided. That means that the entire dre tool had to be forced to go offline.
With this change, one can simply provide `--cordoned-features-file <file>` on the CLI, and the local file will override the github version