### PR TITLE
feat(dre): incremental opening of verified subnets 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ checksum = "dd8ecacd682fa05a985253592963306cb9799622d7b1cce4b1edb89c6ec85be1"
 dependencies = [
  "candid",
  "ic-cdk-macros 0.16.0",
- "ic0 0.23.0",
+ "ic0 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_bytes",
 ]
@@ -3147,7 +3147,7 @@ source = "git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39e
 dependencies = [
  "candid",
  "ic-cdk-macros 0.17.0",
- "ic0 0.23.0",
+ "ic0 0.23.0 (git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39ea8ade59d7c848cde)",
  "serde",
  "serde_bytes",
 ]
@@ -3228,7 +3228,7 @@ source = "git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39e
 dependencies = [
  "futures",
  "ic-cdk 0.17.0",
- "ic0 0.23.0",
+ "ic0 0.23.0 (git+https://github.com/dfinity/cdk-rs.git?rev=8f57d6d26b1d142b5be4b39ea8ade59d7c848cde)",
  "serde",
  "serde_bytes",
  "slotmap",

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -14,6 +14,8 @@ use serde_json::json;
 pub trait DiscourseClient: Sync + Send {
     fn create_replace_nodes_forum_post(&self, subnet_id: PrincipalId, body: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>>;
 
+    fn create_authorized_subnets_update_forum_post(&self, body: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>>;
+
     fn add_proposal_url_to_post(&self, post_id: Option<u64>, proposal_id: u64) -> BoxFuture<'_, anyhow::Result<()>>;
 }
 
@@ -198,6 +200,25 @@ impl DiscourseClient for DiscourseClientImp {
             );
             self.update_post_content(post_id, new_content).await
         })
+    }
+
+    fn create_authorized_subnets_update_forum_post(&self, body: String) -> BoxFuture<'_, anyhow::Result<Option<DiscourseResponse>>> {
+        let post = DiscourseTopic {
+            title: "Adjusting authorized subnets".to_string(),
+            content: body,
+            tags: vec![],
+            category: GOVERNANCE_TOPIC.to_string(),
+        };
+        let post_clone = post.clone();
+
+        let try_call = async move {
+            if self.offline || self.skip_forum_post_creation {
+                return Ok(None);
+            }
+            let topic = self.create_topic(post).await?;
+            Ok(Some(topic))
+        };
+        Box::pin(async move { try_call.await.or_else(|e| self.request_from_user(e, post_clone)) })
     }
 }
 

--- a/rs/ic-canisters/src/lib.rs
+++ b/rs/ic-canisters/src/lib.rs
@@ -25,6 +25,7 @@ pub mod parallel_hardware_identity;
 pub mod registry;
 pub mod sns_wasm;
 
+#[derive(Clone)]
 pub struct IcAgentCanisterClient {
     pub agent: Agent,
 }


### PR DESCRIPTION
This PR adds the support for controlled opening of verified subnets. 
To do that one can:
```bash
dre update-authorized-subnets --open-verified-subnets 2
```

There have been some changes in the table layout of the summary. It looks like the following now:
<details>


