### PR TITLE
chore: skipping all `chore(release)` commits from dre changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -56,7 +56,7 @@ commit_parsers = [
     { message = "^chore\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },
-    { message = "^chore\\(release\\): New release", skip = true },
+    { message = "^chore\\(release\\)", skip = true },
     { message = "^chore|^ci", group = "Miscellaneous Tasks" },
     { body = ".*security", group = "Security" },
 ]

--- a/release-controller/publish_notes.py
+++ b/release-controller/publish_notes.py
@@ -106,7 +106,7 @@ class PublishNotesClient:
             logging.info("creating version %s file on branch %s", version, branch_name)
             self.repo.create_file(
                 path=version_path,
-                message=f"Elect version {version}",
+                message=f"chore(release): Elect version {version}",
                 content=changelog,
                 branch=branch_name,
             )
@@ -117,7 +117,9 @@ class PublishNotesClient:
 
         logging.info("creating pull request for %s, branch %s", version, branch_name)
         self.repo.create_pull(
-            title=f"Elect version {version}", base="main", head=pull_head
+            title=f"chore(release): Elect version {version}",
+            base="main",
+            head=pull_head,
         )
 
     def publish_if_ready(


### PR DESCRIPTION
This PR will filter all `chore(release)` commits from `dre` tool changelog so that we keep it small