### PR TITLE
Implement the motion feature in DRE.

### DIFF
--- a/rs/cli/src/commands/governance/mod.rs
+++ b/rs/cli/src/commands/governance/mod.rs
@@ -1,0 +1,14 @@
+use super::{AuthRequirement, ExecutableCommand};
+use clap::Args;
+mod propose;
+
+use propose::Propose;
+
+#[derive(Args, Debug)]
+/// Commands and actions related to governance.
+pub struct Governance {
+    #[clap(subcommand)]
+    pub subcommands: Subcommands,
+}
+
+super::impl_executable_command_for_enums! { Governance, Propose }

--- a/rs/cli/src/commands/governance/propose/mod.rs
+++ b/rs/cli/src/commands/governance/propose/mod.rs
@@ -1,0 +1,16 @@
+use super::{AuthRequirement, ExecutableCommand};
+use clap::Args;
+mod motion;
+
+use crate::commands::impl_executable_command_for_enums;
+
+use motion::Motion;
+
+#[derive(Args, Debug)]
+/// Creation of proposals.
+pub struct Propose {
+    #[clap(subcommand)]
+    pub subcommands: Subcommands,
+}
+
+impl_executable_command_for_enums! { Propose, Motion }

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -84,13 +84,9 @@ impl ExecutableCommand for Motion {
             println!("Proposal that would have been sent:\n{:#?}", proposal);
             return Ok(());
         }
