### PR TITLE
Refactor proposal generation to accept runner change response directly

### DIFF
--- a/rs/cli/src/commands/subnet/resize.rs
+++ b/rs/cli/src/commands/subnet/resize.rs
@@ -54,9 +54,9 @@ impl ExecutableCommand for Resize {
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let runner = ctx.runner().await?;
 
-        let subnet_manager = ctx.subnet_manager().await?;
-
-        let subnet_change_response = subnet_manager
+        let subnet_change_response = ctx
+            .subnet_manager()
+            .await?
             .subnet_resize(
                 SubnetResizeRequest {
                     subnet: self.id,
@@ -71,7 +71,7 @@ impl ExecutableCommand for Resize {
             )
             .await?;
 
-        let runner_proposal = match runner.propose_subnet_change(subnet_change_response).await? {
+        let runner_proposal = match runner.propose_subnet_change(&subnet_change_response).await? {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };


### PR DESCRIPTION
The `Runner::propose_subnet_change` method now accepts a reference to the `SubnetChangeResponse` instead of cloning it. This refactoring simplifies the method call and improves performance by avoiding unnecessary copies.

11 lines of code deleted too.