### PR TITLE
feat: Add one-line logs option for better production logs.

### DIFF
--- a/release-controller/git_repo.py
+++ b/release-controller/git_repo.py
@@ -12,6 +12,9 @@ from release_index import Version
 from util import version_name
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 class FileChange(typing.TypedDict):
     file_path: str
     num_changes: int
@@ -141,8 +144,13 @@ class GitRepo:
     def fetch(self) -> None:
         """Fetch the repository."""
         if (self.dir / ".git").exists():
+            _LOGGER.info(
+                "Updating repository in %s to latest origin/%s",
+                self.dir,
+                self.main_branch,
+            )
             subprocess.check_call(
-                ["git", "fetch"],
+                ["git", "fetch", "--quiet"],
                 cwd=self.dir,
             )
             subprocess.check_call(
@@ -150,6 +158,7 @@ class GitRepo:
                 cwd=self.dir,
             )
         else:
+            _LOGGER.info("Cloning repository %s to %s", self.repo, self.dir)
             os.makedirs(self.dir, exist_ok=True)
             subprocess.check_call(
                 [
@@ -164,6 +173,7 @@ class GitRepo:
                 "git",
                 "fetch",
                 "--all",
+                "--quiet",
             ],
             cwd=self.dir,
         )
@@ -415,11 +425,11 @@ class GitRepo:
                 .split(" ")[0]
             )
             if tag_version == v.version:
-                logging.info(
+                _LOGGER.info(
                     "RC %s: tag %s already exists on origin", release.rc_name, tag
                 )
             else:
-                logging.info(
+                _LOGGER.info(
                     "RC %s: pushing tag %s to the origin", release.rc_name, tag
                 )
                 subprocess.check_call(

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -68,15 +68,15 @@ class CustomFormatter(logging.Formatter):
         red = ""
         bold_red = ""
         reset = ""
-    fmt = "%(asctime)s %(levelname)8s  %(name)-37s — %(message)s"
+    shortfmt = ":%(name)-20s — %(message)s"
     longfmt = "%(asctime)s %(levelname)13s  %(message)s\n" "%(name)37s"
 
     FORMATS = {
-        logging.DEBUG: blue + fmt + reset,
-        logging.INFO: green + fmt + reset,
-        logging.WARNING: yellow + fmt + reset,
-        logging.ERROR: red + fmt + reset,
-        logging.CRITICAL: bold_red + fmt + reset,
+        logging.DEBUG: blue + "DD" + shortfmt + reset,
+        logging.INFO: green + "II" + shortfmt + reset,
+        logging.WARNING: yellow + "WW" + shortfmt + reset,
+        logging.ERROR: red + "EE" + shortfmt + reset,
+        logging.CRITICAL: bold_red + "!!" + shortfmt + reset,
     }
 
     LONG_FORMATS = {
@@ -87,8 +87,11 @@ class CustomFormatter(logging.Formatter):
         logging.CRITICAL: bold_red + longfmt + reset,
     }
 
+    def __init__(self, one_line_logs: bool):
+        self.one_line_logs = one_line_logs
+
     def format(self, record: logging.LogRecord) -> str:
-        if len(record.name) > 37 or True:
+        if not self.one_line_logs:
             log_fmt = self.LONG_FORMATS.get(record.levelno)
         else:
             log_fmt = self.FORMATS.get(record.levelno)
@@ -449,6 +452,12 @@ def main() -> None:
     )
     parser.add_argument("--verbose", "--debug", action="store_true", dest="verbose")
     parser.add_argument(
+        "--one-line-logs",
+        action="store_true",
+        dest="one_line_logs",
+        help="Make log lines one-line without timestamps (useful in production container for better filtering)",
+    )
+    parser.add_argument(
         "--loop-every",
         action="store",
         type=int,
@@ -495,7 +504,7 @@ def main() -> None:
 
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG if verbose else logging.INFO)
-    ch.setFormatter(CustomFormatter())
+    ch.setFormatter(CustomFormatter(opts.one_line_logs))
     root.addHandler(ch)
 
     # Prep the program for longer timeouts.


### PR DESCRIPTION
Introduce the `--one-line-logs` flag to enable one-line log output without timestamps, enhancing log readability in production environments. The prior format looks nice for sure, but has the disadvantage that we can't filter easily by level or component in the Loki interface.

Enhancements:
- Added `one_line_logs` parameter to `CustomFormatter` class.
- Updated log format handling based on the `one_line_logs` option.
- Introduced custom log level prefixes (e.g., 'DD', 'II') for different log levels when using one-line logs.
- Sneak in better logging alongside quieting of annoying Git operations.