-        match governance.make_proposal(NeuronId { id: neuron.neuron_id }, proposal.into()).await {
-            Ok(propresp) => {
-                println!("{:?}", propresp);
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let propresp = governance.make_proposal(NeuronId { id: neuron.neuron_id }, proposal.into()).await?;
+        println!("{:?}", propresp);
+        Ok(())
     }
 
     fn validate(&self, _args: &crate::commands::Args, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -33,7 +33,7 @@ struct MotionParameters {
     #[arg(long, help_heading = "Command parameters", conflicts_with = "motion_text_file")]
     pub motion_text: Option<String>,
 
-    /// URL for discussion of the proposal; defaults to the DFINITY forum governance topic list if unspecified
+    /// URL typically used to discuss the proposal; defaults to the DFINITY forum governance topic list if unspecified
     #[arg(long, help_heading = "Command parameters", default_value = "https://forum.dfinity.org/c/governance/27")]
     pub proposal_url: url::Url,
 }

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -65,7 +65,7 @@ impl Motion {
             // Strip out '#' plus any extra leading space
             let stripped_title = first_line.trim_start_matches('#').trim_start();
             let body = lines[1..].join("\n"); // Join the remaining lines
-            (Some(stripped_title.to_owned()), body)
+            (Some(stripped_title.to_owned()), body.trim_start().to_string())
         } else {
             (None, lines.join("\n"))
         };

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_governance_api::pb::v1::{MakeProposalRequest, Motion as MotionPayload, ProposalActionRequest};
+use tokio::io::AsyncReadExt;
+
+use crate::commands::{AuthRequirement, ExecutableCommand};
+use ic_canisters::governance::GovernanceCanisterWrapper;
+
+#[derive(Args, Debug)]
+/// Submit a new motion.
+pub struct Motion {
+    /// File containing text of the proposal, customarily written in Markdown format; if "-", read the text from standard input.
+    /// If no explicit --title is specified, the first headline found in the text will be stripped from the motion text.
+    #[clap(num_args(1..))]
+    pub motion_text_file: PathBuf,
+
+    /// Title to give to the proposal; defaults to the first Markdown level-1 heading of the motion text, which will be stripped from
+    /// the summary in the default case.  For this default to kick in, the heading must be at the top of the motion text.
+    #[clap(long)]
+    pub title: Option<String>,
+
+    // ATTENTION REVIEWERS: should we put the entire text of the proposal in the summary?  Or should we intelligently extract the
+    // first paragraph and use that?
+    /// Summary to give to the proposal; defaults to the text of the motion.
+    #[clap(long)]
+    pub summary: Option<String>,
+
+    /// URL for discussion of the proposal; defaults to no the DFINITY forum governance topic.
+    #[clap(long, default_value = "https://forum.dfinity.org/c/governance/27")]
+    pub url: url::Url,
+}
+
+impl Motion {
+    fn extract_title_and_text(&self, text: &String) -> (Option<String>, String) {
+        let mytext = text.trim_start();
+        let (title, text) = if mytext.starts_with("#") && (mytext.starts_with("# ") || !mytext.starts_with("##")) {
+            let mut it = text.lines();
+            let title = it.next();
+            let text = it.collect::<Vec<_>>().join("\n").trim_start().into();
+            (title, text)
+        } else {
+            (None, text.clone())
+        };
+        let title = title.map(|s| s.into());
+        (title, text)
+    }
+}
+
+impl ExecutableCommand for Motion {
+    fn require_auth(&self) -> AuthRequirement {
+        AuthRequirement::Neuron
+    }
+
+    async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
+        let (neuron, client) = ctx.create_ic_agent_canister_client().await?;
+        let governance = GovernanceCanisterWrapper::from(client);
+        let motion_text = match self.motion_text_file.as_path().as_os_str().to_str() {
+            Some("-") => {
+                let mut ret: String = "".to_string();
+                tokio::io::stdin().read_to_string(&mut ret).await?;
+                ret
+            }
+            _ => {
+                let res = tokio::fs::read(&self.motion_text_file).await?;
+                String::from_utf8(res).map_err(|e| anyhow::anyhow!("Motion text must be valid UTF-8: {}", e))?
+            }
+        };
+        let (title, motion_text) = match &self.title {
+            Some(s) => (Some(s.clone()), motion_text.clone()),
+            None => self.extract_title_and_text(&motion_text),
+        };
+        let proposal = MakeProposalRequest {
+            title,
+            summary: match &self.summary {
+                Some(s) => s.clone(),
+                None => motion_text.clone(),
+            },
+            url: self.url.to_string(),
+            action: Some(ProposalActionRequest::Motion(MotionPayload { motion_text })),
+        };
+        if ctx.is_dry_run() {
+            println!("Proposal that would have been sent:\n{:#?}", proposal);
+            return Ok(());
+        }
+        match governance.make_proposal(NeuronId { id: neuron.neuron_id }, proposal.into()).await {
+            Ok(propresp) => {
+                println!("{:?}", propresp);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn validate(&self, _args: &crate::commands::Args, _cmd: &mut clap::Command) {}
+}

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -33,9 +33,9 @@ struct MotionParameters {
     #[arg(long, help_heading = "Command parameters", conflicts_with = "motion_text_file")]
     pub motion_text: Option<String>,
 
-    /// URL for discussion of the proposal; defaults to no the DFINITY forum governance topic.
+    /// URL for discussion of the proposal; defaults to the DFINITY forum governance topic list if unspecified
     #[arg(long, help_heading = "Command parameters", default_value = "https://forum.dfinity.org/c/governance/27")]
-    pub url: url::Url,
+    pub proposal_url: url::Url,
 }
 
 #[derive(Args, Debug)]
@@ -98,7 +98,7 @@ impl ExecutableCommand for Motion {
         let proposal = MakeProposalRequest {
             title,
             summary,
-            url: self.parameters.url.to_string(),
+            url: self.parameters.proposal_url.to_string(),
             action: Some(ProposalActionRequest::Motion(MotionPayload { motion_text })),
         };
         if ctx.is_dry_run() {

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -33,8 +33,8 @@ struct MotionParameters {
     #[arg(long, help_heading = "Command parameters", conflicts_with = "motion_text_file")]
     pub motion_text: Option<String>,
 
-    /// URL typically used to discuss the proposal; defaults to the DFINITY forum governance topic list if unspecified
-    #[arg(long, help_heading = "Command parameters", default_value = "https://forum.dfinity.org/c/governance/27")]
+    /// URL typically used to discuss the proposal; proposals risk being rejected without a valid venue to discuss them
+    #[arg(long, help_heading = "Command parameters")]
     pub proposal_url: url::Url,
 }
 

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -33,7 +33,7 @@ pub struct Motion {
 }
 
 impl Motion {
-    fn extract_title_and_text(&self, text: &String) -> (Option<String>, String) {
+    fn extract_title_and_text(&self, text: &str) -> (Option<String>, String) {
         let mytext = text.trim_start();
         let (title, text) = if mytext.starts_with("#") && (mytext.starts_with("# ") || !mytext.starts_with("##")) {
             let mut it = text.lines();
@@ -41,7 +41,7 @@ impl Motion {
             let text = it.collect::<Vec<_>>().join("\n").trim_start().into();
             (title, text)
         } else {
-            (None, text.clone())
+            (None, text.to_owned())
         };
         let title = title.map(|s| s.into());
         (title, text)

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ use completions::Completions;
 use der_to_principal::DerToPrincipal;
 use firewall::Firewall;
 use get::Get;
+use governance::Governance;
 use hostos::HostOs;
 use ic_canisters::parallel_hardware_identity::KeyIdVec;
 use network::Network;
@@ -32,6 +33,7 @@ pub(crate) mod completions;
 pub(crate) mod der_to_principal;
 pub(crate) mod firewall;
 pub mod get;
+pub(crate) mod governance;
 pub mod hostos;
 pub(crate) mod network;
 pub(crate) mod neuron;
@@ -283,7 +285,7 @@ macro_rules! impl_executable_command_for_enums {
 }
 pub(crate) use impl_executable_command_for_enums;
 
-impl_executable_command_for_enums! { Args, DerToPrincipal, Network, Subnet, Get, Propose, UpdateUnassignedNodes, Version, NodeMetrics, HostOs, Nodes, ApiBoundaryNodes, Vote, Registry, Firewall, Upgrade, Proposals, Completions, Qualify, UpdateAuthorizedSubnets, Neuron }
+impl_executable_command_for_enums! { Args, DerToPrincipal, Network, Subnet, Get, Propose, UpdateUnassignedNodes, Version, NodeMetrics, HostOs, Nodes, ApiBoundaryNodes, Vote, Registry, Firewall, Upgrade, Proposals, Completions, Qualify, UpdateAuthorizedSubnets, Neuron, Governance }
 
 pub trait ExecutableCommand {
     fn require_auth(&self) -> AuthRequirement;

--- a/rs/ic-canisters/src/governance.rs
+++ b/rs/ic-canisters/src/governance.rs
@@ -20,7 +20,6 @@ use ic_nns_governance::pb::v1::NeuronInfo;
 use ic_nns_governance::pb::v1::NodeProvider as PbNodeProvider;
 use ic_nns_governance::pb::v1::Proposal;
 use ic_nns_governance::pb::v1::ProposalInfo;
-use ic_nns_governance_api::pb::v1::manage_neuron_response::Command;
 use ic_nns_governance_api::pb::v1::ListNeurons;
 use ic_nns_governance_api::pb::v1::ListNeuronsResponse;
 use ic_nns_governance_api::pb::v1::ListNodeProvidersResponse;


### PR DESCRIPTION
User must specify a `--proposal-url` for discussion of the proposal, a single non-option argument specifying a file (`-` for stdin) to supply a proposal summary, and optionally a `--title` / a `--motion-text` / a `-motion-text-file`.

If not run with `--dry-run`, this command will not ask you for confirmation.  This is compatible with the way DRE does things (e.g. `dre vote`), and breaks away from the convention of `ic-admin`.  Run it with `--dry-run` and verify the proposal payload is what you meant it to be, before submitting.

Parameters as per right now:

![image](https://github.com/user-attachments/assets/51d79648-01db-4f65-9a7e-31909755505b)
