### PR TITLE
Print proposal ID when a proposal is issued.

### DIFF
--- a/rs/cli/src/commands/api_boundary_nodes/add.rs
+++ b/rs/cli/src/commands/api_boundary_nodes/add.rs
@@ -34,8 +34,8 @@ impl ExecutableCommand for Add {
     }
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(
                 ctx.ic_admin_executor().await?.execution(ic_admin::IcAdminProposal::new(
                     ic_admin::IcAdminProposalCommand::AddApiBoundaryNodes {
                         nodes: self.nodes.to_vec(),
@@ -49,11 +49,7 @@ impl ExecutableCommand for Add {
                 )),
                 ForumPostKind::Generic,
             )
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/api_boundary_nodes/add.rs
+++ b/rs/cli/src/commands/api_boundary_nodes/add.rs
@@ -34,7 +34,7 @@ impl ExecutableCommand for Add {
     }
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(
                 ctx.ic_admin_executor().await?.execution(ic_admin::IcAdminProposal::new(
                     ic_admin::IcAdminProposalCommand::AddApiBoundaryNodes {
@@ -49,7 +49,11 @@ impl ExecutableCommand for Add {
                 )),
                 ForumPostKind::Generic,
             )
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/api_boundary_nodes/remove.rs
+++ b/rs/cli/src/commands/api_boundary_nodes/remove.rs
@@ -30,8 +30,8 @@ impl ExecutableCommand for Remove {
     }
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(
                 ctx.ic_admin_executor().await?.execution(ic_admin::IcAdminProposal::new(
                     ic_admin::IcAdminProposalCommand::RemoveApiBoundaryNodes { nodes: self.nodes.to_vec() },
                     ic_admin::IcAdminProposalOptions {
@@ -42,11 +42,7 @@ impl ExecutableCommand for Remove {
                 )),
                 ForumPostKind::Generic,
             )
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/api_boundary_nodes/remove.rs
+++ b/rs/cli/src/commands/api_boundary_nodes/remove.rs
@@ -30,7 +30,7 @@ impl ExecutableCommand for Remove {
     }
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(
                 ctx.ic_admin_executor().await?.execution(ic_admin::IcAdminProposal::new(
                     ic_admin::IcAdminProposalCommand::RemoveApiBoundaryNodes { nodes: self.nodes.to_vec() },
@@ -42,7 +42,11 @@ impl ExecutableCommand for Remove {
                 )),
                 ForumPostKind::Generic,
             )
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/api_boundary_nodes/update.rs
+++ b/rs/cli/src/commands/api_boundary_nodes/update.rs
@@ -33,7 +33,7 @@ impl ExecutableCommand for Update {
     }
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(
                 ctx.ic_admin_executor().await?.execution(ic_admin::IcAdminProposal::new(
                     ic_admin::IcAdminProposalCommand::DeployGuestosToSomeApiBoundaryNodes {
@@ -48,7 +48,11 @@ impl ExecutableCommand for Update {
                 )),
                 ForumPostKind::Generic,
             )
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/api_boundary_nodes/update.rs
+++ b/rs/cli/src/commands/api_boundary_nodes/update.rs
@@ -33,8 +33,8 @@ impl ExecutableCommand for Update {
     }
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(
                 ctx.ic_admin_executor().await?.execution(ic_admin::IcAdminProposal::new(
                     ic_admin::IcAdminProposalCommand::DeployGuestosToSomeApiBoundaryNodes {
                         nodes: self.nodes.to_vec(),
@@ -48,11 +48,7 @@ impl ExecutableCommand for Update {
                 )),
                 ForumPostKind::Generic,
             )
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/firewall.rs
+++ b/rs/cli/src/commands/firewall.rs
@@ -235,8 +235,12 @@ impl Firewall {
         let hash = parsed.hash;
         info!("Computed hash for firewall rule at position '{}': {}", positions, hash);
 
-        if let Some(p) = Submitter::from(submission_parameters)
-            .propose(
+        // We should probably not be calling the print variant here, since
+        // this is called in a loop by the caller of create_proposal.  Perhaps
+        // we should summarize the proposals that were submitted, or the errors
+        // that were returned.
+        Submitter::from(submission_parameters)
+            .propose_and_print(
                 ctx.ic_admin_executor().await?.execution(FirewallModifyCommand {
                     test_command,
                     hash,
@@ -245,11 +249,7 @@ impl Firewall {
                 }),
                 ForumPostKind::Generic,
             )
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+            .await
     }
 }
 

--- a/rs/cli/src/commands/firewall.rs
+++ b/rs/cli/src/commands/firewall.rs
@@ -235,7 +235,7 @@ impl Firewall {
         let hash = parsed.hash;
         info!("Computed hash for firewall rule at position '{}': {}", positions, hash);
 
-        Submitter::from(submission_parameters)
+        if let Some(p) = Submitter::from(submission_parameters)
             .propose(
                 ctx.ic_admin_executor().await?.execution(FirewallModifyCommand {
                     test_command,
@@ -245,7 +245,11 @@ impl Firewall {
                 }),
                 ForumPostKind::Generic,
             )
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 }
 

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -80,7 +80,7 @@ impl ExecutableCommand for Motion {
             action: Some(ProposalActionRequest::Motion(MotionPayload { motion_text })),
         };
 
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(
                 ctx.governance_executor().await?.execution(request),
                 ForumPostKind::Motion {
@@ -88,7 +88,11 @@ impl ExecutableCommand for Motion {
                     summary: summary.clone(),
                 },
             )
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/governance/propose/motion.rs
+++ b/rs/cli/src/commands/governance/propose/motion.rs
@@ -80,19 +80,15 @@ impl ExecutableCommand for Motion {
             action: Some(ProposalActionRequest::Motion(MotionPayload { motion_text })),
         };
 
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(
                 ctx.governance_executor().await?.execution(request),
                 ForumPostKind::Motion {
                     title: title.clone(),
                     summary: summary.clone(),
                 },
             )
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/hostos/rollout.rs
+++ b/rs/cli/src/commands/hostos/rollout.rs
@@ -30,9 +30,13 @@ impl ExecutableCommand for Rollout {
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let runner_proposal = ctx.runner().await?.hostos_rollout(self.nodes.clone(), &self.version, None)?;
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/hostos/rollout.rs
+++ b/rs/cli/src/commands/hostos/rollout.rs
@@ -30,13 +30,9 @@ impl ExecutableCommand for Rollout {
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let runner_proposal = ctx.runner().await?.hostos_rollout(self.nodes.clone(), &self.version, None)?;
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/hostos/rollout_from_node_group.rs
+++ b/rs/cli/src/commands/hostos/rollout_from_node_group.rs
@@ -100,13 +100,9 @@ impl ExecutableCommand for RolloutFromNodeGroup {
         };
 
         let runner_proposal = runner.hostos_rollout(nodes_to_update, &self.version, Some(summary))?;
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/hostos/rollout_from_node_group.rs
+++ b/rs/cli/src/commands/hostos/rollout_from_node_group.rs
@@ -100,9 +100,13 @@ impl ExecutableCommand for RolloutFromNodeGroup {
         };
 
         let runner_proposal = runner.hostos_rollout(nodes_to_update, &self.version, Some(summary))?;
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/nodes/remove.rs
+++ b/rs/cli/src/commands/nodes/remove.rs
@@ -51,9 +51,13 @@ impl ExecutableCommand for Remove {
                 motivation: self.motivation.clone().unwrap_or_default(),
             })
             .await?;
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/nodes/remove.rs
+++ b/rs/cli/src/commands/nodes/remove.rs
@@ -51,13 +51,9 @@ impl ExecutableCommand for Remove {
                 motivation: self.motivation.clone().unwrap_or_default(),
             })
             .await?;
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/propose.rs
+++ b/rs/cli/src/commands/propose.rs
@@ -43,13 +43,9 @@ impl ExecutableCommand for Propose {
 
         let cmd = IcAdminProposal::new(IcAdminProposalCommand::Raw(args.clone()), Default::default());
 
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(cmd), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(cmd), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/propose.rs
+++ b/rs/cli/src/commands/propose.rs
@@ -43,9 +43,13 @@ impl ExecutableCommand for Propose {
 
         let cmd = IcAdminProposal::new(IcAdminProposalCommand::Raw(args.clone()), Default::default());
 
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(cmd), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/subnet/create.rs
+++ b/rs/cli/src/commands/subnet/create.rs
@@ -86,13 +86,9 @@ impl ExecutableCommand for Create {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic) // FIXME once the Proposable struct gains knowledge of how to create a forum post, then it won't be necessary to pass two different structs.
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic) // FIXME once the Proposable struct gains knowledge of how to create a forum post, then it won't be necessary to pass two different structs.
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/subnet/create.rs
+++ b/rs/cli/src/commands/subnet/create.rs
@@ -86,9 +86,13 @@ impl ExecutableCommand for Create {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic) // FIXME once the Proposable struct gains knowledge of how to create a forum post, then it won't be necessary to pass two different structs.
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/subnet/deploy.rs
+++ b/rs/cli/src/commands/subnet/deploy.rs
@@ -33,13 +33,9 @@ impl ExecutableCommand for Deploy {
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let runner_proposal = ctx.runner().await?.deploy(&self.id, &self.version).await?;
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/subnet/deploy.rs
+++ b/rs/cli/src/commands/subnet/deploy.rs
@@ -33,9 +33,13 @@ impl ExecutableCommand for Deploy {
 
     async fn execute(&self, ctx: crate::ctx::DreContext) -> anyhow::Result<()> {
         let runner_proposal = ctx.runner().await?.deploy(&self.id, &self.version).await?;
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -78,8 +78,8 @@ impl ExecutableCommand for Replace {
             None => return Ok(()),
         };
 
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(
                 ctx.ic_admin_executor().await?.execution(runner_proposal.clone()),
                 match subnet_change_response.subnet_id {
                     Some(id) => ForumPostKind::ReplaceNodes {
@@ -94,11 +94,7 @@ impl ExecutableCommand for Replace {
                     None => ForumPostKind::Generic,
                 },
             )
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -78,7 +78,7 @@ impl ExecutableCommand for Replace {
             None => return Ok(()),
         };
 
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(
                 ctx.ic_admin_executor().await?.execution(runner_proposal.clone()),
                 match subnet_change_response.subnet_id {
@@ -94,7 +94,11 @@ impl ExecutableCommand for Replace {
                     None => ForumPostKind::Generic,
                 },
             )
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/subnet/rescue.rs
+++ b/rs/cli/src/commands/subnet/rescue.rs
@@ -34,9 +34,13 @@ impl ExecutableCommand for Rescue {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/subnet/rescue.rs
+++ b/rs/cli/src/commands/subnet/rescue.rs
@@ -34,13 +34,9 @@ impl ExecutableCommand for Rescue {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/subnet/resize.rs
+++ b/rs/cli/src/commands/subnet/resize.rs
@@ -75,9 +75,13 @@ impl ExecutableCommand for Resize {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/subnet/resize.rs
+++ b/rs/cli/src/commands/subnet/resize.rs
@@ -75,13 +75,9 @@ impl ExecutableCommand for Resize {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -156,12 +156,16 @@ impl ExecutableCommand for UpdateAuthorizedSubnets {
             },
         );
 
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(
                 ctx.ic_admin_executor().await?.execution(prop),
                 ForumPostKind::AuthorizedSubnetsUpdate { body: summary },
             )
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 }
 

--- a/rs/cli/src/commands/update_authorized_subnets.rs
+++ b/rs/cli/src/commands/update_authorized_subnets.rs
@@ -156,16 +156,12 @@ impl ExecutableCommand for UpdateAuthorizedSubnets {
             },
         );
 
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(
                 ctx.ic_admin_executor().await?.execution(prop),
                 ForumPostKind::AuthorizedSubnetsUpdate { body: summary },
             )
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+            .await
     }
 }
 

--- a/rs/cli/src/commands/update_unassigned_nodes.rs
+++ b/rs/cli/src/commands/update_unassigned_nodes.rs
@@ -48,9 +48,13 @@ impl ExecutableCommand for UpdateUnassignedNodes {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/update_unassigned_nodes.rs
+++ b/rs/cli/src/commands/update_unassigned_nodes.rs
@@ -48,13 +48,9 @@ impl ExecutableCommand for UpdateUnassignedNodes {
             Some(runner_proposal) => runner_proposal,
             None => return Ok(()),
         };
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, _cmd: &mut clap::Command) {}

--- a/rs/cli/src/commands/version/revise/guest_os.rs
+++ b/rs/cli/src/commands/version/revise/guest_os.rs
@@ -47,13 +47,9 @@ impl ExecutableCommand for GuestOs {
                 self.security_fix,
             )
             .await?;
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/version/revise/guest_os.rs
+++ b/rs/cli/src/commands/version/revise/guest_os.rs
@@ -47,9 +47,13 @@ impl ExecutableCommand for GuestOs {
                 self.security_fix,
             )
             .await?;
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/version/revise/host_os.rs
+++ b/rs/cli/src/commands/version/revise/host_os.rs
@@ -47,9 +47,13 @@ impl ExecutableCommand for HostOs {
                 self.security_fix,
             )
             .await?;
-        Submitter::from(&self.submission_parameters)
+        if let Some(p) = Submitter::from(&self.submission_parameters)
             .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await
+            .await?
+        {
+            println!("{}", p)
+        };
+        Ok(())
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/commands/version/revise/host_os.rs
+++ b/rs/cli/src/commands/version/revise/host_os.rs
@@ -47,13 +47,9 @@ impl ExecutableCommand for HostOs {
                 self.security_fix,
             )
             .await?;
-        if let Some(p) = Submitter::from(&self.submission_parameters)
-            .propose(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
-            .await?
-        {
-            println!("{}", p)
-        };
-        Ok(())
+        Submitter::from(&self.submission_parameters)
+            .propose_and_print(ctx.ic_admin_executor().await?.execution(runner_proposal), ForumPostKind::Generic)
+            .await
     }
 
     fn validate(&self, _args: &GlobalArgs, cmd: &mut clap::Command) {

--- a/rs/cli/src/proposal_executors.rs
+++ b/rs/cli/src/proposal_executors.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Display};
 
 use futures::future::BoxFuture;
 use ic_nns_governance_api::pb::v1::{manage_neuron_response::MakeProposalResponse, MakeProposalRequest};
@@ -9,6 +9,7 @@ use url::Url;
 /// of the kind of responses that contain a proposal ID.
 /// Not every proposal response from ic-admin can be deserialized
 /// into a proposal ID, but most of them can.
+#[derive(Clone)]
 pub struct ProposalResponseWithId(u64);
 
 impl From<ProposalResponseWithId> for u64 {
@@ -21,6 +22,12 @@ impl TryFrom<u64> for ProposalResponseWithId {
     type Error = anyhow::Error;
     fn try_from(u: u64) -> Result<Self, Self::Error> {
         Ok(Self(u))
+    }
+}
+
+impl Display for ProposalResponseWithId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "proposal {}", self.0)
     }
 }
 

--- a/rs/cli/src/submitter.rs
+++ b/rs/cli/src/submitter.rs
@@ -36,9 +36,10 @@ impl From<&SubmissionParameters> for Submitter {
 impl Submitter {
     /// Submits a proposal (maybe in dry-run mode) with confirmation from the user, unless the user
     /// specifies in the command line that he wants no confirmation (--yes).
+    ///
     /// When a proposal has successfully been executed (as opposed to just simulated),
     /// the result will contain a Some(ProposalResponseWithId).
-    #[must_use = "Are you implementing a CLI command?  Did you forget to print the proposal ID possibly returned by this function?"]
+    #[must_use = "Are you implementing a CLI command?  Did you forget to print the proposal ID possibly returned by this function?  Consider propose_and_print instead."]
     pub async fn propose(&self, execution: Box<dyn ProposalExecution>, kind: ForumPostKind) -> anyhow::Result<Option<ProposalResponseWithId>> {
         if let HowToProceed::Unconditional = self.mode {
         } else {
@@ -84,5 +85,20 @@ impl Submitter {
                 }
             }
         }
+    }
+
+    /// Submits a proposal (maybe in dry-run mode) with confirmation from the user, by calling
+    /// Self.propose().
+    ///
+    /// When a proposal has successfully been executed (as opposed to just simulated),
+    /// the proposal ID will be printed to standard output as "proposal XXXXXX".
+    ///
+    /// You should only call this convenience method if all your code is going to do is print
+    /// the returned proposal ID and exit.
+    pub async fn propose_and_print(&self, execution: Box<dyn ProposalExecution>, kind: ForumPostKind) -> anyhow::Result<()> {
+        if let Some(p) = self.propose(execution, kind).await? {
+            println!("{}", p)
+        };
+        Ok(())
     }
 }

--- a/rs/cli/src/submitter.rs
+++ b/rs/cli/src/submitter.rs
@@ -4,7 +4,7 @@ use log::warn;
 use crate::{
     confirm::{ConfirmationModeOptions, HowToProceed},
     forum::{ForumContext, ForumParameters, ForumPostKind},
-    proposal_executors::ProposalExecution,
+    proposal_executors::{ProposalExecution, ProposalResponseWithId},
     util::yesno,
 };
 
@@ -36,7 +36,10 @@ impl From<&SubmissionParameters> for Submitter {
 impl Submitter {
     /// Submits a proposal (maybe in dry-run mode) with confirmation from the user, unless the user
     /// specifies in the command line that he wants no confirmation (--yes).
-    pub async fn propose(&self, execution: Box<dyn ProposalExecution>, kind: ForumPostKind) -> anyhow::Result<()> {
+    /// When a proposal has successfully been executed (as opposed to just simulated),
+    /// the result will contain a Some(ProposalResponseWithId).
+    #[must_use = "Are you implementing a CLI command?  Did you forget to print the proposal ID possibly returned by this function?"]
+    pub async fn propose(&self, execution: Box<dyn ProposalExecution>, kind: ForumPostKind) -> anyhow::Result<Option<ProposalResponseWithId>> {
         if let HowToProceed::Unconditional = self.mode {
         } else {
             execution.simulate().await?;
@@ -45,17 +48,29 @@ impl Submitter {
         if let HowToProceed::Confirm = self.mode {
             // Ask for confirmation
             if !yesno("Do you want to continue?", false).await?? {
-                return Ok(());
+                return Ok(None);
             }
         }
 
         if let HowToProceed::DryRun = self.mode {
-            Ok(())
+            Ok(None)
         } else {
             let forum_post = ForumContext::from(&self.forum_parameters).client()?.forum_post(kind).await?;
             let res = execution.submit(forum_post.url()).await;
             match res {
-                Ok(res) => forum_post.add_proposal_url(res.into()).await,
+                Ok(res) => {
+                    match forum_post.add_proposal_url(res.clone().into()).await {
+                        Ok(_) => (),
+                        Err(e) => {
+                            if let Some(forum_post_url) = forum_post.url() {
+                                warn!("Failed to add the proposal URL to forum post {}: {}", forum_post_url, e)
+                            } else {
+                                warn!("Failed to add the proposal URL to forum post: {}", e)
+                            }
+                        }
+                    };
+                    Ok(Some(res))
+                }
                 Err(e) => {
                     if let Some(forum_post_url) = forum_post.url() {
                         // Here we would ask the forum post code to delete the post since


### PR DESCRIPTION
This PR refactors proposal submission handling on the Submitter to return `Option<ProposalResponseWithId>`.

With that refactor done, we can make a change across multiple CLI subcommands to ensure that the result of a successful proposal execution (as opposed to just simulation) is printed.

*Key changes:*

- Updated the `Submitter::propose` method signature to return `anyhow::Result<Option<ProposalResponseWithId>>`.
- Added detailed handling and logging for the proposal URL addition process in case of success or failure.
- Ensured CLI commands properly handle and display the proposal ID if returned by the submission process.

This adds compatibility with `ic-admin` to all proposals submitted with DRE, which in turn will be used to fix an issue in release controller.