### PR TITLE
feat: Adding possibility to override neurons per command

### DIFF
--- a/rs/cli/src/auth.rs
+++ b/rs/cli/src/auth.rs
@@ -163,9 +163,8 @@ impl Neuron {
                 include_proposer: false,
             }),
             AuthRequirement::Neuron => Ok({
-                info!("Neuron: {:?}, Auth: {:?}, Neuron Override: {:?}", neuron_id, auth_opts, neuron_override);
                 if neuron_id.is_none() && !auth_specified && neuron_override.is_some() {
-                    info!("Using override neuron");
+                    info!("Using override neuron for this command since no auth options were provided");
                     neuron_override.unwrap()
                 } else {
                     match (neuron_id, offline) {

--- a/rs/cli/src/commands/api_boundary_nodes/mod.rs
+++ b/rs/cli/src/commands/api_boundary_nodes/mod.rs
@@ -12,21 +12,7 @@ mod update;
 #[derive(Args, Debug)]
 pub struct ApiBoundaryNodes {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { Add, Update, Remove }
-
-impl ExecutableCommand for ApiBoundaryNodes {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
-    }
-}
+impl_executable_command_for_enums! { ApiBoundaryNodes, Add, Update, Remove }

--- a/rs/cli/src/commands/hostos/mod.rs
+++ b/rs/cli/src/commands/hostos/mod.rs
@@ -10,21 +10,7 @@ pub mod rollout_from_node_group;
 #[derive(Args, Debug)]
 pub struct HostOs {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-super::impl_executable_command_for_enums! { Rollout, RolloutFromNodeGroup }
-
-impl ExecutableCommand for HostOs {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
-    }
-}
+super::impl_executable_command_for_enums! { HostOs, Rollout, RolloutFromNodeGroup }

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -240,6 +240,10 @@ impl ExecutableCommand for Args {
     fn validate(&self, args: &crate::commands::Args, cmd: &mut Command) {
         self.subcommands.validate(args, cmd)
     }
+
+    fn neuron_override(&self) -> Option<crate::auth::Neuron> {
+        self.subcommands.neuron_override()
+    }
 }
 
 macro_rules! impl_executable_command_for_enums {
@@ -270,6 +274,12 @@ macro_rules! impl_executable_command_for_enums {
                     $(Subcommands::$var(variant) => variant.validate(args, cmd),)*
                 }
             }
+
+            fn neuron_override(&self) -> Option<crate::auth::Neuron> {
+                match &self {
+                    $(Subcommands::$var(variant) => variant.neuron_override(),)*
+                }
+            }
         }
     }
 }
@@ -283,6 +293,10 @@ pub trait ExecutableCommand {
     fn validate(&self, args: &crate::commands::Args, cmd: &mut Command);
 
     fn execute(&self, ctx: DreContext) -> impl std::future::Future<Output = anyhow::Result<()>>;
+
+    fn neuron_override(&self) -> Option<crate::auth::Neuron> {
+        None
+    }
 }
 
 #[derive(Clone)]

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -220,34 +220,8 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
     pub cordoned_features_file: Option<String>,
 }
 
-// Do not use outside of DRE CLI.
-// You can run your command by directly instantiating it.
-impl ExecutableCommand for Args {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommands.require_auth()
-    }
-
-    async fn execute(&self, ctx: DreContext) -> anyhow::Result<()> {
-        self.subcommands.execute(ctx).await
-    }
-
-    /// Validate the command line arguments. You can return an error with something like:
-    /// ```rust
-    /// if args.neuron_id.is_none() {
-    ///    cmd.error(ErrorKind::MissingRequiredArgument, "Neuron ID is required for this command.")).exit();
-    /// }
-    /// ```
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut Command) {
-        self.subcommands.validate(args, cmd)
-    }
-
-    fn neuron_override(&self) -> Option<crate::auth::Neuron> {
-        self.subcommands.neuron_override()
-    }
-}
-
 macro_rules! impl_executable_command_for_enums {
-    ($($var:ident),*) => {
+    ($str_name:ident, $($var:ident),*) => {
         use crate::ctx::DreContext;
         use clap::{Subcommand, Command};
 
@@ -281,11 +255,35 @@ macro_rules! impl_executable_command_for_enums {
                 }
             }
         }
+
+        impl ExecutableCommand for $str_name {
+            fn require_auth(&self) -> AuthRequirement {
+                self.subcommands.require_auth()
+            }
+
+            async fn execute(&self, ctx: DreContext) -> anyhow::Result<()> {
+                self.subcommands.execute(ctx).await
+            }
+
+            /// Validate the command line arguments. You can return an error with something like:
+            /// ```rust
+            /// if args.neuron_id.is_none() {
+            ///    cmd.error(ErrorKind::MissingRequiredArgument, "Neuron ID is required for this command.")).exit();
+            /// }
+            /// ```
+            fn validate(&self, args: &crate::commands::Args, cmd: &mut Command) {
+                self.subcommands.validate(args, cmd)
+            }
+
+            fn neuron_override(&self) -> Option<crate::auth::Neuron> {
+                self.subcommands.neuron_override()
+            }
+        }
     }
 }
 pub(crate) use impl_executable_command_for_enums;
 
