### PR TITLE
feat(cli): add forum post link to proposal options

### DIFF
--- a/rs/cli/src/commands/firewall.rs
+++ b/rs/cli/src/commands/firewall.rs
@@ -104,7 +104,8 @@ impl ExecutableCommand for Firewall {
                     ProposeOptions {
                         title: self.title.clone(),
                         summary: self.summary.clone(),
-                        ..Default::default()
+                        forum_post_link: ctx.forum_post_link(),
+                        motivation: None,
                     },
                     &self.rules_scope,
                 )

--- a/rs/cli/src/qualification/ensure_blessed_versions.rs
+++ b/rs/cli/src/qualification/ensure_blessed_versions.rs
@@ -54,7 +54,8 @@ impl Step for EnsureBlessedRevisions {
                     ProposeOptions {
                         title: Some(format!("Blessing version: {}", &self.version)),
                         summary: Some("Some updates".to_string()),
-                        ..Default::default()
+                        forum_post_link: ctx.dre_ctx().forum_post_link(),
+                        motivation: None,
                     },
                 )
                 .await

--- a/rs/cli/src/qualification/retire_blessed_versions.rs
+++ b/rs/cli/src/qualification/retire_blessed_versions.rs
@@ -50,7 +50,7 @@ impl Step for RetireBlessedVersions {
                         title: Some("Retire replica versions".to_string()),
                         summary: Some("Unelecting a version".to_string()),
                         motivation: Some("Unelecting a version".to_string()),
-                        forum_post_link: None,
+                        forum_post_link: ctx.dre_ctx().forum_post_link(),
                     },
                 )
                 .await


### PR DESCRIPTION
### Features

- **cli.commands:** Add `forum_post_link` and `motivation` to `ProposeOptions` in `Firewall` command.
- **cli.qualification:** Add `forum_post_link` to `ProposeOptions` in `EnsureBlessedRevisions` and `RetireBlessedVersions`.

### Code Updates

- Updated `firewall.rs` to include `forum_post_link` and set `motivation` to `None`.
- Updated `ensure_blessed_versions.rs` to include `forum_post_link` and set `motivation` to `None`.
- Updated `retire_blessed_versions.rs` to include `forum_post_link` using the context's DRE link.