### PR TITLE
feat: success/failure telemetry in release controller reconciler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "aiohttp>=3.10.5",
     "uv>=0.5.20",
     "mypy==1.15.0",
+    "prometheus-client>=0.21.1",
 ]
 
 [tool.rye]

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -39,7 +39,9 @@ py_binary(
     srcs = glob(["*.py"], exclude = ["commit_annotator.py", "ci_check.py"]),
     tags = ["typecheck"],
     env = env,
-    deps = deps,
+    deps = deps + [
+        requirement("prometheus-client"),
+    ],
     data = ["//rs/cli:dre"],
 )
 

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -439,7 +439,9 @@ dre_repo = "dfinity/dre"
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -453,7 +455,7 @@ def main() -> None:
         type=int,
         dest="loop_every",
         default=60,
-        help="Time to wait between loop executions.  If 0 or less, exit immediately after the first loop.  Defaults to %(default)s seconds.",
+        help="Time to wait (in seconds) between loop executions.  If 0 or less, exit immediately after the first loop.",
     )
     parser.add_argument(
         "--skip-preloading-state",
@@ -465,7 +467,7 @@ def main() -> None:
         "--telemetry_port",
         type=int,
         dest="telemetry_port",
-        default="9467",
+        default=9467,
         help="Set the Prometheus telemetry port to listen on.  Telemetry is only served if --loop-every is greater than 0.",
     )
     parser.add_argument(

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -404,7 +404,7 @@ pluggy==1.5.0
 pre-commit==3.8.0
 priority==2.0.0
     # via hypercorn
-prometheus-client==0.20.0
+prometheus-client==0.21.1
     # via jupyter-server
 prompt-toolkit==3.0.47
     # via ipython


### PR DESCRIPTION
Added prometheus-client to dependencies and implemented metrics for cycle success and start timestamps. Updated the telemetry port argument and added Prometheus server initialization.

There is a command line option to set the port for telemetry.  In its default value, it is 9467.

To follow: alerts based on collected telemetry as well as runbooks.