### PR TITLE
refactor(): split into 2 jobs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-and-push:
+    runs-on:
+      labels: dre-runner-custom
+    # This image is based on ubuntu:20.04
+    container: ghcr.io/dfinity/dre/actions-runner:3dd4f38f076cad73fdcc68ad37fd29bed4fa3e4d
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+      - name: "🚀 Build and Push"
+        uses: ./.github/workflows/build
+        with:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
   bazel:
     runs-on:
       labels: dre-runner-custom
@@ -42,10 +60,6 @@ jobs:
       # Will run test as a local subprocess because for some tests
       # create status files on certain locations (like $HOME)
       ########################################
-      - name: "🚀 Building"
-        uses: ./.github/workflows/build
-        with:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: "🚀 Testing"
         env:
           STAGING_PRIVATE_KEY_PEM: "${{ secrets.STAGING_PRIVATE_KEY_PEM }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,10 +34,14 @@ jobs:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
       - uses: actions/checkout@v4
+      - name: "☁️ Setup runner"
+        uses: ./.github/workflows/manage-runner-pre
       - name: "🚀 Build and Push"
         uses: ./.github/workflows/build
         with:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: "🪓 Tear down runner"
+        uses: ./.github/workflows/manage-runner-post
 
   bazel:
     runs-on:
@@ -52,8 +56,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - name: "☁️ Setup runner"
-        uses: ./.github/workflows/manage-runner-pre
 
       ########################################
       # Build and test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,6 +56,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+      - name: "☁️ Setup runner"
+        uses: ./.github/workflows/manage-runner-pre
 
       ########################################
       # Build and test


### PR DESCRIPTION
This splits the workflow into two separate jobs. The benefit is that permissions can be defined separately and the jobs can be parallelized.