### PR TITLE
refactor(cli): streamline neuron balance execution

### DIFF
--- a/rs/cli/src/commands/neuron/balance.rs
+++ b/rs/cli/src/commands/neuron/balance.rs
@@ -4,18 +4,11 @@ use ic_canisters::governance::GovernanceCanisterWrapper;
 use crate::commands::ExecutableCommand;
 
 #[derive(Args, Debug)]
-pub struct Balance {
-    /// Neuron to query, by default will use the one from configured identity
-    #[clap(long)]
-    neuron_override: Option<u64>,
-}
+pub struct Balance {}
 
 impl ExecutableCommand for Balance {
     fn require_auth(&self) -> crate::commands::AuthRequirement {
-        match &self.neuron_override {
-            Some(_) => crate::commands::AuthRequirement::Anonymous,
-            None => crate::commands::AuthRequirement::Neuron,
-        }
+        crate::commands::AuthRequirement::Neuron
     }
 
     fn validate(&self, _args: &crate::commands::Args, _cmd: &mut clap::Command) {}
@@ -23,10 +16,7 @@ impl ExecutableCommand for Balance {
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let (neuron, client) = ctx.create_ic_agent_canister_client().await?;
         let governance = GovernanceCanisterWrapper::from(client);
-        let neuron_id = match self.neuron_override {
-            Some(n) => n,
-            None => neuron.neuron_id,
-        };
+        let neuron_id = ctx.neuron_id().unwrap_or(neuron.neuron_id);
         let neuron_info = governance.get_neuron_info(neuron_id).await?;
 
         println!("{}", neuron_info.stake_e8s / 10_u64.pow(8));

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -203,6 +203,10 @@ impl DreContext {
         Ok(neuron)
     }
 
+    pub fn neuron_id(&self) -> Option<u64> {
+        self.neuron_opts.neuron_id
+    }
+
     pub async fn readonly_ic_admin_for_other_network(&self, network: Network) -> anyhow::Result<impl IcAdmin> {
         let ic_admin = self.ic_admin().await?;
         Ok(IcAdminImpl::new(


### PR DESCRIPTION
### Changes

- **Removed Neuron Override in Balance Command**: Eliminated the unnecessary `neuron_override` field from the `Balance` struct.
