### PR TITLE
refactor(cli): rename neuron input field

### DIFF
--- a/rs/cli/src/commands/neuron/balance.rs
+++ b/rs/cli/src/commands/neuron/balance.rs
@@ -7,12 +7,12 @@ use crate::commands::ExecutableCommand;
 pub struct Balance {
     /// Neuron to query, by default will use the one from configured identity
     #[clap(long)]
-    neuron: Option<u64>,
+    neuron_override: Option<u64>,
 }
 
 impl ExecutableCommand for Balance {
     fn require_auth(&self) -> crate::commands::AuthRequirement {
-        match &self.neuron {
+        match &self.neuron_override {
             Some(_) => crate::commands::AuthRequirement::Anonymous,
             None => crate::commands::AuthRequirement::Neuron,
         }
@@ -23,7 +23,7 @@ impl ExecutableCommand for Balance {
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let (neuron, client) = ctx.create_ic_agent_canister_client().await?;
         let governance = GovernanceCanisterWrapper::from(client);
-        let neuron_id = match self.neuron {
+        let neuron_id = match self.neuron_override {
             Some(n) => n,
             None => neuron.neuron_id,
         };


### PR DESCRIPTION
**Field Renaming**: Renamed `neuron` field to `neuron_override` in the `Balance` struct, in order to fix:
```
❯ dre neuron balance
[...]
thread 'main' panicked at external/crate_index_dre__clap_builder-4.5.22/src/builder/debug_asserts.rs:442:80:
long option names must be unique, but '--neuron' is in use by both 'neuron_id' and 'neuron'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```