### PR TITLE
fix: removing the release from the new release changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -56,7 +56,7 @@ commit_parsers = [
     { message = "^chore\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },
-    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(release\\): New release", skip = true },
     { message = "^chore|^ci", group = "Miscellaneous Tasks" },
     { body = ".*security", group = "Security" },
 ]


### PR DESCRIPTION
Just so that we remove commits [like](https://github.com/dfinity/dre/pull/1206) this from the changelog 