### PR TITLE
fix: check for open AddApiBoundaryNodes proposals in network command

### DIFF
--- a/rs/cli/src/commands/network.rs
+++ b/rs/cli/src/commands/network.rs
@@ -74,6 +74,11 @@ impl ExecutableCommand for Network {
                             omit_nodes.extend(node_ids_remove.iter().map(|node_id| node_id.to_string()));
                             Some(omit_nodes)
                         }
+                        crate::ic_admin::ProposeCommand::AddApiBoundaryNodes { nodes, version: _version } => {
+                            let mut omit_nodes = vec![];
+                            omit_nodes.extend(nodes.iter().map(|node| node.to_string()));
+                            Some(omit_nodes)
+                        }
                         _ => None,
                     })
                     .flatten()


### PR DESCRIPTION
### Added
- Extend `Network` command to check for open `AddApiBoundaryNodes` proposals in the `ProposeCommand`.

Fixes: https://dfinity.slack.com/archives/C02NJPNSLM6/p1737140872700689?thread_ts=1737135696.312359&cid=C02NJPNSLM6