### PR TITLE
chore(msd): deleting directory once the network is garbage collected

### DIFF
--- a/rs/ic-observability/multiservice-discovery/src/definition.rs
+++ b/rs/ic-observability/multiservice-discovery/src/definition.rs
@@ -362,6 +362,11 @@ impl RunningDefinition {
                         warn!(self.definition.log, "Failed to send remove request to the supervisor: {:?}", e);
                     } else {
                         // Only stop if the supervisor was notified
+
+                        if let Err(e) = std::fs::remove_dir_all(&self.definition.registry_path) {
+                            warn!(self.definition.log, "Failed to remove directory holding the targets: {:?}", e);
+                        }
+
                         break;
                     }
                 }


### PR DESCRIPTION
A very niece bug can happen when the same directory is reused with a different network. If the old network and the new network have the same height, our discovery will not sync old stuff but will assume it is the latest version with false values (coming from a previous network with the same name)