### PR TITLE
fix: not panicing for unknown operators because of low heights

### DIFF
--- a/rs/cli/src/commands/registry.rs
+++ b/rs/cli/src/commands/registry.rs
@@ -374,12 +374,8 @@ fn get_node_rewards_table(local_registry: &Arc<dyn LazyRegistry>, network: &Netw
     let table = match rewards_table.first_entry() {
         Some(f) => f.get().table.clone(),
         None => {
-            if network.is_mainnet() {
-                panic!("Failed to get Node Rewards Table for mainnet")
-            } else {
-                warn!("Failed to get Node Rewards Table for {}", network.name);
-                BTreeMap::new()
-            }
+            warn!("Failed to get Node Rewards Table for {}", network.name);
+            BTreeMap::new()
         }
     };
 


### PR DESCRIPTION
For low heights it is possible that some structs will have missing data due to registry not having them at low heights. 