### PR TITLE
fix(release-controller): remove suppression of stdout and stderr in Git commands

### DIFF
--- a/release-controller/git_repo.py
+++ b/release-controller/git_repo.py
@@ -71,8 +71,6 @@ class GitRepo:
                 subprocess.check_call(
                     ["git", "checkout", branch],
                     cwd=self.dir,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
                 )
             except subprocess.CalledProcessError:
                 print("Branch {} does not exist".format(branch))
@@ -80,8 +78,6 @@ class GitRepo:
         subprocess.check_call(
             ["git", "checkout", self.main_branch],
             cwd=self.dir,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
         )
 
     def show(self, obj: str) -> Commit | None:
@@ -146,14 +142,10 @@ class GitRepo:
             subprocess.check_call(
                 ["git", "fetch"],
                 cwd=self.dir,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
             )
             subprocess.check_call(
                 ["git", "reset", "--hard", f"origin/{self.main_branch}"],
                 cwd=self.dir,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
             )
         else:
             os.makedirs(self.dir, exist_ok=True)
@@ -164,8 +156,6 @@ class GitRepo:
                     self.repo,
                     self.dir,
                 ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
             )
         subprocess.check_call(
             [
@@ -173,8 +163,6 @@ class GitRepo:
                 "fetch",
                 "--all",
             ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             cwd=self.dir,
         )
 
@@ -397,8 +385,6 @@ def push_release_tags(repo: GitRepo, release: Release):
                 "origin",
                 f"{v.version}:refs/remotes/origin/{v.version}-commit",
             ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             cwd=repo.dir,
         )
         tag = version_name(release.rc_name, v.name)
@@ -410,8 +396,6 @@ def push_release_tags(repo: GitRepo, release: Release):
                 v.version,
                 "-f",
             ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             cwd=repo.dir,
         )
         tag_version = (
@@ -441,8 +425,6 @@ def push_release_tags(repo: GitRepo, release: Release):
                     tag,
                     "-f",
                 ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
                 cwd=repo.dir,
             )
 

--- a/scripts/host-os-release-notes.py
+++ b/scripts/host-os-release-notes.py
@@ -334,15 +334,11 @@ def main():
         subprocess.check_call(
             ["git", "fetch"],
             cwd=ic_repo_path,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
         )
         print("Resetting HEAD to latest origin/master.")
         subprocess.check_call(
             ["git", "reset", "--hard", "origin/master"],
             cwd=ic_repo_path,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
         )
     else:
         print("Cloning IC repo to {}".format(ic_repo_path))
@@ -353,8 +349,6 @@ def main():
                 "https://github.com/dfinity/ic.git",
                 ic_repo_path,
             ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
         )
 
     if last_commit == "":


### PR DESCRIPTION
The changes in this PR involve the removal of the suppression of `stdout` and `stderr` for various Git commands in the `GitRepo` class and the `host-os-release-notes.py` script. This includes commands such as `checkout`, `fetch`, and `reset`, which now will output their standard messages and errors to the console.

Impact:
- Improved visibility of Git command outputs, aiding in debugging and understanding of the operations being performed by the application.
- Reduced potential difficulties in diagnosing issues, as the immediate feedback from Git operations is now available.
