### PR TITLE
fix(dre): dont require discourse secrets for actions

### DIFF
--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -138,8 +138,8 @@ pub struct DiscourseOpts {
     pub(crate) discourse_api_user: Option<String>,
 
     /// Api url used to interact with the forum
-    #[clap(long, env = "DISCOURSE_API_URL", global = true)]
-    pub(crate) discourse_api_url: Option<String>,
+    #[clap(long, env = "DISCOURSE_API_URL", global = true, default_value = "https://forum.dfinity.org")]
+    pub(crate) discourse_api_url: String,
 
     /// Skip forum post creation all together, also will not
     /// prompt user for the link

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -264,21 +264,27 @@ impl DreContext {
             return Ok(client.clone());
         }
 
+        let placeholder_key = "placeholder_key".to_string();
+        let placeholder_user = "placeholder_user".to_string();
+        let placeholder_url = "https://placeholder_url.com".to_string();
+
         let (api_key, api_user, forum_url) = match (
             self.discourse_opts.discourse_api_key.clone(),
             self.discourse_opts.discourse_api_user.clone(),
             self.discourse_opts.discourse_api_url.clone(),
         ) {
-            (Some(api_key), Some(api_user), Some(forum_url)) => (api_key, api_user, forum_url),
             // Actual api won't be called so these values don't matter
-            _ if self.discourse_opts.discourse_skip_post_creation => (
-                "placeholder_key".to_string(),
-                "placeholder_user".to_string(),
-                "https://placeholder_url.com".to_string(),
-            ),
-            _ => anyhow::bail!(
-                "Expected to have `api_key`, `forum_url` and `api_user`. Instead found: {:?}",
-                self.discourse_opts
+            _ if self.discourse_opts.discourse_skip_post_creation => (placeholder_key, placeholder_user, placeholder_url),
+            (api_key, api_user, forum_url) => (
+                api_key.unwrap_or_else(|| {
+                    warn!("Will use placeholder_key for discourse api key since it was not provided");
+                    placeholder_key
+                }),
+                api_user.unwrap_or_else(|| {
+                    warn!("Will use placeholder_user for discourse api user since it was not provided");
+                    placeholder_user
+                }),
+                forum_url,
             ),
         };
 
@@ -366,7 +372,7 @@ pub mod tests {
             store: Store::new(false).unwrap(),
             discourse_opts: DiscourseOpts {
                 discourse_api_key: None,
-                discourse_api_url: None,
+                discourse_api_url: "".to_string(),
                 discourse_api_user: None,
                 discourse_skip_post_creation: true,
                 discourse_subnet_topic_override_file_path: None,

--- a/rs/cli/src/unit_tests/ctx_init.rs
+++ b/rs/cli/src/unit_tests/ctx_init.rs
@@ -50,7 +50,7 @@ async fn get_context(network: &Network, version: IcAdminVersion) -> anyhow::Resu
         Store::new(false)?,
         crate::commands::DiscourseOpts {
             discourse_api_key: None,
-            discourse_api_url: None,
+            discourse_api_url: "".to_string(),
             discourse_api_user: None,
             discourse_skip_post_creation: true,
             discourse_subnet_topic_override_file_path: None,
@@ -194,7 +194,7 @@ async fn get_ctx_for_neuron_test(
         Store::new(offline)?,
         crate::commands::DiscourseOpts {
             discourse_api_key: None,
-            discourse_api_url: None,
+            discourse_api_url: "".to_string(),
             discourse_api_user: None,
             discourse_skip_post_creation: false,
             discourse_subnet_topic_override_file_path: None,


### PR DESCRIPTION
Previously the tool would error out if nothing is provided.

With this the tool will use placeholder key and user which will fail to create posts but the user will be prompted to create them manually and provide the links.