### PR TITLE
chore(dre): New defaults for state size when updating authorized subnets

### DIFF
--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -17,7 +17,7 @@ use crate::{
 use super::{AuthRequirement, ExecutableCommand};
 
 const DEFAULT_CANISTER_LIMIT: u64 = 60_000;
-const DEFAULT_STATE_SIZE_BYTES_LIMIT: u64 = 429_496_729_600; // 400GB
+const DEFAULT_STATE_SIZE_BYTES_LIMIT: u64 = 400 * 1024 * 1024 * 1024; // 400GB
 
 const DEFAULT_AUTHORIZED_SUBNETS_CSV: &str = include_str!(concat!(env!("OUT_DIR"), "/non_public_subnets.csv"));
 

--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -17,7 +17,7 @@ use crate::{
 use super::{AuthRequirement, ExecutableCommand};
 
 const DEFAULT_CANISTER_LIMIT: u64 = 60_000;
-const DEFAULT_STATE_SIZE_BYTES_LIMIT: u64 = 322_122_547_200; // 300GB
+const DEFAULT_STATE_SIZE_BYTES_LIMIT: u64 = 429_496_729_600; // 400GB
 
 const DEFAULT_AUTHORIZED_SUBNETS_CSV: &str = include_str!(concat!(env!("OUT_DIR"), "/non_public_subnets.csv"));
 


### PR DESCRIPTION
After recent development the limits adjusted. During discussion it was noted that state size criteria technically could be removed all together but we opted to keep it until further CMC development takes place.

Full discussion in [this thread](https://dfinity.slack.com/archives/C01DB8MQ5M1/p1736151170753039). 