### PR TITLE
fix: avoid including DRE binary twice in the release controller container

### DIFF
--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -93,10 +93,6 @@ long_tests = ["tests/test_commit_annotator.py"]
     ]
 ]
 
-tar(
-    name = "bins_release_controller_tar",
-    srcs = ["//rs/cli:dre"],
-)
 
 tar(
     name = "bins_commit_annotator_tar",
@@ -107,7 +103,7 @@ py_oci_image(
     name = "oci_image",
     base = "@bazel_image_7_4_1",
     binary = ":release-controller",
-    tars = [":bins_release_controller_tar"]
+    tars = []
 )
 
 py_oci_image(

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -38,7 +38,9 @@ py_binary(
     main = "reconciler.py",
     srcs = glob(["*.py"], exclude = ["commit_annotator.py", "ci_check.py"]),
     tags = ["typecheck"],
-    env = env,
+    env = {
+        "DRE_PATH": "$(rootpath //rs/cli:dre)",
+    },
     deps = deps + [
         requirement("prometheus-client"),
     ],
@@ -92,7 +94,6 @@ long_tests = ["tests/test_commit_annotator.py"]
         {"targets": long_tests, "tags": ["manual"]},
     ]
 ]
-
 
 tar(
     name = "bins_commit_annotator_tar",

--- a/release-controller/dre_cli.py
+++ b/release-controller/dre_cli.py
@@ -53,7 +53,6 @@ class DRECli:
     def __init__(
         self,
         auth: typing.Optional[Auth] = None,
-        cli_path: typing.Optional[pathlib.Path] = None,
     ):
         self._logger = LOGGER.getChild(self.__class__.__name__)
         self.env = os.environ.copy()
@@ -66,7 +65,7 @@ class DRECli:
             ]
         else:
             self.auth = []
-        self.cli = str(cli_path) if cli_path else resolve_binary("dre")
+        self.cli = resolve_binary("dre")
 
     def _run(self, *args: str, **subprocess_kwargs: typing.Any) -> str:
         """Run the dre CLI."""

--- a/release-controller/dryrun.py
+++ b/release-controller/dryrun.py
@@ -227,9 +227,8 @@ class PublishNotesClient(object):
 class DRECli(dre_cli.DRECli):
     def __init__(
         self,
-        cli_path: typing.Optional[pathlib.Path] = None,
     ) -> None:
-        super().__init__(cli_path=cli_path)
+        super().__init__()
         self._logger = LOGGER.getChild(self.__class__.__name__)
 
     def propose_to_revise_elected_guestos_versions(

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -552,17 +552,15 @@ def main() -> None:
         else dryrun.PublishNotesClient()
     )
 
-    cli_path = pathlib.Path("rs/cli/dre") if os.getenv("BAZEL") == "true" else None
     dre = (
         dre_cli.DRECli(
             dre_cli.Auth(
                 key_path=os.environ["PROPOSER_KEY_FILE"],
                 neuron_id=os.environ["PROPOSER_NEURON_ID"],
             ),
-            cli_path=cli_path,
         )
         if not dry_run
-        else dryrun.DRECli(cli_path=cli_path)
+        else dryrun.DRECli()
     )
     state = reconciler_state.ReconcilerState(
         None if skip_preloading_state else dre.get_election_proposals_by_version,

--- a/release-controller/util.py
+++ b/release-controller/util.py
@@ -32,10 +32,26 @@ def resolve_binary(name: str) -> str:
     # when specified as a data dependency of a container built via Bazel.
     # Only do this when looking for the DRE binary.
     if name == "dre":
-        binary_local = os.path.join(os.path.dirname(__file__), "..", "rs/cli", name)
-        if os.access(binary_local, os.X_OK):
-            _LOGGER.debug("Using %s for executable %s", binary_local, name)
-            return binary_local
+        if os.getenv("DRE_PATH") is not None:
+            # This branch is taken when running with bazel run, or when the user
+            # manually wants to use a specific DRE tool.
+            binary_local = str(os.getenv("DRE_PATH"))
+            _LOGGER.debug(
+                "Using %s for executable %s as per environment variable DRE_PATH",
+                binary_local,
+                name,
+            )
+        else:
+            binary_local = os.path.join(
+                os.path.dirname(__file__), os.path.pardir, "rs", "cli", "dre"
+            )
+            if os.access(binary_local, os.X_OK):
+                _LOGGER.debug(
+                    "Using %s for executable %s within container",
+                    binary_local,
+                    name,
+                )
+                return binary_local
     return name
 
 

--- a/tools/python/py_oci_image.bzl
+++ b/tools/python/py_oci_image.bzl
@@ -77,7 +77,7 @@ def py_oci_image(name, binary, tars = [], **kwargs):
     )
 
     oci_load(
-        name = "{}_load_locally".format(name),
+        name = "{}_load".format(name),
         image = name,
         repo_tags = [],
         tags = ["manual"],


### PR DESCRIPTION
Binary is already included as data dependency.

Additionally, updated `util.py` to include a logger for debugging binary resolution.