### PR TITLE
fix(decentralization): improve node penalty calculations

### DIFF
--- a/rs/decentralization/src/nakamoto/mod.rs
+++ b/rs/decentralization/src/nakamoto/mod.rs
@@ -799,7 +799,10 @@ mod tests {
             subnet_initial.check_business_rules().unwrap(),
             (
                 20,
-                vec!["node_provider NP2 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.".to_string(), "node_provider NP4 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.".to_string()]
+                vec![
+                    "node_provider NP2 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.".to_string(),
+                    "node_provider NP4 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.".to_string()
+                ]
             )
         );
 

--- a/rs/decentralization/src/nakamoto/mod.rs
+++ b/rs/decentralization/src/nakamoto/mod.rs
@@ -798,8 +798,8 @@ mod tests {
         assert_eq!(
             subnet_initial.check_business_rules().unwrap(),
             (
-                10,
-                vec!["node_provider NP2 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.".to_string()]
+                20,
+                vec!["node_provider NP2 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.".to_string(), "node_provider NP4 controls 2 of nodes, which is higher than target of 1 for the subnet. Applying penalty of 10.".to_string()]
             )
         );
 


### PR DESCRIPTION
- Utilize `feature_value_counts` for penalty determination instead of `feature_value_counts_max`, so that ALL instances of values above the maximum allowed are penalized. This should result in more correct penalty calculations in case there are multiple violations.
