### PR TITLE
Reorder command line arguments in the DRE invocation.

### DIFF
--- a/release-controller/dre_cli.py
+++ b/release-controller/dre_cli.py
@@ -56,9 +56,9 @@ class DRECli:
             subprocess.check_output(
                 [
                     self.cli,
-                    *(["--yes"] if "propose" in args else []),
                     *self.auth,
                     *args,
+                    *(["--yes"] if "propose" in args else []),
                 ],
                 env=self.env,
                 text=True,


### PR DESCRIPTION
Moved the "--yes" flag after other arguments to comply with the fact that mode of operation arguments are part of the subcommand now.