### PR TITLE
Keep track of proposal state, used by reconciler, only in RAM.

### DIFF
--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -192,16 +192,6 @@ bazel run //release-controller:release-controller \
   -- --dry-run --verbose
 ```
 
-Custom path for the reconciler state?
-
-
-```sh
-export RECONCILER_STATE_DIR=/tmp/dryrun/reconciler-state
-bazel run //release-controller:release-controller \
-  --action_env=RECONCILER_STATE_DIR \
-  -- --dry-run --verbose
-```
-
 Typing errors preventing you from running it, because you are editing code and
 testing your changes?  Add `--output_groups=-mypy` right after `bazel run`.
 

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -35,7 +35,7 @@ from release_notes import (
     SecurityReleaseNotesRequest,
     OrdinaryReleaseNotesRequest,
 )
-from util import version_name, release_controller_cache_directory
+from util import version_name
 from watchdog import Watchdog
 
 
@@ -539,9 +539,6 @@ def main() -> None:
         else dryrun.DRECli()
     )
     state = reconciler_state.ReconcilerState(
-        pathlib.Path(
-            os.environ.get("RECONCILER_STATE_DIR", release_controller_cache_directory())
-        ),
         None if skip_preloading_state else dre.get_election_proposals_by_version,
     )
     slack_announcer = (

--- a/release-controller/tests/test_reconciler.py
+++ b/release-controller/tests/test_reconciler.py
@@ -24,11 +24,7 @@ class AmnesiacReconcilerState(ReconcilerState):
     """Reconciler state that uses a temporary directory for storage."""
 
     def __init__(self) -> None:
-        self.tempdir = tempfile.TemporaryDirectory()
-        super().__init__(pathlib.Path(self.tempdir.name))
-
-    def __del__(self) -> None:
-        self.tempdir.cleanup()
+        super().__init__()
 
 
 class MockActiveVersionProvider(object):

--- a/release-controller/util.py
+++ b/release-controller/util.py
@@ -2,7 +2,6 @@ import collections.abc
 import hashlib
 import math
 import os
-import pathlib
 import sys
 import time
 import typing
@@ -26,10 +25,6 @@ def resolve_binary(name: str) -> str:
     if name == "dre" and os.path.exists(binary_local):
         return binary_local
     return name
-
-
-def release_controller_cache_directory() -> pathlib.Path:
-    return pathlib.Path.home() / ".cache" / "release-controller"
 
 
 T = typing.TypeVar("T")


### PR DESCRIPTION
This PR updates the `ReconcilerState` class to use an in-memory dictionary for state storage instead of file operations. This change simplifies initialization and eliminates file system interactions, improving performance and reliability.

The main effect of this change is to make the reconciler retry proposals that formerly failed to be submitted *immediately after restart*, rather than (as is right now) waiting for a configured retry duration.

The configured retry duration is still respected during the execution of the reconciler.