### PR TITLE
fix: not panicing on uknown providers for operators

### DIFF
--- a/rs/ic-management-backend/src/lazy_registry.rs
+++ b/rs/ic-management-backend/src/lazy_registry.rs
@@ -442,7 +442,7 @@ impl LazyRegistry for LazyRegistryImpl {
                                     });
 
                                     if maybe_provider.is_none() && self.network.is_mainnet() && !self.offline {
-                                        panic!("Node provider not found for operator: {}", principal);
+                                        warn!("Node provider not found for operator: {}", principal);
                                     }
                                     maybe_provider.unwrap_or_default()
                                 })


### PR DESCRIPTION
This should not affect regular runs. This will affect using random `--height`s when dumping the registry. 

When printing out random heights it would usually panic with the following message:
```bash
Node provider not found for operator: c5ssg-eh22p-pmsn6-fpjzj-k5nql-mx5mc-7gb4a-4klco-c4f37-ydnfp-bae
```