### PR TITLE
feat(dre): add ability to omit/ignore a list of nodes when healing the entire network

### DIFF
--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -6,7 +6,7 @@ use log::warn;
 
 use crate::{
     commands::{AuthRequirement, ExecutableCommand},
-    discourse_client::parse_proposal_id_from_governance_response,
+    discourse_client::parse_proposal_id_from_ic_admin_response,
     ic_admin::ProposeOptions,
     subnet_manager::SubnetTarget,
 };
@@ -126,7 +126,7 @@ impl ExecutableCommand for Replace {
 
             if let Some(topic) = maybe_topic {
                 discourse_client
-                    .add_proposal_url_to_post(topic.update_id, parse_proposal_id_from_governance_response(proposal_response)?)
+                    .add_proposal_url_to_post(topic.update_id, parse_proposal_id_from_ic_admin_response(proposal_response)?)
                     .await?
             }
         }

--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use log::info;
 
 use crate::{
-    discourse_client::parse_proposal_id_from_governance_response,
+    discourse_client::parse_proposal_id_from_ic_admin_response,
     ic_admin::{ProposeCommand, ProposeOptions},
 };
 
@@ -170,7 +170,7 @@ impl ExecutableCommand for UpdateAuthorizedSubnets {
 
         if let Some(topic) = maybe_topic {
             discourse_client
-                .add_proposal_url_to_post(topic.update_id, parse_proposal_id_from_governance_response(proposal_response)?)
+                .add_proposal_url_to_post(topic.update_id, parse_proposal_id_from_ic_admin_response(proposal_response)?)
                 .await?;
         }
 

--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -222,10 +222,11 @@ impl DiscourseClient for DiscourseClientImp {
     }
 }
 
-pub fn parse_proposal_id_from_governance_response(response: String) -> anyhow::Result<u64> {
+pub fn parse_proposal_id_from_ic_admin_response(response: String) -> anyhow::Result<u64> {
     // To ensure we capture just the line with "proposal xyz"
     let last_line = response
         .lines()
+        .filter(|line| !line.trim().is_empty())
         .last()
         .ok_or(anyhow::anyhow!("Expected at least one line in the response"))?;
     let re = Regex::new(r"\s*(\d+)\s*")?;
@@ -280,16 +281,20 @@ mod tests {
 
     #[test]
     fn parse_proposal_id_test() {
-        let text = " 123456   ".to_string();
-        let parsed = parse_proposal_id_from_governance_response(text).unwrap();
+        let text = r#" some text blah 111
+proposal 123456
+
+"#
+        .to_string();
+        let parsed = parse_proposal_id_from_ic_admin_response(text).unwrap();
         assert_eq!(parsed, 123456);
 
         let text = "222222".to_string();
-        let parsed = parse_proposal_id_from_governance_response(text).unwrap();
+        let parsed = parse_proposal_id_from_ic_admin_response(text).unwrap();
         assert_eq!(parsed, 222222);
 
         let text = "Proposal id 123456".to_string();
-        let parsed = parse_proposal_id_from_governance_response(text).unwrap();
+        let parsed = parse_proposal_id_from_ic_admin_response(text).unwrap();
         assert_eq!(parsed, 123456)
     }
 }


### PR DESCRIPTION
The list of omitted nodes is used internally when healing and optimizing the network since certain steps may add nodes to subnets and we don't want to use the same nodes in subsequent steps. So a kind of a node reservation.
It may make sense to expose this list to the command line user as well,  e.g. in case one does not want particular nodes to be considered healthy and to be added to subnets, even though nothing is obviously wrong with the nodes. This way the list of omited nodes does not start empty.

This makes the omit_nodes work the same as omit_subnets, that was introduced earlier.

Also, several minor refactorings and bug fixes.