| Subnet id | Subnet Type | Public | Description |
| --------- | ----------- | ------ | ----------- |
| 2fq7c-slacv-26cgz-vzbx2-2jrcs-5edph-i5s2j-tck77-c3rlz-iobzx-mqe | Application | false | Subnet has more than 60000 canisters |
| 3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe | Application | ~~true~~ ⇒ false | Subnet has more than 300 GiB state size |
| 4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe | Application | true |  |
| 4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe | Verified Application | ~~false~~ ⇒ true |  |
| 5kdm2-62fc6-fwnja-hutkz-ycsnm-4z33i-woh43-4cenu-ev7mi-gii6t-4ae | Verified Application | ~~false~~ ⇒ true |  |
| 6pbhf-qzpdk-kuqbr-pklfa-5ehhf-jfjps-zsj6q-57nrl-kzhpd-mu7hc-vae | Application | ~~true~~ ⇒ false | Subnet has more than 300 GiB state size |
| bkfrj-6k62g-dycql-7h53p-atvkj-zg4to-gaogh-netha-ptybj-ntsgw-rqe | Application | false | [Explicitly removed] European subnet |
| brlsh-zidhj-3yy3e-6vqbz-7xnih-xeq2l-as5oc-g32c4-i5pdn-2wwof-oae | Application | true |  |
| csyj4-zmann-ys6ge-3kzi6-onexi-obayx-2fvak-zersm-euci4-6pslt-lae | Verified Application | ~~false~~ ⇒ true |  |
| cv73p-6v7zi-u67oy-7jc3h-qspsz-g5lrj-4fn7k-xrax3-thek2-sl46v-jae | Application | true |  |
| e66qm-3cydn-nkf4i-ml4rb-4ro6o-srm5s-x5hwq-hnprz-3meqp-s7vks-5qe | Application | true |  |
| ejbmu-grnam-gk6ol-6irwa-htwoj-7ihfl-goimw-hlnvh-abms4-47v2e-zqe | Verified Application | ~~false~~ ⇒ true |  |
| eq6en-6jqla-fbu5s-daskr-h6hx2-376n5-iqabl-qgrng-gfqmv-n3yjr-mqe | Verified Application | false | Subnet has more than 60000 canisters |
| fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae | Application | true |  |
| gmq5v-hbozq-uui6y-o55wc-ihop3-562wb-3qspg-nnijg-npqp5-he3cj-3ae | Application | true |  |
| io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe | Verified Application | ~~false~~ ⇒ true |  |
| jtdsg-3h6gi-hs7o5-z2soi-43w3z-soyl3-ajnp3-ekni5-sw553-5kw67-nqe | Application | true |  |
| k44fs-gm4pv-afozh-rs7zw-cg32n-u7xov-xqyx3-2pw5q-eucnu-cosd4-uqe | Application | false | Subnet has more than 300 GiB state size |
| lhg73-sax6z-2zank-6oer2-575lz-zgbxx-ptudx-5korm-fy7we-kh4hl-pqe | Application | false | Subnet has more than 300 GiB state size |
| lspz2-jx4pu-k3e7p-znm7j-q4yum-ork6e-6w4q6-pijwq-znehu-4jabe-kqe | Application | true |  |
| mpubz-g52jc-grhjo-5oze5-qcj74-sex34-omprz-ivnsm-qvvhr-rfzpv-vae | Application | true |  |
| nl6hn-ja4yw-wvmpy-3z2jx-ymc34-pisx3-3cp5z-3oj4a-qzzny-jbsv3-4qe | Application | true |  |
| o3ow2-2ipam-6fcjo-3j5vt-fzbge-2g7my-5fz2m-p4o2t-dwlc4-gt2q7-5ae | Application | true |  |
| opn46-zyspe-hhmyp-4zu6u-7sbrh-dok77-m7dch-im62f-vyimr-a3n2c-4ae | Application | true |  |
| pae4o-o6dxf-xki7q-ezclx-znyd6-fnk6w-vkv5z-5lfwh-xym2i-otrrw-fqe | Verified Application | ~~false~~ ⇒ true |  |
| pjljw-kztyl-46ud4-ofrj6-nzkhm-3n4nt-wi3jt-ypmav-ijqkt-gjf66-uae | Application | true |  |
| pzp6e-ekpqk-3c5x7-2h6so-njoeq-mt45d-h3h6c-q3mxf-vpeq5-fk5o7-yae | Application | false | [Explicitly removed] Fiduciary subnet |
| qdvhd-os4o2-zzrdw-xrcv4-gljou-eztdp-bj326-e6jgr-tkhuc-ql6v2-yqe | Application | true |  |
| qxesv-zoxpm-vc64m-zxguk-5sj74-35vrb-tbgwg-pcird-5gr26-62oxl-cae | Verified Application | ~~false~~ ⇒ true |  |
| shefu-t3kr5-t5q3w-mqmdq-jabyv-vyvtf-cyyey-3kmo4-toyln-emubw-4qe | Verified Application | ~~false~~ ⇒ true |  |
| snjp4-xlbw4-mnbog-ddwy6-6ckfd-2w5a2-eipqo-7l436-pxqkh-l6fuv-vae | Verified Application | ~~false~~ ⇒ true |  |
| tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe | System | false | System subnets should be closed for public access |
| uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe | System | false | System subnets should be closed for public access |
| w4asl-4nmyj-qnr7c-6cqq4-tkwmt-o26di-iupkq-vx4kt-asbrx-jzuxh-4ae | Verified Application | ~~false~~ ⇒ true |  |
| w4rem-dv5e3-widiz-wbpea-kbttk-mnzfm-tzrc7-svcj3-kbxyb-zamch-hqe | System | false | System subnets should be closed for public access |
| x33ed-h457x-bsgyx-oqxqf-6pzwv-wkhzr-rm2j3-npodi-purzm-n66cg-gae | Application | false | [Explicitly removed] SNS subnet |
| yinp6-35cfo-wgcd2-oc4ty-2kqpf-t4dul-rfk33-fsq3r-mfmua-m2ngh-jqe | Application | ~~true~~ ⇒ false | Subnet has more than 300 GiB state size |


</details>