### PR TITLE
refactor: integrate cordoned node removal into network healing

### DIFF
--- a/rs/decentralization/src/nakamoto/mod.rs
+++ b/rs/decentralization/src/nakamoto/mod.rs
@@ -488,7 +488,7 @@ impl Display for NakamotoScore {
 mod tests {
     use std::str::FromStr;
 
-    use crate::network::{DecentralizedSubnet, NetworkHealRequest, NetworkHealSubnets, SubnetChangeRequest};
+    use crate::network::{DecentralizedSubnet, NetworkHealRequest, NetworkHealSubnet, SubnetChangeRequest};
     use ic_base_types::PrincipalId;
     use ic_management_types::HealthStatus;
     use indexmap::IndexMap;
@@ -944,26 +944,29 @@ mod tests {
     fn test_network_heal_subnets_ord() {
         let not_important_small = new_test_subnet(0, 13, 0)
             .with_subnet_id(PrincipalId::from_str("k44fs-gm4pv-afozh-rs7zw-cg32n-u7xov-xqyx3-2pw5q-eucnu-cosd4-uqe").unwrap());
-        let not_important_small = NetworkHealSubnets {
+        let not_important_small = NetworkHealSubnet {
             name: String::from("App 20"),
             decentralized_subnet: not_important_small,
             unhealthy_nodes: vec![],
+            cordoned_nodes: vec![],
         };
 
         let not_important_large = new_test_subnet(0, 28, 0)
             .with_subnet_id(PrincipalId::from_str("bkfrj-6k62g-dycql-7h53p-atvkj-zg4to-gaogh-netha-ptybj-ntsgw-rqe").unwrap());
-        let not_important_large = NetworkHealSubnets {
+        let not_important_large = NetworkHealSubnet {
             name: String::from("European"),
             decentralized_subnet: not_important_large,
             unhealthy_nodes: vec![],
+            cordoned_nodes: vec![],
         };
 
         let important =
             serde_json::from_str::<ic_management_types::Subnet>(include_str!("../../test_data/subnet-uzr34.json")).expect("failed to read test data");
-        let important = NetworkHealSubnets {
+        let important = NetworkHealSubnet {
             name: important.metadata.name.clone(),
             decentralized_subnet: DecentralizedSubnet::from(important),
             unhealthy_nodes: vec![],
+            cordoned_nodes: vec![],
         };
 
         let unordered = vec![not_important_small.clone(), important.clone(), not_important_large.clone()];
@@ -1003,7 +1006,7 @@ mod tests {
         important.insert(subnet.principal, subnet);
 
         let network_heal_response = NetworkHealRequest::new(important.clone())
-            .heal_and_optimize(nodes_available.clone(), &health_of_nodes, vec![], &all_nodes, false)
+            .heal_and_optimize(nodes_available.clone(), &health_of_nodes, vec![], &all_nodes, false, false)
             .await
             .unwrap();
         let result = network_heal_response.first().unwrap().clone();

--- a/rs/decentralization/src/network.rs
+++ b/rs/decentralization/src/network.rs
@@ -8,7 +8,7 @@ use anyhow::anyhow;
 use futures::future::BoxFuture;
 use ic_base_types::PrincipalId;
 use ic_management_types::{HealthStatus, NetworkError, Node, NodeFeature};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use log::{debug, info, warn};
 use rand::{seq::SliceRandom, SeedableRng};
@@ -1207,26 +1207,27 @@ impl SubnetChange {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NetworkHealSubnets {
+pub struct NetworkHealSubnet {
     pub name: String,
     pub decentralized_subnet: DecentralizedSubnet,
     pub unhealthy_nodes: Vec<Node>,
+    pub cordoned_nodes: Vec<(Node, String)>,
 }
 
-impl NetworkHealSubnets {
+impl NetworkHealSubnet {
     const IMPORTANT_SUBNETS: &'static [&'static str] = &["NNS", "SNS", "Bitcoin", "Internet Identity", "tECDSA signing"];
 }
 
-impl PartialOrd for NetworkHealSubnets {
+impl PartialOrd for NetworkHealSubnet {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for NetworkHealSubnets {
+impl Ord for NetworkHealSubnet {
     fn cmp(&self, other: &Self) -> Ordering {
-        let self_is_important = NetworkHealSubnets::IMPORTANT_SUBNETS.contains(&self.name.as_str());
-        let other_is_important = NetworkHealSubnets::IMPORTANT_SUBNETS.contains(&other.name.as_str());
+        let self_is_important = NetworkHealSubnet::IMPORTANT_SUBNETS.contains(&self.name.as_str());
+        let other_is_important = NetworkHealSubnet::IMPORTANT_SUBNETS.contains(&other.name.as_str());
 
         match (self_is_important, other_is_important) {
             (true, false) => Ordering::Greater,
@@ -1252,88 +1253,127 @@ impl NetworkHealRequest {
         cordoned_features: Vec<CordonedFeature>,
         all_nodes: &[Node],
         optimize_for_business_rules_compliance: bool,
+        remove_cordoned_nodes: bool,
     ) -> Result<Vec<SubnetChangeResponse>, NetworkError> {
         let mut subnets_changed = Vec::new();
-        let subnets_to_heal = unhealthy_with_nodes(&self.subnets, health_of_nodes)
+        let mut subnets_to_fix: IndexMap<PrincipalId, NetworkHealSubnet> = unhealthy_with_nodes(&self.subnets, health_of_nodes)
             .iter()
-            .flat_map(|(subnet_id, unhealthy_nodes)| {
-                let unhealthy_subnet = self.subnets.get(subnet_id).ok_or(NetworkError::SubnetNotFound(*subnet_id))?;
-
-                Ok::<NetworkHealSubnets, NetworkError>(NetworkHealSubnets {
-                    name: unhealthy_subnet.metadata.name.clone(),
-                    decentralized_subnet: DecentralizedSubnet::from(unhealthy_subnet),
-                    unhealthy_nodes: unhealthy_nodes.clone(),
+            .filter_map(|(subnet_id, unhealthy_nodes)| {
+                self.subnets.get(subnet_id).map(|unhealthy_subnet| {
+                    (
+                        *subnet_id,
+                        NetworkHealSubnet {
+                            name: unhealthy_subnet.metadata.name.clone(),
+                            decentralized_subnet: DecentralizedSubnet::from(unhealthy_subnet),
+                            unhealthy_nodes: unhealthy_nodes.clone(),
+                            cordoned_nodes: vec![],
+                        },
+                    )
                 })
             })
-            .sorted_by(|a, b| a.cmp(b).reverse())
-            .collect_vec();
-        let subnets_to_optimize = if optimize_for_business_rules_compliance {
-            // Exclude subnets that are already in subnets_to_heal
-            let subnet_ids_to_heal = subnets_to_heal
-                .iter()
-                .map(|subnet| subnet.decentralized_subnet.id)
-                .collect::<AHashSet<_>>();
-            let subnets = self
+            .sorted_by(|a, b| b.1.cmp(&a.1))
+            .collect();
+        if remove_cordoned_nodes {
+            for (subnet_id, subnet) in self
                 .subnets
                 .iter()
                 .filter_map(|(subnet_id, subnet)| {
-                    if subnet_ids_to_heal.contains(subnet_id) {
-                        None
+                    let cordoned_nodes: Vec<(Node, String)> = subnet
+                        .nodes
+                        .iter()
+                        .filter_map(|node| {
+                            cordoned_features.iter().find_map(|feature| {
+                                if node.get_feature(&feature.feature) == Some(feature.value.clone()) {
+                                    Some((node.clone(), feature.explanation.clone().unwrap_or_default()))
+                                } else {
+                                    None
+                                }
+                            })
+                        })
+                        .collect();
+                    if !cordoned_nodes.is_empty() {
+                        Some((
+                            *subnet_id,
+                            NetworkHealSubnet {
+                                name: subnet.metadata.name.clone(),
+                                decentralized_subnet: DecentralizedSubnet::from(subnet.clone()),
+                                unhealthy_nodes: vec![],
+                                cordoned_nodes,
+                            },
+                        ))
                     } else {
-                        Some(subnet.clone())
+                        None
                     }
                 })
-                .collect_vec();
-            // Find subnets that have business rules violations
-            subnets_with_business_rules_violations(&subnets)
-                .into_iter()
-                .map(|subnet| NetworkHealSubnets {
+                .sorted_by(|a, b| b.1.cmp(&a.1))
+            {
+                if let Some(existing_subnet) = subnets_to_fix.get_mut(&subnet_id) {
+                    existing_subnet.cordoned_nodes.extend(subnet.cordoned_nodes.clone());
+                } else {
+                    subnets_to_fix.insert(subnet_id, subnet);
+                }
+            }
+        };
+        if optimize_for_business_rules_compliance {
+            for subnet in subnets_with_business_rules_violations(&self.subnets.values().cloned().collect::<Vec<_>>()) {
+                let network_heal_subnet = NetworkHealSubnet {
                     name: subnet.metadata.name.clone(),
                     decentralized_subnet: DecentralizedSubnet::from(subnet),
                     unhealthy_nodes: vec![],
-                })
-                .sorted_by(|a, b| a.cmp(b).reverse())
-                .collect_vec()
-        } else {
-            vec![]
-        };
+                    cordoned_nodes: vec![],
+                };
+                if !subnets_to_fix.contains_key(&network_heal_subnet.decentralized_subnet.id) {
+                    subnets_to_fix.insert(network_heal_subnet.decentralized_subnet.id, network_heal_subnet);
+                }
+            }
+        }
 
-        if subnets_to_heal.is_empty() && subnets_to_optimize.is_empty() {
+        if subnets_to_fix.is_empty() {
             info!("Nothing to do! All subnets are healthy and compliant with business rules.")
         }
 
-        for subnet in subnets_to_heal.into_iter().chain(subnets_to_optimize) {
+        for (_subnet_id, subnet) in subnets_to_fix.iter() {
             // If more than 1/3 nodes do not have the latest subnet state, subnet will stall.
             // From those 1/2 are added and 1/2 removed -> nodes_in_subnet/3 * 1/2 = nodes_in_subnet/6
             let max_replaceable_nodes = subnet.decentralized_subnet.nodes.len() / 6;
+            let nodes_to_replace: IndexSet<_> = subnet
+                .unhealthy_nodes
+                .clone()
+                .into_iter()
+                .map(|node| (node, "unhealthy".to_string()))
+                .chain(subnet.cordoned_nodes.clone().into_iter())
+                .collect();
 
-            let unhealthy_nodes = if subnet.unhealthy_nodes.len() > max_replaceable_nodes {
-                let unhealthy_nodes = subnet.unhealthy_nodes.into_iter().take(max_replaceable_nodes).collect_vec();
+            let nodes_to_replace = if nodes_to_replace.len() > max_replaceable_nodes {
+                let nodes_to_replace = nodes_to_replace.into_iter().take(max_replaceable_nodes).collect_vec();
                 warn!(
                     "Subnet {}: replacing {} of {} unhealthy nodes: {:?}",
                     subnet.decentralized_subnet.id,
                     max_replaceable_nodes,
-                    unhealthy_nodes.len(),
-                    unhealthy_nodes.iter().map(|node| node.principal).collect_vec()
+                    nodes_to_replace.len(),
+                    nodes_to_replace.iter().map(|(node, _)| node.principal).collect_vec()
                 );
-                unhealthy_nodes
+                nodes_to_replace
             } else {
                 info!(
-                    "Subnet {}: replacing {} unhealthy nodes: {:?}, and optimizing {} nodes. Max safely replaceable nodes based on subnet size: {}",
+                    "Subnet {}: replacing {} nodes; unhealthy {:?}, optimizing {:?}. Max safely replaceable nodes based on subnet size: {}",
                     subnet.decentralized_subnet.id,
-                    subnet.unhealthy_nodes.len(),
+                    nodes_to_replace.len(),
                     subnet
                         .unhealthy_nodes
                         .iter()
                         .map(|node| node.principal.to_string().split('-').next().unwrap().to_string())
                         .collect_vec(),
-                    max_replaceable_nodes - subnet.unhealthy_nodes.len(),
-                    max_replaceable_nodes
+                    subnet
+                        .cordoned_nodes
+                        .iter()
+                        .map(|(node, _)| node.principal.to_string().split('-').next().unwrap().to_string())
+                        .collect_vec(),
+                    max_replaceable_nodes,
                 );
-                subnet.unhealthy_nodes
+                nodes_to_replace.into_iter().collect_vec()
             };
-            let unhealthy_nodes_len = unhealthy_nodes.len();
-            let optimize_limit = max_replaceable_nodes - unhealthy_nodes_len;
+            let optimize_limit = max_replaceable_nodes - nodes_to_replace.len();
             let change_req = SubnetChangeRequest {
                 subnet: subnet.decentralized_subnet.clone(),
                 available_nodes: available_nodes.clone(),
@@ -1348,7 +1388,7 @@ impl NetworkHealRequest {
                         .clone()
                         .optimize(
                             num_nodes_to_optimize,
-                            &unhealthy_nodes,
+                            &nodes_to_replace.iter().map(|(node, _)| node.clone()).collect_vec(),
                             health_of_nodes,
                             cordoned_features.clone(),
                             all_nodes,
@@ -1442,7 +1482,7 @@ impl NetworkHealRequest {
                 change.score_after
             );
 
-            let num_opt = change.node_ids_removed.len() - unhealthy_nodes_len;
+            let num_opt = change.node_ids_removed.len() - nodes_to_replace.len();
             let reason_additional_optimizations = if num_opt == 0 {
                 format!(
                     "
@@ -1476,20 +1516,31 @@ https://github.com/dfinity/dre/blob/79066127f58c852eaf4adda11610e815a426878c/rs/
 
             let mut motivations: Vec<String> = Vec::new();
 
-            for node in unhealthy_nodes.iter() {
-                motivations.push(format!(
-                    "replacing {} node {}",
-                    health_of_nodes
-                        .get(&node.principal)
-                        .map(|s| s.to_string().to_lowercase())
-                        .unwrap_or("unhealthy".to_string()),
-                    node.principal
-                ));
-            }
+            let unhealthy_nodes_ids = subnet.unhealthy_nodes.iter().map(|node| node.principal).collect::<HashSet<_>>();
+            let cordoned_nodes_ids = subnet.cordoned_nodes.iter().map(|(node, _)| node.principal).collect::<HashSet<_>>();
 
-            let unhealthy_nodes_ids = unhealthy_nodes.iter().map(|node| node.principal).collect::<HashSet<_>>();
-            for node_id in change.node_ids_removed.iter().filter(|n| !unhealthy_nodes_ids.contains(n)) {
-                motivations.push(format!("replacing node {} to optimize network topology", node_id));
+            for (node, desc) in nodes_to_replace.iter() {
+                let node_id_short = node
+                    .principal
+                    .to_string()
+                    .split_once('-')
+                    .expect("subnet id is expected to have a -")
+                    .0
+                    .to_string();
+                if unhealthy_nodes_ids.contains(&node.principal) {
+                    motivations.push(format!(
+                        "replacing {} node {}",
+                        health_of_nodes
+                            .get(&node.principal)
+                            .map(|s| s.to_string().to_lowercase())
+                            .unwrap_or("unhealthy".to_string()),
+                        node_id_short
+                    ));
+                } else if cordoned_nodes_ids.contains(&node.principal) {
+                    motivations.push(format!("replacing cordoned node {} ({})", node_id_short, desc));
+                } else {
+                    motivations.push(format!("replacing node {} to optimize network topology", node_id_short));
+                };
             }
 
             available_nodes.retain(|node| !change.node_ids_added.contains(&node.principal));


### PR DESCRIPTION
### Changed
- Consolidated network healing and cordoned nodes removal into a single process.
- Extended `network_heal` functionality to handle both unhealthy and cordoned node replacement. This should result in fewer proposals in some cases, and overall produce better decentralization results.
- Removed standalone `network_remove_cordoned_nodes` function and refactored logic accordingly.

Example proposal submitted with the new code: https://dashboard.internetcomputer.org/proposal/134983