### PR TITLE
feature: Change release_tag field to be optional

### DIFF
--- a/rs/cli/src/commands/version/revise/guest_os.rs
+++ b/rs/cli/src/commands/version/revise/guest_os.rs
@@ -10,7 +10,7 @@ pub struct GuestOs {
 
     /// Git tag for the release
     #[clap(long)]
-    pub release_tag: String,
+    pub release_tag: Option<String>,
 
     /// Force proposal submission, ignoring missing download URLs
     #[clap(long, visible_alias = "force")]

--- a/rs/cli/src/commands/version/revise/host_os.rs
+++ b/rs/cli/src/commands/version/revise/host_os.rs
@@ -10,7 +10,7 @@ pub struct HostOs {
 
     /// Git tag for the release
     #[clap(long)]
-    pub release_tag: String,
+    pub release_tag: Option<String>,
 
     /// Force proposal submission, ignoring missing download URLs
     #[clap(long, visible_alias = "force")]

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -254,7 +254,7 @@ impl Runner {
         &self,
         release_artifact: &Artifact,
         version: &str,
-        release_tag: &str,
+        release_tag: &Option<String>,
         ignore_missing_urls: bool,
         forum_post_link: String,
         security_fix: bool,
@@ -289,7 +289,7 @@ impl Runner {
         &self,
         release_artifact: &Artifact,
         version: &str,
-        release_tag: &str,
+        release_tag: &Option<String>,
         ignore_missing_urls: bool,
         retire_versions: Option<Vec<String>>,
         security_fix: bool,
@@ -1327,9 +1327,13 @@ impl UpdateVersion {
 pub fn format_regular_version_upgrade_summary(
     version: &str,
     release_artifact: &Artifact,
-    release_tag: &str,
+    release_tag: &Option<String>,
     forum_post_link: String,
 ) -> anyhow::Result<String> {
+    let release_tag = match release_tag {
+        Some(git_tag) => git_tag,
+        None => return Err(anyhow::anyhow!("Release tag is required for non-security versions")),
+    };
     let template = format!(
         r#"Elect new {release_artifact} binary revision [{version}](https://github.com/dfinity/ic/tree/{release_tag})
 

--- a/rs/cli/src/unit_tests/version.rs
+++ b/rs/cli/src/unit_tests/version.rs
@@ -82,7 +82,7 @@ async fn guest_os_elect_version_tests() {
             "Elect new IC",
             crate::commands::version::revise::guest_os::GuestOs {
                 version: "new_version".to_string(),
-                release_tag: "rel_tag".to_string(),
+                release_tag: Some("rel_tag".to_string()),
                 ignore_missing_urls: false,
                 security_fix: false,
             },
@@ -92,7 +92,7 @@ async fn guest_os_elect_version_tests() {
             "Security patch update",
             crate::commands::version::revise::guest_os::GuestOs {
                 version: "new_version".to_string(),
-                release_tag: "rel_tag".to_string(),
+                release_tag: Some("rel_tag".to_string()),
                 ignore_missing_urls: false,
                 security_fix: true,
             },


### PR DESCRIPTION
Updated GuestOs and HostOs structs to make release_tag an Option<String>. Adjusted relevant functions to handle the new optional release_tag properly.
