### PR TITLE
fix(ci): use GitHub App token to trigger CI actions

### DIFF
--- a/.github/workflows/build/action.yaml
+++ b/.github/workflows/build/action.yaml
@@ -3,7 +3,7 @@ description: Reusable action for building and repin with bazel
 
 inputs:
   GITHUB_TOKEN:
-    description: "Github SA PTA for the repo allowing workflows to run actions"
+    description: "Github App Token, that allows to push to the repository and trigger actions"
     required: true
 
 runs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 2
 
       # The GitHub App token is necessary for pushing changed files back to the repository
-      # If secrets.GITHUB_TOKEN is used, the push will not trigger any actions
+      # If regular secrets.GITHUB_TOKEN is used instead, the push will not trigger any actions
       # https://github.com/orgs/community/discussions/25702
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      # The GitHub App token is necessary for pushing changed files back to the repository
+      # If secrets.GITHUB_TOKEN is used, the push will not trigger any actions
+      # https://github.com/orgs/community/discussions/25702
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
       - name: "☁️ Setup runner"
         uses: ./.github/workflows/manage-runner-pre
 
@@ -45,7 +56,9 @@ jobs:
       - name: "🚀 Building"
         uses: ./.github/workflows/build
         with:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # See above where the token is generated: we can't use regular secrets.GITHUB_TOKEN
+          # since the push needs to trigger actions again
+          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
       - name: "🚀 Testing"
         env:
           STAGING_PRIVATE_KEY_PEM: "${{ secrets.STAGING_PRIVATE_KEY_PEM }}"


### PR DESCRIPTION
An alternative implementation similar to https://github.com/dfinity/dre/pull/1135 would also work, but that would approximately double the load on the CI.
The change from this PR doesn't increase the load, although admitedly it's not as clean as #1135