-impl_executable_command_for_enums! { DerToPrincipal, Network, Subnet, Get, Propose, UpdateUnassignedNodes, Version, NodeMetrics, HostOs, Nodes, ApiBoundaryNodes, Vote, Registry, Firewall, Upgrade, Proposals, Completions, Qualify, UpdateAuthorizedSubnets, Neuron }
+impl_executable_command_for_enums! { Args, DerToPrincipal, Network, Subnet, Get, Propose, UpdateUnassignedNodes, Version, NodeMetrics, HostOs, Nodes, ApiBoundaryNodes, Vote, Registry, Firewall, Upgrade, Proposals, Completions, Qualify, UpdateAuthorizedSubnets, Neuron }
 
 pub trait ExecutableCommand {
     fn require_auth(&self) -> AuthRequirement;

--- a/rs/cli/src/commands/neuron/mod.rs
+++ b/rs/cli/src/commands/neuron/mod.rs
@@ -12,21 +12,7 @@ mod top_up;
 #[derive(Args, Debug)]
 pub struct Neuron {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { Balance, TopUp, Refresh }
-
-impl ExecutableCommand for Neuron {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut Command) {
-        self.subcommand.validate(args, cmd)
-    }
-
-    async fn execute(&self, ctx: DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-}
+impl_executable_command_for_enums! { Neuron, Balance, TopUp, Refresh }

--- a/rs/cli/src/commands/nodes/mod.rs
+++ b/rs/cli/src/commands/nodes/mod.rs
@@ -8,20 +8,6 @@ mod remove;
 #[derive(Args, Debug)]
 pub struct Nodes {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
-impl_executable_command_for_enums! { Remove }
-
-impl ExecutableCommand for Nodes {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
-    }
-}
+impl_executable_command_for_enums! { Nodes, Remove }

--- a/rs/cli/src/commands/proposals/mod.rs
+++ b/rs/cli/src/commands/proposals/mod.rs
@@ -59,24 +59,10 @@ mod pending;
 #[clap(alias = "proposal")]
 pub struct Proposals {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { Pending, Get, Analyze, Filter, List }
-
-impl ExecutableCommand for Proposals {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
-    }
-}
+impl_executable_command_for_enums! { Proposals, Pending, Get, Analyze, Filter, List }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Proposal {

--- a/rs/cli/src/commands/qualify/mod.rs
+++ b/rs/cli/src/commands/qualify/mod.rs
@@ -10,21 +10,7 @@ mod list;
 #[derive(Args, Debug)]
 pub struct Qualify {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { List, Execute }
-
-impl ExecutableCommand for Qualify {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-}
+impl_executable_command_for_enums! { Qualify, List, Execute }

--- a/rs/cli/src/commands/subnet/deploy.rs
+++ b/rs/cli/src/commands/subnet/deploy.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 #[derive(Args, Debug)]
+#[clap(visible_aliases = &["upgrade", "update"])]
 pub struct Deploy {
     /// Version to propose for the subnet
     #[clap(long, short)]

--- a/rs/cli/src/commands/subnet/deploy.rs
+++ b/rs/cli/src/commands/subnet/deploy.rs
@@ -2,7 +2,10 @@ use clap::Args;
 
 use ic_types::PrincipalId;
 
-use crate::commands::{AuthRequirement, ExecutableCommand};
+use crate::{
+    auth::get_automation_neuron_default_path,
+    commands::{AuthRequirement, ExecutableCommand},
+};
 
 #[derive(Args, Debug)]
 pub struct Deploy {
@@ -29,4 +32,14 @@ impl ExecutableCommand for Deploy {
     }
 
     fn validate(&self, _args: &crate::commands::Args, _cmd: &mut clap::Command) {}
+
+    fn neuron_override(&self) -> Option<crate::auth::Neuron> {
+        Some(crate::auth::Neuron {
+            auth: crate::auth::Auth::Keyfile {
+                path: get_automation_neuron_default_path(),
+            },
+            neuron_id: 80,
+            include_proposer: true,
+        })
+    }
 }

--- a/rs/cli/src/commands/subnet/mod.rs
+++ b/rs/cli/src/commands/subnet/mod.rs
@@ -35,4 +35,8 @@ impl ExecutableCommand for Subnet {
     fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
         self.subcommand.validate(args, cmd)
     }
+
+    fn neuron_override(&self) -> Option<crate::auth::Neuron> {
+        self.subcommand.neuron_override()
+    }
 }

--- a/rs/cli/src/commands/subnet/mod.rs
+++ b/rs/cli/src/commands/subnet/mod.rs
@@ -18,25 +18,7 @@ mod whatif;
 #[derive(Parser, Debug)]
 pub struct Subnet {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { WhatifDecentralization, Deploy, Replace, Resize, Create, Rescue }
-
-impl ExecutableCommand for Subnet {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
-    }
-
-    fn neuron_override(&self) -> Option<crate::auth::Neuron> {
-        self.subcommand.neuron_override()
-    }
-}
+impl_executable_command_for_enums! { Subnet, WhatifDecentralization, Deploy, Replace, Resize, Create, Rescue }

--- a/rs/cli/src/commands/version/mod.rs
+++ b/rs/cli/src/commands/version/mod.rs
@@ -8,21 +8,7 @@ pub(crate) mod revise;
 #[derive(Args, Debug)]
 pub struct Version {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { ReviseElectedVersions }
-
-impl ExecutableCommand for Version {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
-    }
-}
+impl_executable_command_for_enums! { Version, ReviseElectedVersions }

--- a/rs/cli/src/commands/version/revise/mod.rs
+++ b/rs/cli/src/commands/version/revise/mod.rs
@@ -11,10 +11,10 @@ pub(crate) mod host_os;
 #[derive(Args, Debug)]
 pub struct ReviseElectedVersions {
     #[clap(subcommand)]
-    pub subcommand: Subcommands,
+    pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { GuestOs, HostOs }
+impl_executable_command_for_enums! { ReviseElectedVersions, GuestOs, HostOs }
 
 impl From<Subcommands> for Artifact {
     fn from(value: Subcommands) -> Self {
@@ -22,19 +22,5 @@ impl From<Subcommands> for Artifact {
             Subcommands::GuestOs { .. } => Artifact::GuestOs,
             Subcommands::HostOs { .. } => Artifact::HostOs,
         }
-    }
-}
-
-impl ExecutableCommand for ReviseElectedVersions {
-    fn require_auth(&self) -> AuthRequirement {
-        self.subcommand.require_auth()
-    }
-
-    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        self.subcommand.execute(ctx).await
-    }
-
-    fn validate(&self, args: &crate::commands::Args, cmd: &mut clap::Command) {
-        self.subcommand.validate(args, cmd)
     }
 }

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -350,6 +350,7 @@ pub mod tests {
                         },
                     },
                 },
+                neuron_override: None,
                 requirement: crate::commands::AuthRequirement::Neuron,
                 neuron_id: match neuron.neuron_id {
                     0 => None,

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -27,6 +27,7 @@ struct NeuronOpts {
     auth_opts: AuthOpts,
     requirement: AuthRequirement,
     neuron_id: Option<u64>,
+    neuron_override: Option<Neuron>,
 }
 
 #[derive(Clone)]
@@ -68,6 +69,7 @@ impl DreContext {
         health_client: Arc<dyn HealthStatusQuerier>,
         store: Store,
         discourse_opts: DiscourseOpts,
+        neuron_override: Option<Neuron>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             proposal_agent: Arc::new(ProposalAgentImpl::new(&network.nns_urls)),
@@ -87,6 +89,7 @@ impl DreContext {
                 auth_opts: auth,
                 requirement: auth_requirement,
                 neuron_id,
+                neuron_override,
             },
             cordoned_features_fetcher,
             health_client,
@@ -120,6 +123,7 @@ impl DreContext {
             store.health_client(&network)?,
             store,
             args.discourse_opts.clone(),
+            args.neuron_override(),
         )
         .await
     }
@@ -178,6 +182,7 @@ impl DreContext {
             self.network(),
             self.neuron_opts.neuron_id,
             self.store.is_offline(),
+            self.neuron_opts.neuron_override.clone(),
         )
         .await;
 

--- a/rs/cli/src/unit_tests/ctx_init.rs
+++ b/rs/cli/src/unit_tests/ctx_init.rs
@@ -55,6 +55,7 @@ async fn get_context(network: &Network, version: IcAdminVersion) -> anyhow::Resu
             discourse_skip_post_creation: true,
             discourse_subnet_topic_override_file_path: None,
         },
+        None,
     )
     .await
 }
@@ -198,6 +199,7 @@ async fn get_ctx_for_neuron_test(
             discourse_skip_post_creation: false,
             discourse_subnet_topic_override_file_path: None,
         },
+        None,
     )
     .await
 }


### PR DESCRIPTION
There are some proposals that we would like to _automatically_ submit with correct neuron that is not the default neuron (Like subnet version upgrade proposals). This PR adds the possibility to add an override on a command level that will be used only if no other auth opts are specified.

This PR also includes removing of some boiler plate code as well and turns it into a macro