### PR TITLE
chore: removing chat integration from docs

### DIFF
--- a/docs/chat/icp-support.md
+++ b/docs/chat/icp-support.md
@@ -1,9 +1,0 @@
-# Chat with support bot
-
-<iframe
-  allow="autoplay; camera; microphone"
-  sandbox="allow-downloads allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-popups-to-escape-sandbox"
-  src="https://superinterface.ai/iframes/0c4cea8d-84d7-4a14-ba5e-d72d39150af9?publicApiKey=12b6109a-152c-4279-9c89-e4742a6a3108"
-  style="width: 100%; height: 100%; min-height: 600px"
-  frameborder="0"
-></iframe>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,8 +7,6 @@ repo_url: https://github.com/dfinity/dre/
 edit_uri: edit/main/docs/
 
 nav:
-  - "ICP Support":
-      - Chatbot: "chat/icp-support.md"
   - "General":
       - index.md
       - Getting started: getting-started.md


### PR DESCRIPTION
We decided to not go with this route. This PR cleans up the remains of icp support chatbot