### PR TITLE
Use proposal_id member for successful NNS proposal text, and handle DREMalfunction too

### DIFF
--- a/release-controller/forum.py
+++ b/release-controller/forum.py
@@ -22,11 +22,18 @@ def _post_template(
     if isinstance(proposal, reconciler_state.NoProposal):
         return f"We're preparing [a new IC release](https://github.com/dfinity/ic/tree/{version_name}). The changelog will be announced soon."
 
+    elif isinstance(proposal, reconciler_state.DREMalfunction):
+        return (
+            f"A proposal to adopt [a new IC release](https://github.com/dfinity/ic/tree/{version_name}) has been prepared,"
+            " but a temporary hiccup has taken place, preventing the proposal ID from being obtained."
+            " The proposal ID and the changelog will be announced soon."
+        )
+
     return f"""\
 Hello there!
 
 We are happy to announce that voting is now open for [a new IC release](https://github.com/dfinity/ic/tree/{version_name}).
-The NNS proposal is here: [IC NNS Proposal {proposal}](https://dashboard.internetcomputer.org/proposal/{proposal}).
+The NNS proposal is here: [IC NNS Proposal {proposal.proposal_id}](https://dashboard.internetcomputer.org/proposal/{proposal.proposal_id}).
 
 Here is a summary of the changes since the last release:
 

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -408,7 +408,6 @@ class Reconciler:
                     except Exception:
                         fail = prop.record_malfunction()
                         revlogger.error("%s", fail)
-                        continue
 
                 rclogger.debug("Updating forum posts after processing versions.")
                 # Update the forum posts in case the proposal was created.

--- a/release-controller/tests/test_forum.py
+++ b/release-controller/tests/test_forum.py
@@ -4,6 +4,7 @@ import httpretty.utils
 from release_index import Release
 from release_index import Version
 import dryrun
+import reconciler_state
 
 import pytest
 
@@ -25,8 +26,9 @@ def test_create_release_notes_on_new_release() -> None:
     def changelog(v: str, security_fix: bool):
         return f"release notes for version {v}{' (security fix)' if security_fix else ''}..."
 
-    def proposal(v: str):
-        return int(v.removeprefix("test"))
+    def proposal(v: str) -> reconciler_state.SubmittedProposal:
+        proposal_id = int(v.removeprefix("test"))
+        return reconciler_state.SubmittedProposal(None, None, proposal_id)
 
     post.update(summary_retriever=changelog, proposal_id_retriever=proposal)
     raw = """\


### PR DESCRIPTION
Added logic to handle DREMalfunction in proposal retrieval, providing updated template for forum posts.