### PR TITLE
fix: update discourse forum posts contents for subnet proposals

### DIFF
--- a/rs/cli/src/discourse_client.rs
+++ b/rs/cli/src/discourse_client.rs
@@ -257,20 +257,21 @@ impl DiscourseClient for DiscourseClientImp {
                 return Ok(());
             }
 
-            let new_content = format!("Proposal id [{0}](https://dashboard.internetcomputer.org/proposal/{0})", proposal_id);
             if post_id.is_none() {
-                warn!("Update the forum post with the following text");
-                warn!("{}", new_content);
+                warn!("Failed to find post id to update the proposal id");
                 return Ok(());
             }
             let post_id = post_id.unwrap();
 
-            let content = self.get_post_content(post_id).await?;
+            let orig_content = self.get_post_content(post_id).await?;
             let new_content = format!(
-                r#"{0}
+                r#"A new proposal with id [{0}](https://dashboard.internetcomputer.org/proposal/{0}) has been submitted for this subnet.
 
-{1}"#,
-                content, new_content
+[details="Click here to open proposal details"]
+{1}
+[/details]
+"#,
+                proposal_id, orig_content
             );
             self.update_post_content(post_id, new_content).await
         })

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -950,7 +950,7 @@ impl Runner {
                         &change,
                         &health_of_nodes,
                         Some(format!(
-                            "The following nodes in subnet `{}` have been cordoned and will be removed:\n{}",
+                            "The following nodes in subnet `{}` have been cordoned and need to be removed from the subnet:\n{}",
                             subnet_id_short,
                             nodes_to_remove_with_explanations
                                 .iter()


### PR DESCRIPTION
In particular: collapse the proposal summary, to reduce the forum post length.

Here is how the post looks like
![image](https://github.com/user-attachments/assets/9af07bcc-b34b-4a76-a060-c68240910a99)

And expanded:
![image](https://github.com/user-attachments/assets/b2ee7b62-8159-480e-833f-9ce680eb2407)
