### PR TITLE
chore: remove cookie consent configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,10 +132,3 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/dfinity/dre
-  consent:
-    title: Cookie consent
-    description: >-
-      We use cookies to recognize your repeated visits and preferences, as well
-      as to measure the effectiveness of our documentation and whether users
-      find what they're searching for. With your consent, you're helping us to
-      make our documentation better.


### PR DESCRIPTION
We actually can't track cookies since we serve pages on GH.