### PR TITLE
Use Bazel to build DRE CLI when running release controller through Bazel

### DIFF
--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -40,6 +40,7 @@ py_binary(
     tags = ["typecheck"],
     env = env,
     deps = deps,
+    data = ["//rs/cli:dre"],
 )
 
 py_binary(

--- a/release-controller/dre_cli.py
+++ b/release-controller/dre_cli.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pathlib
 import subprocess
 import typing
 from util import resolve_binary
@@ -49,7 +50,11 @@ def _mode_flags(dry_run: bool) -> list[str]:
 
 
 class DRECli:
-    def __init__(self, auth: typing.Optional[Auth] = None):
+    def __init__(
+        self,
+        auth: typing.Optional[Auth] = None,
+        cli_path: typing.Optional[pathlib.Path] = None,
+    ):
         self._logger = LOGGER.getChild(self.__class__.__name__)
         self.env = os.environ.copy()
         if auth:
@@ -61,7 +66,7 @@ class DRECli:
             ]
         else:
             self.auth = []
-        self.cli = resolve_binary("dre")
+        self.cli = str(cli_path) if cli_path else resolve_binary("dre")
 
     def _run(self, *args: str, **subprocess_kwargs: typing.Any) -> str:
         """Run the dre CLI."""

--- a/release-controller/dryrun.py
+++ b/release-controller/dryrun.py
@@ -225,8 +225,11 @@ class PublishNotesClient(object):
 
 
 class DRECli(dre_cli.DRECli):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(
+        self,
+        cli_path: typing.Optional[pathlib.Path] = None,
+    ) -> None:
+        super().__init__(cli_path=cli_path)
         self._logger = LOGGER.getChild(self.__class__.__name__)
 
     def propose_to_revise_elected_guestos_versions(

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -529,15 +529,17 @@ def main() -> None:
         else dryrun.PublishNotesClient()
     )
 
+    cli_path = pathlib.Path("rs/cli/dre") if os.getenv("BAZEL") == "true" else None
     dre = (
         dre_cli.DRECli(
             dre_cli.Auth(
                 key_path=os.environ["PROPOSER_KEY_FILE"],
                 neuron_id=os.environ["PROPOSER_NEURON_ID"],
-            )
+            ),
+            cli_path=cli_path,
         )
         if not dry_run
-        else dryrun.DRECli()
+        else dryrun.DRECli(cli_path=cli_path)
     )
     state = reconciler_state.ReconcilerState(
         None if skip_preloading_state else dre.get_election_proposals_by_version,


### PR DESCRIPTION
Our release controller can be run with `bazel run` (an activity frequently engaged in during local testing).  When this takes place, currently and by default the release controller will attempt to use whatever `dre` binary is in the user's `$PATH`.

This obviously fails when there's no such binary.

To address this, and to ensure that the release controller is running with an up-to-date version of `dre`, this change makes Bazel build the `dre` binary before starting the release controller, and then makes the release controller use the Bazel-built `dre` program, but only when running under Bazel.

This commit introduces support for an optional `cli_path` parameter in the `DRECli` class constructor, allowing users to specify a custom path to the `dre` CLI executable. This change is also useful when running the code within different environments or when testing with CLI mocks.

The following files were updated:
- `release-controller/dre_cli.py`
- `release-controller/dryrun.py`
- `release-controller/reconciler.py`