### PR TITLE
Update DRE CLI binary name, fixing brown paper bug.

### DIFF
--- a/release-controller/dre_cli.py
+++ b/release-controller/dre_cli.py
@@ -47,7 +47,7 @@ class DRECli:
             ]
         else:
             self.auth = []
-        self.cli = resolve_binary("old-dre")
+        self.cli = resolve_binary("dre")
 
     def _run(self, *args: str, **subprocess_kwargs: typing.Any) -> str:
         """Run the dre CLI."""


### PR DESCRIPTION
Changed the binary name from 'old-dre' to 'dre'.

This update ensures that the correct executable is used for DRE operations.