### PR TITLE
Clean up the commit annotator and add telemetry

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,6 +8,7 @@ exports_files([
     "cordoned_features.yaml",
     "WORKSPACE.bazel",
     "mypy.ini",
+    "pyproject.toml",
 ])
 
 alias(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ extend-exclude = '''
 '''
 
 [tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "debug"
 # the following option appears in a pytest version that is later than the one currently used in Bazel.
 # asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,10 @@ extend-exclude = '''
   ^/release-controller/release_index.py    # This file is generated from /bin/release-controller-update-data-model.sh
 )
 '''
+
+[tool.pytest.ini_options]
+# the following option appears in a pytest version that is later than the one currently used in Bazel.
+# asyncio_default_fixture_loop_scope = "function"
+filterwarnings = [
+    "ignore::_pytest.warning_types.PytestAssertRewriteWarning"
+]

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -82,6 +82,8 @@ genrule(
     tags = ["no-sandbox"] + ["manual"],
 )
 
+medium_tests = ["tests/test_release_notes.py"]
+
 # Add file here if you do not want to run the test automatically.
 long_tests = ["tests/test_commit_annotator.py"]
 
@@ -102,9 +104,16 @@ long_tests = ["tests/test_commit_annotator.py"]
     ]
     for group in [
         {
-            "targets": glob(["tests/test_*.py"], exclude=long_tests),
+            "targets": glob(["tests/test_*.py"], exclude=long_tests + medium_tests),
             "tags": [],
             "test_size": "small",
+            "data": [],
+            "env": {},
+        },
+        {
+            "targets": medium_tests,
+            "tags": [],
+            "test_size": "medium",
             "data": [],
             "env": {},
         },

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -48,9 +48,10 @@ py_binary(
 )
 
 py_binary(
-    name = "commit_annotator",
+    name = "commit-annotator",
     main = "commit_annotator.py",
     srcs = glob(["*.py"], exclude = ["reconciler.py", "ci_check.py"]),
+    tags = ["typecheck"],
     data = [":bazelisk", ":target_determinator"],
     env = env,
     deps = deps,
@@ -115,7 +116,7 @@ py_oci_image(
 py_oci_image(
     name = "oci_image_commit_annotator",
     base = "@bazel_image_7_4_1",
-    binary = ":commit_annotator",
+    binary = ":commit-annotator",
     tars = [":bins_commit_annotator_tar"]
 )
 

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -54,7 +54,9 @@ py_binary(
     tags = ["typecheck"],
     data = [":bazelisk", ":target_determinator"],
     env = env,
-    deps = deps,
+    deps = deps + [
+        requirement("prometheus-client"),
+    ],
 )
 
 native_binary(

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -83,18 +83,19 @@ long_tests = ["tests/test_commit_annotator.py"]
         py_test(
             name = target[6:-3],
             srcs = ["tests/runner.py"] + [target] + glob(["tests/mock_*.py"]),
-            data = glob(["tests/test_data/*"]),
+            data = glob(["tests/test_data/*"]) + ["//:pyproject.toml"],
             main = "tests/runner.py",
             env = env,
-            tags = ["no-sandbox"] + group["tags"],
-            deps = deps + dev_deps + ["release-controller"],
+            tags = ["no-sandbox"] + group["tags"] + ["typecheck"],
+            deps = deps + dev_deps + ["release-controller"] + ["commit-annotator"],
             env_inherit = ["HOME"],
+            size = group["test_size"],
         )
         for target in group["targets"]
     ]
     for group in [
-        {"targets": glob(["tests/test_*.py"], exclude=long_tests), "tags": ["typecheck"]},
-        {"targets": long_tests, "tags": ["manual"]},
+        {"targets": glob(["tests/test_*.py"], exclude=long_tests), "tags": [], "test_size": "small"},
+        {"targets": long_tests, "tags": ["manual"], "test_size": "large"},
     ]
 ]
 

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -75,6 +75,13 @@ native_binary(
     out = "target-determinator",
 )
 
+genrule(
+    name = "ic_repo_clone_for_long_tests",
+    outs = ["ic.git.tar"],
+    cmd = "git clone https://github.com/dfinity/ic.git ic.git && cd `dirname $@`/ic.git && tar cf ../ic.git.tar .",
+    tags = ["no-sandbox"] + ["manual"],
+)
+
 # Add file here if you do not want to run the test automatically.
 long_tests = ["tests/test_commit_annotator.py"]
 
@@ -83,9 +90,9 @@ long_tests = ["tests/test_commit_annotator.py"]
         py_test(
             name = target[6:-3],
             srcs = ["tests/runner.py"] + [target] + glob(["tests/mock_*.py"]),
-            data = glob(["tests/test_data/*"]) + ["//:pyproject.toml"],
+            data = glob(["tests/test_data/*"]) + ["//:pyproject.toml"] + group["data"],
             main = "tests/runner.py",
-            env = env,
+            env = env | group["env"],
             tags = ["no-sandbox"] + group["tags"] + ["typecheck"],
             deps = deps + dev_deps + ["release-controller"] + ["commit-annotator"],
             env_inherit = ["HOME"],
@@ -94,8 +101,22 @@ long_tests = ["tests/test_commit_annotator.py"]
         for target in group["targets"]
     ]
     for group in [
-        {"targets": glob(["tests/test_*.py"], exclude=long_tests), "tags": [], "test_size": "small"},
-        {"targets": long_tests, "tags": ["manual"], "test_size": "large"},
+        {
+            "targets": glob(["tests/test_*.py"], exclude=long_tests),
+            "tags": [],
+            "test_size": "small",
+            "data": [],
+            "env": {},
+        },
+        {
+            "targets": long_tests,
+            "tags": ["manual"],
+            "test_size": "large",
+            "data": ["ic_repo_clone_for_long_tests"],
+            "env": {
+                "IC_REPO_SEED_TAR": "$(location ic_repo_clone_for_long_tests)",
+            },
+        },
     ]
 ]
 

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -99,12 +99,12 @@ long_tests = ["tests/test_commit_annotator.py"]
 ]
 
 tar(
-    name = "bins_release_controller_tar",
+    name = "release_controller_deps",
     srcs = ["//rs/cli:dre"],
 )
 
 tar(
-    name = "bins_commit_annotator_tar",
+    name = "commit_annotator_deps",
     srcs = [":bazelisk", ":target_determinator"],
 )
 
@@ -112,14 +112,14 @@ py_oci_image(
     name = "oci_image",
     base = "@bazel_image_7_4_1",
     binary = ":release-controller",
-    tars = [":bins_release_controller_tar"]
+    tars = [":release_controller_deps"]
 )
 
 py_oci_image(
     name = "oci_image_commit_annotator",
     base = "@bazel_image_7_4_1",
     binary = ":commit-annotator",
-    tars = [":bins_commit_annotator_tar"]
+    tars = [":commit_annotator_deps"]
 )
 
 exports_files(["README.md"])

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -231,7 +231,7 @@ bazel run //release-controller:commit-annotator \
   --verbose
 ```
 
-Please consult `--help` for the plethora of options to tweak the behavior
+Please consult `--help` for additional options.
 
 ### Tests
 

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -227,7 +227,7 @@ bazel run //release-controller:commit-annotator \
   -- \
   --no-push-annotations \
   --loop-every=0 \
-  --no-fetch-annotations \ # don't clobber locally created annootations 
+  --no-fetch-annotations \ # don't clobber locally created annotations 
   --verbose
 ```
 

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -232,7 +232,6 @@ bazel run //release-controller:commit-annotator \
 ```
 
 Please consult `--help` for the plethora of options to tweak the behavior
-of the annotator at local run time.
 
 ### Tests
 

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -217,6 +217,23 @@ SHASUM=...
 podman run -it --entrypoint=/release-controller/release-controller $SHASUM
 ```
 
+### Running the annotator locally in "dry-run mode"
+
+The annotator can be run in a mostly stateless mode, for one single loop,
+with the following options:
+
+```sh
+bazel run //release-controller:commit-annotator \
+  -- \
+  --no-push-annotations \
+  --loop-every=0 \
+  --no-fetch-annotations \ # don't clobber locally created annootations 
+  --verbose
+```
+
+Please consult `--help` for the plethora of options to tweak the behavior
+of the annotator at local run time.
+
 ### Tests
 
 #### Unit tests

--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -1,16 +1,18 @@
+import argparse
 import logging
 import os
 import subprocess
 import sys
 import re
+import time
 import typing
 
 sys.path.append(os.path.join(os.path.dirname(__file__)))
 
-from git_repo import GitRepo
+from git_repo import GitRepo, GitRepoAnnotator, GitRepoBehavior
 from datetime import datetime
 from tenacity import retry, stop_after_attempt
-from util import resolve_binary
+from util import resolve_binary, conventional_logging
 from watchdog import Watchdog
 
 from const import GUESTOS_CHANGED_NOTES_NAMESPACE
@@ -18,6 +20,9 @@ from const import GUESTOS_CHANGED_NOTES_NAMESPACE
 GUESTOS_TARGETS_NOTES_NAMESPACE = "guestos-targets"
 GUESTOS_BAZEL_TARGETS = "//ic-os/guestos/envs/prod:update-img.tar.zst union //ic-os/setupos/envs/prod:disk-img.tar.zst"
 CUTOFF_COMMIT = "8646665552677436c8a889ce970857e531fee49b"
+
+
+_LOGGER = logging.getLogger()
 
 
 def release_branch_date(branch: str) -> typing.Optional[datetime]:
@@ -31,7 +36,9 @@ def release_branch_date(branch: str) -> typing.Optional[datetime]:
 
 # target-determinator sometimes fails on first few tries
 @retry(stop=stop_after_attempt(10))
-def target_determinator(ic_repo: GitRepo, object: str) -> bool:
+def target_determinator(ic_repo: GitRepoAnnotator, object: str) -> bool:
+    logger = _LOGGER.getChild("target_determinator").getChild(object)
+    logger.debug("Attempting to determine target")
     ic_repo.checkout(object)
     p = subprocess.run(
         [
@@ -48,98 +55,196 @@ def target_determinator(ic_repo: GitRepo, object: str) -> bool:
         stderr=subprocess.PIPE,
     )
     output = p.stdout.decode().strip()
-    logging.info(f"stdout of target determinator for {object}: '{output}'")
-    logging.info(
+    logger.debug(f"stdout of target determinator for {object}: '{output}'")
+    logger.debug(
         f"stderr of target determinator for {object}: '{p.stderr.decode().strip()}'"
     )
     return output != ""
 
 
-def annotate_object(ic_repo: GitRepo, object: str):
-    logging.info("annotating git commit {}".format(object))
+def annotate_object(ic_repo: GitRepoAnnotator, object: str) -> None:
+    logger = _LOGGER.getChild("annotate_object").getChild(object)
+    logger.debug("Attempting to annotate")
     ic_repo.checkout(object)
-    logging.info("running bazel query for {}".format(object))
-    bazel_query_output = (
-        subprocess.check_output(
-            [
-                resolve_binary("bazel"),
-                "query",
-                f"deps({GUESTOS_BAZEL_TARGETS})",
-            ],
-            cwd=ic_repo.dir,
-        )
-        .decode()
-        .splitlines()
-    )
-    ic_repo.add_note(
-        GUESTOS_TARGETS_NOTES_NAMESPACE,
+    logger.debug("Running bazel query")
+    bazel_query_output = subprocess.check_output(
+        [
+            resolve_binary("bazel"),
+            "query",
+            f"deps({GUESTOS_BAZEL_TARGETS})",
+        ],
+        text=True,
+        cwd=ic_repo.dir,
+    ).splitlines()
+    ic_repo.add(
         object=object,
+        namespace=GUESTOS_TARGETS_NOTES_NAMESPACE,
         content="\n".join(
-            [line for line in bazel_query_output if not line.startswith("@")]
+            [
+                line
+                for line in bazel_query_output
+                if line.strip() and not line.startswith("@")
+            ]
         ),
     )
-    ic_repo.add_note(
-        namespace=GUESTOS_CHANGED_NOTES_NAMESPACE,
+    ic_repo.add(
         object=object,
+        namespace=GUESTOS_CHANGED_NOTES_NAMESPACE,
         content=str(target_determinator(ic_repo=ic_repo, object=object)),
     )
 
 
-def annotate_branch(ic_repo: GitRepo, branch: str):
+def annotate_branch(annotator: GitRepoAnnotator, branch: str) -> None:
+    logger = _LOGGER.getChild(branch)
+    logger.debug("Attempting to annotate")
+    # Reverse to annotate oldest objects first so that loop can be easily restarted if it breaks.
     commits = []
+    annotator.checkout(branch)
     current_commit = branch
-    ic_repo.checkout(branch)
     while True:
         if current_commit == CUTOFF_COMMIT:
             break
-        if ic_repo.get_note(
+        if annotator.get(
             namespace=GUESTOS_CHANGED_NOTES_NAMESPACE, object=current_commit
         ):
+            logger.debug("Found annotated commit %s", current_commit)
             break
-
-        logging.info("branch %s: found git commit %s", branch, current_commit)
+        logger.debug("Found unannotated commit %s", current_commit)
         commits.append(current_commit)
-        current_commit = ic_repo.parent(current_commit)
-
-    # reverse to annotate oldest objects first so that loop can be easily restarted if it breaks
+        current_commit = annotator.parent(current_commit)
+    if commits:
+        logger.info("About to annotate %s commits", len(commits))
     for c in reversed(commits):
-        annotate_object(ic_repo=ic_repo, object=c)
+        annotate_object(ic_repo=annotator, object=c)
+    if commits:
+        logger.info("Successfully annotated %s commits", len(commits))
 
 
-def main():
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--no-push-annotations",
+        action="store_false",
+        dest="push_annotations",
+        help="The default is to push annotations to remote server.  This option turns it off.",
+    )
+    parser.add_argument(
+        "--no-save-annotations",
+        action="store_false",
+        dest="save_annotations",
+        help="The default is to save annotations locally.  This option turns it off.  The upside is that, on every loop, the annotator attempts to re-annotate the same commits it had annotated before",
+    )
+    parser.add_argument(
+        "--no-fetch-annotations",
+        action="store_false",
+        dest="fetch_annotations",
+        help="The default is to fetch annotations from the repository on every loop, annihilating local annotations.  This option turns it off.",
+    )
+    parser.add_argument("--verbose", "--debug", action="store_true", dest="verbose")
+    parser.add_argument(
+        "--one-line-logs",
+        action="store_true",
+        dest="one_line_logs",
+        help="Make log lines one-line without timestamps (useful in production container for better filtering)",
+    )
+    parser.add_argument(
+        "--loop-every",
+        action="store",
+        type=int,
+        dest="loop_every",
+        default=30,
+        help="Time to wait (in seconds) between loop executions.  If 0 or less, exit immediately after the first loop.",
+    )
+    parser.add_argument(
+        "--branch-globs",
+        default="master,rc--*",
+        type=str,
+        dest="branch_globs",
+        help="Use this branch glob (or comma-separated list of globs) to determine which branches to annotate",
+    )
+    parser.add_argument(
+        "--skip-branch-older-than",
+        default=20,
+        type=int,
+        dest="max_branch_age_days",
+        help="Skip annotating branches older than this value (in days).",
+    )
+    opts = parser.parse_args()
+
+    behavior: GitRepoBehavior = {
+        "push_annotations": opts.push_annotations,
+        "save_annotations": opts.save_annotations,
+        "fetch_annotations": opts.fetch_annotations,
+    }
+    github_token = os.getenv("GITHUB_TOKEN", None)
+    github_org = os.getenv("GITHUB_ORG", "dfinity")
+    creds = f"oauth2:{github_token}@" if github_token else ""
+
+    conventional_logging(opts.one_line_logs, opts.verbose)
+
     ic_repo = GitRepo(
-        f"https://oauth2:{os.environ['GITHUB_TOKEN']}@github.com/{os.environ['GITHUB_ORG']}/ic.git",
+        f"https://{creds}github.com/{github_org}/ic.git",
         main_branch="master",
+        behavior=behavior,
     )
 
     # Watchdog needs to be fed (to report healthy progress) every 10 minutes
-    watchdog = Watchdog(timeout_seconds=600)
+    watchdog = Watchdog(timeout_seconds=max([600, opts.loop_every * 2]))
     watchdog.start()
 
+    logger = _LOGGER.getChild("annotator")
+    branch_globs = opts.branch_globs.split(",")
     while True:
         ic_repo.fetch()
         try:
-            annotate_branch(ic_repo, branch="master")
-        except Exception as e:
-            logging.error("failed to annotate master, retrying", exc_info=e)
-            continue
-        for b in ic_repo.branch_list("rc--*"):
-            try:
-                branch_date = release_branch_date(b)
-                if not branch_date or (datetime.now() - branch_date).days > 20:
-                    logging.info("skipping git branch as too old: {}".format(b))
-                    continue
-                logging.info("annotating branch {}".format(b))
-                annotate_branch(ic_repo, branch=b)
-                watchdog.report_healthy()
-            except Exception as e:
-                logging.error(
-                    "failed to annotate branch {}, will retry later".format(b),
-                    exc_info=e,
+            now = time.time()
+            with ic_repo.annotator(
+                [GUESTOS_CHANGED_NOTES_NAMESPACE, GUESTOS_TARGETS_NOTES_NAMESPACE]
+            ) as annotator:
+                for b in [
+                    branch
+                    for glob in branch_globs
+                    for branch in ic_repo.branch_list(glob)
+                ]:
+                    # if b is a directly-specified branch instead of a glob
+                    # then assume the date is "now" rather than fool around
+                    # with trying to determine the branch date.
+                    branch_date = (
+                        datetime.now() if b in branch_globs else release_branch_date(b)
+                    )
+                    if (
+                        not branch_date
+                        or (datetime.now() - branch_date).days
+                        > opts.max_branch_age_days
+                    ):
+                        logger.debug(
+                            "Ignoring branch as older than %s days: %s",
+                            opts.max_branch_age_days,
+                            b,
+                        )
+                        continue
+                    annotate_branch(annotator, branch=b)
+            watchdog.report_healthy()
+            if opts.loop_every <= 0:
+                break
+            else:
+                sleepytime = opts.loop_every - (time.time() - now)
+                if sleepytime > 0.0:
+                    time.sleep(sleepytime)
+        except KeyboardInterrupt:
+            logger.info("Interrupted.")
+            raise
+        except Exception:
+            if opts.loop_every <= 0:
+                raise
+            else:
+                logger.exception(
+                    f"Failed to annotate.  Retrying in {opts.loop_every} seconds.  Traceback:"
                 )
-                continue
+                time.sleep(opts.loop_every)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     main()

--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -154,7 +154,7 @@ def main() -> None:
         "--no-fetch-annotations",
         action="store_false",
         dest="fetch_annotations",
-        help="The default is to fetch annotations from the repository on every loop, annihilating local annotations.  This option turns it off.",
+        help="The default is to fetch annotations from the repository on every loop, overwriting local annotations. This option turns off that behavior.",
     )
     parser.add_argument("--verbose", "--debug", action="store_true", dest="verbose")
     parser.add_argument(

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -545,7 +545,7 @@ def main() -> None:
     while True:
         try:
             now = time.time()
-            LAST_CYCLE_START_TIMESTAMP_SECONDS.set(int(time.time()))
+            LAST_CYCLE_START_TIMESTAMP_SECONDS.set(int(now))
             reconciler.reconcile()
             LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS.set(int(time.time()))
             LAST_CYCLE_SUCCESSFUL.set(1)

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -588,7 +588,7 @@ Changes [were removed](https://github.com/dfinity/ic/compare/{release_tag}...{ba
 def is_guestos_change(ic_repo: GitRepo, commit: str) -> bool:
     """Check if GuestOS changed for the commit by querying git notes populated by commit annotator."""
     with ic_repo.annotator([GUESTOS_CHANGED_NOTES_NAMESPACE]) as ann:
-        changed = ann.get(GUESTOS_CHANGED_NOTES_NAMESPACE, commit)
+        changed = ann.get(namespace=GUESTOS_CHANGED_NOTES_NAMESPACE, object=commit)
     if not changed:
         raise ValueError(
             f"Could not find GuestOS label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -587,7 +587,8 @@ Changes [were removed](https://github.com/dfinity/ic/compare/{release_tag}...{ba
 
 def is_guestos_change(ic_repo: GitRepo, commit: str) -> bool:
     """Check if GuestOS changed for the commit by querying git notes populated by commit annotator."""
-    changed = ic_repo.get_note(GUESTOS_CHANGED_NOTES_NAMESPACE, commit)
+    with ic_repo.annotator([GUESTOS_CHANGED_NOTES_NAMESPACE]) as ann:
+        changed = ann.get(GUESTOS_CHANGED_NOTES_NAMESPACE, commit)
     if not changed:
         raise ValueError(
             f"Could not find GuestOS label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."

--- a/release-controller/tests/runner.py
+++ b/release-controller/tests/runner.py
@@ -9,10 +9,6 @@ if __name__ == "__main__":
     sys.path.append(os.path.join(dir_path, "tests"))
 
     if hasattr(pytest, "main") or os.getenv("RUN_ANYWAY"):
-        import logging
-
-        logging.basicConfig(level=logging.INFO)
-
         args = ["-vv", "--show-capture=all", "-n=8"] + (
             sys.argv[1:] if sys.argv[1:] else [dir_path]
         )

--- a/release-controller/tests/test_commit_annotator.py
+++ b/release-controller/tests/test_commit_annotator.py
@@ -17,6 +17,12 @@ def test_determinator_touchstones() -> None:
         ("replica changed", "951e895c7", True),
         ("cargo lock paths only", "5a250cb34", False),
     ]
+    # It would be fantastic if this clone could be a @pytest.fixture
+    # but, due to our use of the xdist pytest plugin, that provides
+    # no savings (each process clones its own repo, rather than reusing
+    # the fixtures throughout the session).  It would still not be useful
+    # to parallelize the different tests on the table above, since the
+    # GitRepo class is not thread-safe anyway.
     with tempfile.TemporaryDirectory() as d:
         _LOGGER.info("Cloning IC repo...")
         ic_repo = GitRepo(

--- a/release-controller/tests/test_commit_annotator.py
+++ b/release-controller/tests/test_commit_annotator.py
@@ -1,34 +1,44 @@
 import logging
+import os
 import pathlib
+import pytest
+import tarfile
 import tempfile
+import typing
 
 from commit_annotator import target_determinator
-from git_repo import GitRepo
+from git_repo import GitRepo, GitRepoAnnotator
 
 
 _LOGGER = logging.getLogger()
 
 
-def test_determinator_touchstones() -> None:
-    table = [
-        ("not a guestos change", "00dc67f8d", False),
-        ("bumped dependencies", "2d0835bba", True),
-        ("github dir changed", "94fd38099", False),
-        ("replica changed", "951e895c7", True),
-        ("cargo lock paths only", "5a250cb34", False),
-    ]
-    # It would be fantastic if this clone could be a @pytest.fixture
-    # but, due to our use of the xdist pytest plugin, that provides
-    # no savings (each process clones its own repo, rather than reusing
-    # the fixtures throughout the session).  It would still not be useful
-    # to parallelize the different tests on the table above, since the
-    # GitRepo class is not thread-safe anyway.
+# It would be fantastic if this clone could be a plain @pytest.fixture
+# but, due to our use of the xdist pytest plugin, that provides
+# no savings (each process clones its own IC repo, rather than reusing
+# the fixtures throughout the session).  It would still not be useful
+# to parallelize the different tests on the table above, since the
+# GitRepo class is not thread-safe anyway.
+# So what do we do here?  We look for a variable (present in Bazel
+# tests) that signals a promise that the tarball named in the variable
+# contains an up-to-date clone of the IC repo.  If we find it, we
+# extract it prior to instantiating the IC repo clone.
+@pytest.fixture(scope="session")
+def annotator() -> typing.Generator[GitRepoAnnotator, None, None]:
     with tempfile.TemporaryDirectory() as d:
-        _LOGGER.info("Cloning IC repo...")
+        cache_dir = pathlib.Path(d)
+        if "IC_REPO_SEED_TAR" in os.environ:
+            unpacked_dir = cache_dir / "github.com" / "dfinity" / "ic.git"
+            _LOGGER.info("Unpacking seed tarball of IC repo to %s...", unpacked_dir)
+            os.makedirs(unpacked_dir, exist_ok=True)
+            with tarfile.open(os.environ["IC_REPO_SEED_TAR"]) as seed_repo:
+                seed_repo.extractall(unpacked_dir, filter="tar")
+        else:
+            _LOGGER.info("Cloning IC repo under cache directory %s...", cache_dir)
         ic_repo = GitRepo(
             "https://github.com/dfinity/ic.git",
             main_branch="master",
-            repo_cache_dir=pathlib.Path(d),
+            repo_cache_dir=cache_dir,
             behavior={
                 "push_annotations": False,
                 "save_annotations": True,
@@ -37,9 +47,30 @@ def test_determinator_touchstones() -> None:
         )
         _LOGGER.info("Clone of IC repo finished.  Going into annotator context.")
         with ic_repo.annotator([]) as annotator:
-            for explanation, object, expected_result in table:
-                _LOGGER.info(f"Testing touchstone {explanation}...")
-                actual_result = target_determinator(object=object, ic_repo=annotator)
-                assert (
-                    actual_result == expected_result
-                ), f"While running touchstone {explanation} on commit {object}, result {actual_result} != expected {expected_result}"
+            yield annotator
+
+
+def _test_guestos_changed(
+    ann: GitRepoAnnotator, object: str, expect_changed: bool
+) -> None:
+    assert target_determinator(object=object, ic_repo=ann) == expect_changed
+
+
+def test_guestos_changed__not_guestos_change(annotator: GitRepoAnnotator) -> None:
+    _test_guestos_changed(annotator, object="00dc67f8d", expect_changed=False)
+
+
+def test_guestos_changed__bumped_dependencies(annotator: GitRepoAnnotator) -> None:
+    _test_guestos_changed(annotator, object="2d0835bba", expect_changed=True)
+
+
+def test_guestos_changed__github_dir_changed(annotator: GitRepoAnnotator) -> None:
+    _test_guestos_changed(annotator, object="94fd38099", expect_changed=False)
+
+
+def test_guestos_changed__replica_changed(annotator: GitRepoAnnotator) -> None:
+    _test_guestos_changed(annotator, object="951e895c7", expect_changed=True)
+
+
+def test_guestos_changed__cargo_lock_paths_only(annotator: GitRepoAnnotator) -> None:
+    _test_guestos_changed(annotator, object="5a250cb34", expect_changed=False)

--- a/release-controller/tests/test_commit_annotator.py
+++ b/release-controller/tests/test_commit_annotator.py
@@ -42,7 +42,7 @@ def annotator() -> typing.Generator[GitRepoAnnotator, None, None]:
             behavior={
                 "push_annotations": False,
                 "save_annotations": True,
-                "fetch_annotations": True,
+                "fetch_annotations": False,
             },
         )
         _LOGGER.info("Clone of IC repo finished.  Going into annotator context.")


### PR DESCRIPTION
This commit renames the `commit_annotator` binary and associated Python script to `commit-annotator`, adhering to naming conventions. It also adds a new tag (`typecheck`) for the `commit-annotator` binary which enables mypy type checking, which has been completed too.

Prometheus metrics server has been added (defaults to listening on port 9468).

Options were added to allow the commit annotator to run in a dry-run mode, locally annotating tags without saving them to disk, pulling them from the remote, or pushing them to the remote.  These changes allow for manual testing of the commit annotator without any credentials.

Conventional logging as well as loop time allow the annotator to run on a looser loop without spinning CPU uselessly between runs.