### PR TITLE
HSM handling improvements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ checksum = "dd8ecacd682fa05a985253592963306cb9799622d7b1cce4b1edb89c6ec85be1"
 dependencies = [
  "candid",
  "ic-cdk-macros 0.16.0",
- "ic0 0.23.0",
+ "ic0 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_bytes",
 ]
@@ -3147,7 +3147,7 @@ source = "git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39e
 dependencies = [
  "candid",
  "ic-cdk-macros 0.17.0",
- "ic0 0.23.0",
+ "ic0 0.23.0 (git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39ea8ade59d7c848cde)",
  "serde",
  "serde_bytes",
 ]
@@ -3228,7 +3228,7 @@ source = "git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39e
 dependencies = [
  "futures",
  "ic-cdk 0.17.0",
- "ic0 0.23.0",
+ "ic0 0.23.0 (git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39ea8ade59d7c848cde)",
  "serde",
  "serde_bytes",
  "slotmap",

--- a/rs/cli/src/auth.rs
+++ b/rs/cli/src/auth.rs
@@ -1,14 +1,12 @@
-use std::path::PathBuf;
-
-use anyhow::anyhow;
 use dialoguer::{console::Term, theme::ColorfulTheme, Password, Select};
 use ic_canisters::governance::GovernanceCanisterWrapper;
-use ic_canisters::parallel_hardware_identity::{hsm_key_id_to_int, KeyIdVec, ParallelHardwareIdentity};
+use ic_canisters::parallel_hardware_identity::{hsm_key_id_to_int, HsmPinHandler, KeyIdVec, ParallelHardwareIdentity, PinHandlerError};
 use ic_canisters::IcAgentCanisterClient;
 use ic_icrc1_test_utils::KeyPairGenerator;
 use ic_management_types::Network;
 use keyring::{Entry, Error};
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
+use std::path::PathBuf;
 
 use crate::commands::{AuthOpts, AuthRequirement, HsmOpts, HsmParams};
 
@@ -29,6 +27,65 @@ impl Eq for Neuron {}
 
 pub const STAGING_NEURON_ID: u64 = 49;
 pub const STAGING_KEY_PATH_FROM_HOME: &str = ".config/dfx/identity/bootstrap-super-leader/identity.pem";
+
+/// `keyring`-based memory for PIN that uses console prompting for the PIN
+/// when a PIN is necessary and has not been supplied by the user.
+/// This implementation lives in this crate to avoid having to add a
+/// `keyring` dependency to the parallel_hardware_identity module.
+#[derive(Default)]
+struct PlatformKeyringPinHandler {}
+
+impl HsmPinHandler for PlatformKeyringPinHandler {
+    fn retrieve(&self, key: &str, from_memory: bool) -> Result<String, PinHandlerError> {
+        if !from_memory {
+            match Password::new().with_prompt("Please enter the hardware security module PIN: ").interact() {
+                Ok(pin) => Ok(pin),
+                Err(e) => Err(PinHandlerError(format!("Prompt for PIN failed: {}", e))),
+            }
+        } else {
+            let entry = match Entry::new("dre-tool-hsm-pin", key) {
+                Ok(entry) => Ok(entry),
+                Err(e) => Err(PinHandlerError(format!("Keyring initialization failed: {}", e))),
+            }?;
+            match entry.get_password() {
+                Ok(pin) => Ok(pin),
+                Err(e) => {
+                    if let Error::NoEntry = e {
+                    } else {
+                        error!("Cannot retrieve password from keyring; switching to unconditional prompt.  Error: {}", e);
+                    };
+                    match Password::new().with_prompt("Please enter the hardware security module PIN: ").interact() {
+                        Ok(pin) => Ok(pin),
+                        Err(e) => Err(PinHandlerError(format!("Prompt for PIN failed: {}", e))),
+                    }
+                }
+            }
+        }
+    }
+
+    fn store(&self, key: &str, pin: &str) -> Result<(), PinHandlerError> {
+        let entry = match Entry::new("dre-tool-hsm-pin", key) {
+            Ok(entry) => Ok(entry),
+            Err(e) => Err(PinHandlerError(format!("Keyring initialization failed: {}", e))),
+        }?;
+        match entry.set_password(pin) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(PinHandlerError(format!("{}", e))),
+        }
+    }
+
+    fn forget(&self, key: &str) -> Result<(), PinHandlerError> {
+        let entry = match Entry::new("dre-tool-hsm-pin", key) {
+            Ok(entry) => Ok(entry),
+            Err(e) => Err(PinHandlerError(format!("Keyring initialization failed: {}", e))),
+        }?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(PinHandlerError(format!("{}", e))),
+        }
+    }
+}
 
 impl Neuron {
     pub(crate) async fn from_opts_and_req(
@@ -221,35 +278,13 @@ impl Auth {
         }
     }
 
-    /// If it is called it is expected to retrieve an Auth of type Hsm or fail
     /// FIXME: this should not return anyhow::Error, but rather a structured error,
     /// since anyhow swallows panics, and transforms them to errors.
     fn detect_hsm_auth(maybe_pin: Option<String>, maybe_slot: Option<u64>, maybe_key_id: Option<KeyIdVec>) -> anyhow::Result<Self> {
-        let detected_hsm = ParallelHardwareIdentity::scan_for_hsm(maybe_slot, maybe_key_id)?;
-        let identity = match maybe_pin {
-            Some(pin) => detected_hsm.authenticate(pin),
-            None => {
-                let pin_entry = Entry::new("dre-tool-hsm-pin", detected_hsm.memo_key.as_str())?;
-                let tentative_pin = match pin_entry.get_password() {
-                    Err(Error::NoEntry) => Password::new()
-                        .with_prompt("Please enter the hardware security module PIN: ")
-                        .interact()?,
-                    Ok(pin) => pin,
-                    Err(e) => return Err(anyhow!("Problem getting PIN from keyring: {}", e)),
-                };
-                match detected_hsm.authenticate(tentative_pin.clone()) {
-                    Ok(identity) => {
-                        pin_entry.set_password(&tentative_pin)?;
-                        Ok(identity)
-                    }
-                    Err(e) => {
-                        pin_entry.delete_credential()?;
-                        return Err(anyhow!("Hardware security module PIN incorrect ({})", e));
-                    }
-                }
-            }
-        }?;
-        Ok(Auth::Hsm { identity })
+        let memory = PlatformKeyringPinHandler::default();
+        Ok(Auth::Hsm {
+            identity: ParallelHardwareIdentity::scan(maybe_pin, maybe_slot, maybe_key_id, &memory)?,
+        })
     }
 
     /// Create an Auth that automatically detects an HSM.  Falls back to

--- a/rs/ic-canisters/src/parallel_hardware_identity.rs
+++ b/rs/ic-canisters/src/parallel_hardware_identity.rs
@@ -358,6 +358,7 @@ impl From<PinHandlerError> for HardwareIdentityError {
 }
 
 /// Interface to retrieve, store and forget PINs associated with HSMs.
+/// The key is a string derived from the HSM slot description and manufacturer.
 pub trait HsmPinHandler {
     /// Retrieve a PIN from the user, or from within the user keyring associated with the specified key.
     /// If from_keyring is false, implementors must disregard keyring contents and force a prompt.


### PR DESCRIPTION
* Tighten the interface between the ParallelHardwareIdentity module and its users.
* Simplify error handling when collecting the PIN.
* Make PIN prompt robust against failures of the system keyring (PIN may not be saved, but at least the tool works with manual prompting).
* Protect HSM from locking itself if the PIN is at its last try -- skip retrieving the PIN from the keyring, and prohibit the use of environment variables to supply the PIN, preferring to prompt the user for a PIN instead (or let the user cancel).