### PR TITLE
feat: implement retry mechanism for Discourse API requests

### DIFF
--- a/rs/cli/src/forum/impls.rs
+++ b/rs/cli/src/forum/impls.rs
@@ -450,12 +450,12 @@ impl DiscourseClientImp {
                     }
                 }
                 Err(error) => {
-                    warn!("Error while sending request to Discourse: {}. Retrying in {} seconds", error, retry_secs);
-                    tokio::time::sleep(std::time::Duration::from_secs(retry_secs)).await;
-
                     if retry_num == retries_max {
                         return Err(DiscourseClientImpError::OtherReqwestError(error));
                     }
+
+                    warn!("Error while sending request to Discourse: {}. Retrying in {} seconds", error, retry_secs);
+                    tokio::time::sleep(std::time::Duration::from_secs(retry_secs)).await;
                 }
             }
         }

--- a/rs/cli/src/forum/impls.rs
+++ b/rs/cli/src/forum/impls.rs
@@ -419,25 +419,49 @@ impl DiscourseClientImp {
             request = request.body(payload);
         }
 
-        match request.send().await {
-            Ok(r) => {
-                let rstatus = r.status();
-                match r.error_for_status() {
-                    Ok(t) => t
-                        .json()
-                        .await
-                        .map_err(|e| DiscourseClientImpError::DeserializeFailed(format!("Deserialization of response failed: {}", e))),
-                    Err(e) => {
-                        if rstatus == reqwest::StatusCode::NOT_FOUND {
-                            Err(DiscourseClientImpError::NotFound)
-                        } else {
-                            Err(DiscourseClientImpError::OtherReqwestError(e))
+        let sleep_secs = 5;
+        let retries_max = 5;
+
+        for retry_num in 1..=retries_max {
+            let retry_secs = sleep_secs * retry_num;
+
+            match request.try_clone().unwrap().send().await {
+                Ok(response) => {
+                    if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                        warn!("Rate limited by Discourse, retrying in {} seconds", retry_secs);
+                        tokio::time::sleep(std::time::Duration::from_secs(retry_secs)).await;
+                        continue;
+                    }
+
+                    let response_status = response.status();
+                    match response.error_for_status() {
+                        Ok(success_response) => {
+                            return success_response
+                                .json()
+                                .await
+                                .map_err(|e| DiscourseClientImpError::DeserializeFailed(format!("Deserialization of response failed: {}", e)));
+                        }
+                        Err(error) => {
+                            if response_status == reqwest::StatusCode::NOT_FOUND {
+                                return Err(DiscourseClientImpError::NotFound);
+                            }
+                            return Err(DiscourseClientImpError::OtherReqwestError(error));
                         }
                     }
                 }
+                Err(error) => {
+                    warn!("Error while sending request to Discourse: {}. Retrying in {} seconds", error, retry_secs);
+                    tokio::time::sleep(std::time::Duration::from_secs(retry_secs)).await;
+
+                    if retry_num == retries_max {
+                        return Err(DiscourseClientImpError::OtherReqwestError(error));
+                    }
+                }
             }
-            Err(e) => Err(DiscourseClientImpError::OtherReqwestError(e)),
         }
+
+        // This should never be reached due to the return in the last retry iteration
+        unreachable!("Should have either succeeded or returned an error by now");
     }
 
     async fn get_category_id(&self, category_name: String) -> anyhow::Result<u64> {

--- a/rs/cli/src/forum/impls.rs
+++ b/rs/cli/src/forum/impls.rs
@@ -361,6 +361,7 @@ struct DiscourseClientImp {
 #[derive(Debug)]
 enum DiscourseClientImpError {
     NotFound,
+    CloneFailed,
     ExpectedPayload,
     DeserializeFailed(String),
     OtherReqwestError(reqwest::Error),
@@ -425,14 +426,10 @@ impl DiscourseClientImp {
         for retry_num in 1..=retries_max {
             let retry_secs = sleep_secs * retry_num;
 
-            match request.try_clone().unwrap().send().await {
+            // Properly handle potential cloning failure.
+            let cloned_request = request.try_clone().ok_or(DiscourseClientImpError::CloneFailed)?;
+            match cloned_request.send().await {
                 Ok(response) => {
-                    if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                        warn!("Rate limited by Discourse, retrying in {} seconds", retry_secs);
-                        tokio::time::sleep(std::time::Duration::from_secs(retry_secs)).await;
-                        continue;
-                    }
-
                     let response_status = response.status();
                     match response.error_for_status() {
                         Ok(success_response) => {
@@ -442,10 +439,15 @@ impl DiscourseClientImp {
                                 .map_err(|e| DiscourseClientImpError::DeserializeFailed(format!("Deserialization of response failed: {}", e)));
                         }
                         Err(error) => {
-                            if response_status == reqwest::StatusCode::NOT_FOUND {
+                            if response_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                                warn!("Rate limited by Discourse, retrying in {} seconds", retry_secs);
+                                tokio::time::sleep(std::time::Duration::from_secs(retry_secs)).await;
+                                continue;
+                            } else if response_status == reqwest::StatusCode::NOT_FOUND {
                                 return Err(DiscourseClientImpError::NotFound);
+                            } else {
+                                return Err(DiscourseClientImpError::OtherReqwestError(error));
                             }
-                            return Err(DiscourseClientImpError::OtherReqwestError(error));
                         }
                     }
                 }
@@ -453,7 +455,6 @@ impl DiscourseClientImp {
                     if retry_num == retries_max {
                         return Err(DiscourseClientImpError::OtherReqwestError(error));
                     }
-
                     warn!("Error while sending request to Discourse: {}. Retrying in {} seconds", error, retry_secs);
                     tokio::time::sleep(std::time::Duration::from_secs(retry_secs)).await;
                 }


### PR DESCRIPTION
### Added
- Implemented a retry mechanism for sending requests to the Discourse API to handle `TOO_MANY_REQUESTS` errors by retrying with exponential backoff.

### Updated
- Modified existing request logic to encapsulate retry logic using a `for` loop.
- Updated error handling to include retries upon request failures, with a max retry count of 5 and incremental sleep before each retry.
- Included logging for rate limiting warnings and retry attempts.

### Removed
- Eliminated old match structure for direct request handling, replacing it with retry-inclusive logic.

### Misc
- Added unreachable!() statement to ensure code paths are handled explicitly.