### PR TITLE
feat: listing registry at specific height

### DIFF
--- a/rs/cli/src/commands/registry.rs
+++ b/rs/cli/src/commands/registry.rs
@@ -50,7 +50,7 @@ pub struct Registry {
     pub filters: Vec<Filter>,
 
     /// Specify the height for the registry
-    #[clap(long, alias = "registry-height")]
+    #[clap(long, visible_aliases = ["registry-height", "version"])]
     pub height: Option<u64>,
 }
 

--- a/rs/cli/src/commands/registry.rs
+++ b/rs/cli/src/commands/registry.rs
@@ -48,6 +48,10 @@ pub struct Registry {
     /// Filters in `key=value` format
     #[clap(long, short, alias = "filter")]
     pub filters: Vec<Filter>,
+
+    /// Specify the height for the registry
+    #[clap(long, alias = "registry-height")]
+    pub height: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -114,7 +118,7 @@ impl ExecutableCommand for Registry {
 
 impl Registry {
     async fn get_registry(&self, ctx: DreContext) -> anyhow::Result<RegistryDump> {
-        let local_registry = ctx.registry().await;
+        let local_registry = ctx.registry_with_version(self.height).await;
 
         let elected_guest_os_versions = get_elected_guest_os_versions(&local_registry)?;
         let elected_host_os_versions = get_elected_host_os_versions(&local_registry)?;

--- a/rs/cli/src/ctx.rs
+++ b/rs/cli/src/ctx.rs
@@ -117,13 +117,17 @@ impl DreContext {
         .await
     }
 
-    pub async fn registry(&self) -> Arc<dyn LazyRegistry> {
+    pub async fn registry_with_version(&self, version_height: Option<u64>) -> Arc<dyn LazyRegistry> {
         if let Some(reg) = self.registry.borrow().as_ref() {
             return reg.clone();
         }
-        let registry = self.store.registry(self.network(), self.proposals_agent()).await.unwrap();
+        let registry = self.store.registry(self.network(), self.proposals_agent(), version_height).await.unwrap();
         *self.registry.borrow_mut() = Some(registry.clone());
         registry
+    }
+
+    pub async fn registry(&self) -> Arc<dyn LazyRegistry> {
+        self.registry_with_version(None).await
     }
 
     pub fn network(&self) -> &Network {

--- a/rs/cli/src/store.rs
+++ b/rs/cli/src/store.rs
@@ -109,7 +109,12 @@ impl Store {
         Ok(path)
     }
 
-    pub async fn registry(&self, network: &Network, proposal_agent: Arc<dyn ProposalAgent>) -> anyhow::Result<Arc<dyn LazyRegistry>> {
+    pub async fn registry(
+        &self,
+        network: &Network,
+        proposal_agent: Arc<dyn ProposalAgent>,
+        version_height: Option<u64>,
+    ) -> anyhow::Result<Arc<dyn LazyRegistry>> {
         let registry_path = self.local_store_for_network(network)?;
 
         info!("Using local registry path for network {}: {}", network.name, registry_path.display());
@@ -128,6 +133,7 @@ impl Store {
             proposal_agent,
             self.guest_labels_cache_path(network)?,
             self.health_client(network)?,
+            version_height,
         )))
     }
 

--- a/rs/ic-management-backend/src/lazy_registry.rs
+++ b/rs/ic-management-backend/src/lazy_registry.rs
@@ -174,6 +174,7 @@ where
     proposal_agent: Arc<dyn ProposalAgent>,
     guest_labels_cache_path: PathBuf,
     health_client: Arc<dyn HealthStatusQuerier>,
+    version_height: Option<u64>,
 }
 
 pub trait LazyRegistryEntry: RegistryValue {
@@ -265,7 +266,9 @@ impl LazyRegistryFamilyEntries for LazyRegistryImpl {
     }
 
     fn get_latest_version(&self) -> RegistryVersion {
-        self.local_registry.get_latest_version()
+        self.version_height
+            .map(RegistryVersion::new)
+            .unwrap_or_else(|| self.local_registry.get_latest_version())
     }
 }
 
@@ -277,6 +280,7 @@ impl LazyRegistryImpl {
         proposal_agent: Arc<dyn ProposalAgent>,
         guest_labels_cache_path: PathBuf,
         health_client: Arc<dyn HealthStatusQuerier>,
+        version_height: Option<u64>,
     ) -> Self {
         Self {
             local_registry,
@@ -293,6 +297,7 @@ impl LazyRegistryImpl {
             proposal_agent,
             guest_labels_cache_path,
             health_client,
+            version_height,
         }
     }
 


### PR DESCRIPTION
This PR adds the possibility to list the registry at specific height. Default behavior remains listing the latest height.
Example usage:
```bash
dre registry --height 41890
```