### PR TITLE
refactor: encapsulate NodeOperator computed fields

### DIFF
--- a/dashboard/packages/app/src/components/subnets/AvailableNodes.tsx
+++ b/dashboard/packages/app/src/components/subnets/AvailableNodes.tsx
@@ -210,7 +210,7 @@ function TabPanel({
               <Grid item>
                 <Typography variant='h5'>Missing guests</Typography>
                 <Typography variant='subtitle1'>Guests which need to be added to the network</Typography>
-                <Typography variant="subtitle2">Total allowed: {operators.reduce((r, c) => r + c.allowance, 0)}</Typography>
+                <Typography variant="subtitle2">Total allowed: {operators.reduce((r, c) => r + c.node_allowance, 0)}</Typography>
               </Grid>
               <Grid item>
               </Grid>

--- a/dashboard/packages/app/src/components/subnets/types.tsx
+++ b/dashboard/packages/app/src/components/subnets/types.tsx
@@ -20,7 +20,7 @@ export interface Datacenter {
 export interface Operator {
   principal: string;
   provider: Provider;
-  allowance: number;
+  node_allowance: number;
   datacenter?: Datacenter;
 }
 

--- a/rs/cli/src/operations/hostos_rollout.rs
+++ b/rs/cli/src/operations/hostos_rollout.rs
@@ -696,7 +696,7 @@ pub mod test {
                         name: None,
                         website: None,
                     },
-                    allowance: 23933,
+                    node_allowance: 23933,
                     datacenter: None,
                     rewardable_nodes: BTreeMap::new(),
                     ipv6: "".to_string(),

--- a/rs/decentralization/test_data/available-nodes.json
+++ b/rs/decentralization/test_data/available-nodes.json
@@ -9,7 +9,7 @@
         "name": "Allusion",
         "website": "https://www.allusion.be"
       },
-      "allowance": 3,
+      "node_allowance": 3,
       "datacenter": {
         "name": "br1",
         "owner": {
@@ -37,7 +37,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -71,7 +71,7 @@
         "name": "Tomahawk.vc",
         "website": "https://www.tomahawk.vc/"
       },
-      "allowance": 26,
+      "node_allowance": 26,
       "datacenter": {
         "name": "zh4",
         "owner": {
@@ -99,7 +99,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -133,7 +133,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -162,7 +162,7 @@
         "name": "Starbase",
         "website": "starbase.co"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "ty3",
         "owner": {
@@ -190,7 +190,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "ch2",
         "owner": {
@@ -218,7 +218,7 @@
         "principal": "pfcmh-uqedc-ijkjz-mdo35-bvprd-2vtlw-ktod5-npgfc-pgbq4-akaen-uqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "tp1",
         "owner": {
@@ -247,7 +247,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -275,7 +275,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "ny1",
         "owner": {
@@ -303,7 +303,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -331,7 +331,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -360,7 +360,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -388,7 +388,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "pl1",
         "owner": {
@@ -416,7 +416,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -450,7 +450,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -479,7 +479,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -508,7 +508,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -537,7 +537,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -566,7 +566,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -595,7 +595,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -624,7 +624,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -653,7 +653,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -681,7 +681,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -710,7 +710,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -739,7 +739,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -768,7 +768,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -797,7 +797,7 @@
         "name": "Rishi Sachdev",
         "website": null
       },
-      "allowance": 2,
+      "node_allowance": 2,
       "datacenter": {
         "name": "tp1",
         "owner": {
@@ -826,7 +826,7 @@
         "name": "Rishi Sachdev",
         "website": null
       },
-      "allowance": 2,
+      "node_allowance": 2,
       "datacenter": {
         "name": "tp1",
         "owner": {
@@ -855,7 +855,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -883,7 +883,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "lv1",
         "owner": {
@@ -912,7 +912,7 @@
         "name": "Brener, Inc.",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "sj1",
         "owner": {
@@ -941,7 +941,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -969,7 +969,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -998,7 +998,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -1027,7 +1027,7 @@
         "name": "Tomahawk.vc",
         "website": "https://www.tomahawk.vc/"
       },
-      "allowance": 26,
+      "node_allowance": 26,
       "datacenter": {
         "name": "zh4",
         "owner": {
@@ -1056,7 +1056,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -1085,7 +1085,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1118,7 +1118,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -1151,7 +1151,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 5,
+      "node_allowance": 5,
       "datacenter": {
         "name": "dl1",
         "owner": {
@@ -1179,7 +1179,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "ch2",
         "owner": {
@@ -1208,7 +1208,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -1236,7 +1236,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -1265,7 +1265,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1294,7 +1294,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -1323,7 +1323,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -1352,7 +1352,7 @@
         "name": "Goat, LLC",
         "website": null
       },
-      "allowance": 3,
+      "node_allowance": 3,
       "datacenter": {
         "name": "at1",
         "owner": {
@@ -1381,7 +1381,7 @@
         "name": "Starbase",
         "website": "starbase.co"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "ty3",
         "owner": {
@@ -1410,7 +1410,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -1439,7 +1439,7 @@
         "name": "Rishi Sachdev",
         "website": null
       },
-      "allowance": 2,
+      "node_allowance": 2,
       "datacenter": {
         "name": "tp1",
         "owner": {
@@ -1468,7 +1468,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -1497,7 +1497,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1525,7 +1525,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -1559,7 +1559,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -1587,7 +1587,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -1621,7 +1621,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -1649,7 +1649,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "ch2",
         "owner": {
@@ -1678,7 +1678,7 @@
         "name": "BLP22, LLC",
         "website": null
       },
-      "allowance": 5,
+      "node_allowance": 5,
       "datacenter": {
         "name": "at2",
         "owner": {
@@ -1707,7 +1707,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1735,7 +1735,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -1764,7 +1764,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1793,7 +1793,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -1822,7 +1822,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1851,7 +1851,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1879,7 +1879,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -1912,7 +1912,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -1946,7 +1946,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -1975,7 +1975,7 @@
         "name": "Rishi Sachdev",
         "website": null
       },
-      "allowance": 2,
+      "node_allowance": 2,
       "datacenter": {
         "name": "tp1",
         "owner": {
@@ -2004,7 +2004,7 @@
         "name": "Rishi Sachdev",
         "website": null
       },
-      "allowance": 2,
+      "node_allowance": 2,
       "datacenter": {
         "name": "tp1",
         "owner": {
@@ -2032,7 +2032,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 5,
+      "node_allowance": 5,
       "datacenter": {
         "name": "dl1",
         "owner": {
@@ -2060,7 +2060,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2094,7 +2094,7 @@
         "name": "Allusion",
         "website": "https://www.allusion.be"
       },
-      "allowance": 3,
+      "node_allowance": 3,
       "datacenter": {
         "name": "br1",
         "owner": {
@@ -2123,7 +2123,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -2152,7 +2152,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -2180,7 +2180,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2213,7 +2213,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -2241,7 +2241,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "ch2",
         "owner": {
@@ -2269,7 +2269,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2302,7 +2302,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2336,7 +2336,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -2365,7 +2365,7 @@
         "name": "Archery Blockchain SCSp",
         "website": "https://bochlsersolutions.com"
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "ge1",
         "owner": {
@@ -2394,7 +2394,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -2422,7 +2422,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "lv1",
         "owner": {
@@ -2451,7 +2451,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -2479,7 +2479,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2512,7 +2512,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "lv1",
         "owner": {
@@ -2541,7 +2541,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh7",
         "owner": {
@@ -2570,7 +2570,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -2603,7 +2603,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2636,7 +2636,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "ny1",
         "owner": {
@@ -2664,7 +2664,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "jv1",
         "owner": {
@@ -2693,7 +2693,7 @@
         "name": "Starbase",
         "website": "starbase.co"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "ty3",
         "owner": {
@@ -2722,7 +2722,7 @@
         "name": "Giant Leaf, LLC",
         "website": "giantleafllc.com"
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "or1",
         "owner": {
@@ -2750,7 +2750,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "ch2",
         "owner": {
@@ -2779,7 +2779,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -2807,7 +2807,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2841,7 +2841,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -2870,7 +2870,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -2898,7 +2898,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -2932,7 +2932,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -2961,7 +2961,7 @@
         "name": "Allusion",
         "website": "https://www.allusion.be"
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "an1",
         "owner": {
@@ -2989,7 +2989,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -3023,7 +3023,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -3052,7 +3052,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -3080,7 +3080,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh2",
         "owner": {
@@ -3109,7 +3109,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -3138,7 +3138,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -3166,7 +3166,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 5,
+      "node_allowance": 5,
       "datacenter": {
         "name": "dl1",
         "owner": {
@@ -3195,7 +3195,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -3224,7 +3224,7 @@
         "name": "Staking Facilities",
         "website": "https://stakingfacilities.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mu1",
         "owner": {
@@ -3253,7 +3253,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -3281,7 +3281,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -3310,7 +3310,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -3339,7 +3339,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -3367,7 +3367,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -3401,7 +3401,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -3430,7 +3430,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -3459,7 +3459,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -3487,7 +3487,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "pl1",
         "owner": {
@@ -3516,7 +3516,7 @@
         "name": "BLP22, LLC",
         "website": null
       },
-      "allowance": 5,
+      "node_allowance": 5,
       "datacenter": {
         "name": "at2",
         "owner": {
@@ -3545,7 +3545,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -3574,7 +3574,7 @@
         "name": "Tomahawk.vc",
         "website": "https://www.tomahawk.vc/"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh3",
         "owner": {
@@ -3602,7 +3602,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -3636,7 +3636,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -3665,7 +3665,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -3694,7 +3694,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -3723,7 +3723,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -3751,7 +3751,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "jv1",
         "owner": {
@@ -3780,7 +3780,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -3809,7 +3809,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -3838,7 +3838,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -3866,7 +3866,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -3895,7 +3895,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -3924,7 +3924,7 @@
         "name": "Tomahawk.vc",
         "website": "https://www.tomahawk.vc/"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh3",
         "owner": {
@@ -3952,7 +3952,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -3980,7 +3980,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "pl1",
         "owner": {
@@ -4008,7 +4008,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "jv1",
         "owner": {
@@ -4036,7 +4036,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -4070,7 +4070,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -4099,7 +4099,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -4128,7 +4128,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -4157,7 +4157,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -4186,7 +4186,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -4214,7 +4214,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -4248,7 +4248,7 @@
         "name": "Starbase",
         "website": "starbase.co"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "ty3",
         "owner": {
@@ -4277,7 +4277,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -4305,7 +4305,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -4338,7 +4338,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "jv1",
         "owner": {
@@ -4367,7 +4367,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -4396,7 +4396,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -4425,7 +4425,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -4453,7 +4453,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -4482,7 +4482,7 @@
         "name": "Allusion",
         "website": "https://www.allusion.be"
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "an1",
         "owner": {
@@ -4511,7 +4511,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -4540,7 +4540,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -4569,7 +4569,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -4597,7 +4597,7 @@
         "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "pl1",
         "owner": {
@@ -4626,7 +4626,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -4655,7 +4655,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -4684,7 +4684,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -4713,7 +4713,7 @@
         "name": "Allusion",
         "website": "https://www.allusion.be"
       },
-      "allowance": 3,
+      "node_allowance": 3,
       "datacenter": {
         "name": "br1",
         "owner": {
@@ -4742,7 +4742,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -4771,7 +4771,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -4800,7 +4800,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -4828,7 +4828,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "jv1",
         "owner": {
@@ -4857,7 +4857,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -4885,7 +4885,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "jv1",
         "owner": {
@@ -4913,7 +4913,7 @@
         "principal": "spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe",
         "website": null
       },
-      "allowance": 4,
+      "node_allowance": 4,
       "datacenter": {
         "name": "jv1",
         "owner": {
@@ -4942,7 +4942,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {
@@ -4970,7 +4970,7 @@
         "principal": "lq5ra-f4ibl-t7wpy-hennc-m4eb7-tnfxe-eorgd-onpsl-wervo-7chjj-6qe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "bo1",
         "owner": {
@@ -4999,7 +4999,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -5028,7 +5028,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -5056,7 +5056,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -5090,7 +5090,7 @@
         "name": "Bigger Capital",
         "website": "https://bigger.capital"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "aw1",
         "owner": {
@@ -5119,7 +5119,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mb1",
         "owner": {
@@ -5148,7 +5148,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -5177,7 +5177,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -5206,7 +5206,7 @@
         "name": "Virtual Hive GmbH",
         "website": "https://virtualhive.io"
       },
-      "allowance": 1,
+      "node_allowance": 1,
       "datacenter": {
         "name": "fr2",
         "owner": {
@@ -5235,7 +5235,7 @@
         "name": "Sygnum Bank",
         "website": "sygnum.com"
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "zh5",
         "owner": {
@@ -5263,7 +5263,7 @@
         "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "mr1",
         "owner": {
@@ -5297,7 +5297,7 @@
         "name": "Fractal Labs AG",
         "website": null
       },
-      "allowance": 0,
+      "node_allowance": 0,
       "datacenter": {
         "name": "lj1",
         "owner": {

--- a/rs/decentralization/test_data/subnet-uzr34.json
+++ b/rs/decentralization/test_data/subnet-uzr34.json
@@ -10,7 +10,7 @@
           "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "website": null
         },
-        "allowance": 1,
+        "node_allowance": 1,
         "datacenter": {
           "name": "lv1",
           "owner": {
@@ -39,7 +39,7 @@
           "principal": "bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe",
           "website": null
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "mr1",
           "owner": {
@@ -69,7 +69,7 @@
           "name": "Starbase",
           "website": "starbase.co"
         },
-        "allowance": 1,
+        "node_allowance": 1,
         "datacenter": {
           "name": "ty3",
           "owner": {
@@ -99,7 +99,7 @@
           "name": "Virtual Hive GmbH",
           "website": "https://virtualhive.io"
         },
-        "allowance": 1,
+        "node_allowance": 1,
         "datacenter": {
           "name": "fr2",
           "owner": {
@@ -129,7 +129,7 @@
           "name": "OneSixtyTwo Digital Capital",
           "website": "https://162digitalcapital.com"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "sg1",
           "owner": {
@@ -159,7 +159,7 @@
           "name": "Sygnum Bank",
           "website": "sygnum.com"
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "zh5",
           "owner": {
@@ -189,7 +189,7 @@
           "name": "Tomahawk.vc",
           "website": "https://www.tomahawk.vc/"
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "zh3",
           "owner": {
@@ -219,7 +219,7 @@
           "name": "Fractal Labs AG",
           "website": null
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "mb1",
           "owner": {
@@ -249,7 +249,7 @@
           "name": "Bigger Capital",
           "website": "https://bigger.capital"
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "aw1",
           "owner": {
@@ -279,7 +279,7 @@
           "name": "Sygnum Bank",
           "website": "sygnum.com"
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "zh5",
           "owner": {
@@ -309,7 +309,7 @@
           "name": "Starbase",
           "website": "starbase.co"
         },
-        "allowance": 1,
+        "node_allowance": 1,
         "datacenter": {
           "name": "ty3",
           "owner": {
@@ -339,7 +339,7 @@
           "name": "Peggy Shafaghi",
           "website": null
         },
-        "allowance": 1,
+        "node_allowance": 1,
         "datacenter": {
           "name": "fm1",
           "owner": {
@@ -369,7 +369,7 @@
           "name": "Virtual Hive GmbH",
           "website": "https://virtualhive.io"
         },
-        "allowance": 1,
+        "node_allowance": 1,
         "datacenter": {
           "name": "fr2",
           "owner": {
@@ -398,7 +398,7 @@
           "principal": "eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe",
           "website": null
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "pl1",
           "owner": {
@@ -428,7 +428,7 @@
           "name": "BLP22, LLC",
           "website": null
         },
-        "allowance": 5,
+        "node_allowance": 5,
         "datacenter": {
           "name": "at2",
           "owner": {
@@ -458,7 +458,7 @@
           "name": "OneSixtyTwo Digital Capital",
           "website": "https://162digitalcapital.com"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "sg1",
           "owner": {
@@ -488,7 +488,7 @@
           "name": "Jimmy Quach",
           "website": null
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "at1",
           "owner": {
@@ -518,7 +518,7 @@
           "name": "Allusion",
           "website": "https://www.allusion.be"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "an1",
           "owner": {
@@ -548,7 +548,7 @@
           "name": "Fractal Labs AG",
           "website": null
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "lj1",
           "owner": {
@@ -578,7 +578,7 @@
           "name": "Archery Blockchain SCSp",
           "website": "https://bochlsersolutions.com"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "ge1",
           "owner": {
@@ -607,7 +607,7 @@
           "principal": "i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae",
           "website": null
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "bu1",
           "owner": {
@@ -637,7 +637,7 @@
           "name": "Bigger Capital",
           "website": "https://bigger.capital"
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "aw1",
           "owner": {
@@ -667,7 +667,7 @@
           "name": "OneSixtyTwo Digital Capital",
           "website": "https://162digitalcapital.com"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "sg3",
           "owner": {
@@ -697,7 +697,7 @@
           "name": "Fractal Labs AG",
           "website": null
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "lj1",
           "owner": {
@@ -727,7 +727,7 @@
           "name": "Giant Leaf, LLC",
           "website": "giantleafllc.com"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "or1",
           "owner": {
@@ -757,7 +757,7 @@
           "name": "Archery Blockchain SCSp",
           "website": "https://bochlsersolutions.com"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "ge2",
           "owner": {
@@ -787,7 +787,7 @@
           "name": "Bigger Capital",
           "website": "https://bigger.capital"
         },
-        "allowance": 0,
+        "node_allowance": 0,
         "datacenter": {
           "name": "aw1",
           "owner": {
@@ -817,7 +817,7 @@
           "name": "Archery Blockchain SCSp",
           "website": "https://bochlsersolutions.com"
         },
-        "allowance": 4,
+        "node_allowance": 4,
         "datacenter": {
           "name": "ge1",
           "owner": {

--- a/rs/ic-management-backend/src/lazy_registry.rs
+++ b/rs/ic-management-backend/src/lazy_registry.rs
@@ -442,7 +442,7 @@ impl LazyRegistry for LazyRegistryImpl {
                                     maybe_provider.unwrap_or_default()
                                 })
                                 .unwrap(),
-                            allowance: or.node_allowance,
+                            node_allowance: or.node_allowance,
                             datacenter: data_centers.get(&or.dc_id).map(|dc| {
                                 let (continent, country, area): (_, _, _) = dc
                                     .region

--- a/rs/ic-management-backend/src/registry.rs
+++ b/rs/ic-management-backend/src/registry.rs
@@ -409,7 +409,7 @@ impl RegistryState {
                                 principal: p,
                             })
                             .expect("provider missing from operator record"),
-                        allowance: or.node_allowance,
+                        node_allowance: or.node_allowance,
                         datacenter: data_center_records.get(&or.dc_id).map(|dc| {
                             let (continent, country, area): (_, _, _) = dc.region.splitn(3, ',').map(|s| s.to_string()).collect_tuple().unwrap_or((
                                 "Unknown".to_string(),

--- a/rs/ic-management-types/src/lib.rs
+++ b/rs/ic-management-types/src/lib.rs
@@ -594,7 +594,7 @@ pub struct CreateSubnetProposalInfo {
 pub struct Operator {
     pub principal: PrincipalId,
     pub provider: Provider,
-    pub allowance: u64,
+    pub node_allowance: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub datacenter: Option<Datacenter>,


### PR DESCRIPTION
### Changes

- Introduced `NodeOperatorComputed` struct to group computed fields within `NodeOperator`.
- Updated fields under the `computed` struct: `nodes_health`, `total_up_nodes`, `rewards_correct`, `node_allowance_remaining`, `node_allowance_total`, `nodes_in_subnets`, and `nodes_in_registry`.
- Renamed `allowance` to `node_allowance` consistently across the codebase.
- Updated logic in `Registry` for better encapsulation of computed properties, including calculation of `node_allowance_total` and condition checks involving `total_up_nodes`.

- Updated tests and affected modules to reflect struct and field changes.