### PR TITLE
fix: don't include automatic upgrades into changelog for `dre`

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: "🆕 Create a new Pull Request with the changes"
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "chore: Update dependencies"
+          commit-message: "chore(deps): Update dependencies"
           branch: bot-update-deps
           title: "chore: Update dependencies"
           body: "This PR updates Python, Rust crates, and IC repository dependencies"


### PR DESCRIPTION
There is a filter in `cliff.toml` that will skip all conventional commits that start with `chore(deps)` and the aim of this PR is to use that to skip automatic dependency bumps. 

An argument can be made that the users of our rust libraries would maybe love to know what are the upgraded versions of the libraries but I doubt it is useful in changelog and it should be kept as slim as possible.