### PR TITLE
feat(msd): adding possibility to remove stale targets

### DIFF
--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -942,6 +942,7 @@ pub fn boundary_nodes_from_definitions(definitions: &BTreeMap<String, RunningDef
 mod tests {
     use super::{Definition, TestDefinition};
     use crate::{definition::DefinitionsSupervisor, make_logger, metrics::RunningDefinitionsMetrics};
+    use crossbeam_channel::unbounded;
     use ic_management_types::Network;
     use std::{collections::BTreeMap, str::FromStr, time::Duration};
     use tempfile::tempdir;
@@ -952,7 +953,8 @@ mod tests {
         let definitions_dir = tempdir().unwrap();
         let definitions_path = definitions_dir.path().join(String::from("definitions.json"));
         let log = make_logger();
-        let supervisor = DefinitionsSupervisor::new(handle.clone(), false, Some(definitions_path.clone()), log.clone());
+        let (sender, _) = unbounded();
+        let supervisor = DefinitionsSupervisor::new(handle.clone(), false, Some(definitions_path.clone()), log.clone(), None, sender);
 
         let mocked_definition = Definition::new(
             vec![url::Url::from_str("http://[2a00:fb01:400:42:5000:3cff:fe45:6c61]:8080").unwrap()],

--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -385,7 +385,6 @@ impl RunningDefinition {
         crossbeam::select! {
             recv(self.stop_signal) -> _ => {
                 info!(self.definition.log, "Received shutdown signal after being garbage collected for {}", self.definition.name);
-                return;
             }
         }
     }
@@ -709,7 +708,7 @@ impl DefinitionsSupervisor {
                     .run(
                         self.rt.clone(),
                         metrics.clone(),
-                        self.garbage_collection_timeout.clone(),
+                        self.garbage_collection_timeout,
                         self.remove_request_sender.clone(),
                     )
                     .await,
@@ -735,7 +734,9 @@ impl DefinitionsSupervisor {
                                 info!(self.log, "Removed network: {}", name);
                             }
                         },
-                        Err(_) => {}
+                        Err(e) => {
+                            warn!(self.log, "Received error on request to remove a definition: {:?}", e)
+                        }
                     }
                 }
                 recv(end_receiver) -> _ => {

--- a/rs/ic-observability/multiservice-discovery/src/main.rs
+++ b/rs/ic-observability/multiservice-discovery/src/main.rs
@@ -283,7 +283,7 @@ exist, it will be created.
         long = "gc-timeout",
         value_parser = parse_duration,
         help = r#"
-If set, networks that cannot be scraped for `Duration` will be removed.
+If set, networks unreachable for at least the provided `Duration` will be automatically removed.
 
     "#
         )]

--- a/rs/ic-observability/multiservice-discovery/src/main.rs
+++ b/rs/ic-observability/multiservice-discovery/src/main.rs
@@ -281,7 +281,6 @@ exist, it will be created.
 
     #[clap(
         long = "gc-timeout",
-        default_value = "None",
         value_parser = parse_duration,
         help = r#"
 If set, networks that cannot be scraped for `Duration` will be removed.


### PR DESCRIPTION
In case of testnets (be it farm testnets or new k8s testnets) we will be notified upon testnet creation but not on test removal. This PR aims to add the possibility for MSD to know which testnets are no longer active and remove them for the exported targets and scraping. 