### PR TITLE
feat(cli): support forum post link simulation

### DIFF
--- a/rs/cli/src/forum/mod.rs
+++ b/rs/cli/src/forum/mod.rs
@@ -119,6 +119,15 @@ impl ForumParameters {
         }
         Ok(())
     }
+
+    pub fn forum_post_link_for_simulation(&self) -> Option<String> {
+        match &self.forum_post_link {
+            ForumPostLinkVariant::Url(u) => Some(u.to_string()),
+            ForumPostLinkVariant::Ask => Some("Will be prompted".to_string()),
+            ForumPostLinkVariant::ManageOnDiscourse => Some("Will be automatically created on Discourse".to_string()),
+            ForumPostLinkVariant::Omit => None,
+        }
+    }
 }
 
 // FIXME: this should become part of a new composite trait

--- a/rs/cli/src/governance.rs
+++ b/rs/cli/src/governance.rs
@@ -29,12 +29,17 @@ impl GovernanceCanisterProposalExecutor {
         Box::new(ProposalExecutionViaGovernanceCanister { executor: self, proposal: p })
     }
 
-    pub fn simulate<'c, 'd, W: ProposableViaGovernanceCanister + 'c>(&'d self, cmd: &'c W) -> BoxFuture<'c, anyhow::Result<()>>
+    pub fn simulate<'c, 'd, W: ProposableViaGovernanceCanister + 'c>(
+        &'d self,
+        cmd: &'c W,
+        forum_post_link_description: Option<String>,
+    ) -> BoxFuture<'c, anyhow::Result<()>>
     where
         'd: 'c,
     {
         Box::pin(async move {
             println!("Proposal that would be submitted:\n{:#?}", cmd);
+            println!("Forum post link: {}", forum_post_link_description.unwrap_or("None".to_string()));
             Ok(())
         })
     }
@@ -80,8 +85,8 @@ impl<T> ProposalExecution for ProposalExecutionViaGovernanceCanister<T>
 where
     T: ProposableViaGovernanceCanister<ProposalResult = ProposalResponseWithId>,
 {
-    fn simulate(&self) -> BoxFuture<'_, anyhow::Result<()>> {
-        Box::pin(async { self.executor.simulate(&self.proposal).await })
+    fn simulate(&self, forum_post_link_description: Option<String>) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { self.executor.simulate(&self.proposal, forum_post_link_description).await })
     }
 
     fn submit<'a, 'b>(&'a self, forum_post_link: Option<Url>) -> BoxFuture<'b, anyhow::Result<ProposalResponseWithId>>

--- a/rs/cli/src/proposal_executors.rs
+++ b/rs/cli/src/proposal_executors.rs
@@ -112,7 +112,7 @@ impl ProposableViaGovernanceCanister for MakeProposalRequest {
 /// of a proposal (any object that implements either RunnableViaIcAdmin or
 /// ProposableViaGovernanceCanister, and produces a ProposalResponseWithId).
 pub trait ProposalExecution: Send + Sync {
-    fn simulate(&self) -> BoxFuture<'_, anyhow::Result<()>>;
+    fn simulate(&self, forum_post_link_description: Option<String>) -> BoxFuture<'_, anyhow::Result<()>>;
 
     /// Runs the proposal in forrealz mode.  Result is returned and logged at debug level.
     fn submit<'a, 'b>(&'a self, forum_post_link: Option<Url>) -> BoxFuture<'b, anyhow::Result<ProposalResponseWithId>>

--- a/rs/cli/src/submitter.rs
+++ b/rs/cli/src/submitter.rs
@@ -43,7 +43,7 @@ impl Submitter {
     pub async fn propose(&self, execution: Box<dyn ProposalExecution>, kind: ForumPostKind) -> anyhow::Result<Option<ProposalResponseWithId>> {
         if let HowToProceed::Unconditional = self.mode {
         } else {
-            execution.simulate().await?;
+            execution.simulate(self.forum_parameters.forum_post_link_for_simulation()).await?;
         };
 
         if let HowToProceed::Confirm = self.mode {

--- a/rs/cli/src/unit_tests/update_unassigned_nodes.rs
+++ b/rs/cli/src/unit_tests/update_unassigned_nodes.rs
@@ -122,7 +122,7 @@ async fn should_skip_update_same_version_nns_provided() {
 async fn should_update_unassigned_nodes() {
     let mut ic_admin = MockIcAdmin::new();
     // Should be called since versions differ
-    ic_admin.expect_simulate_proposal().once().returning(|_| Box::pin(async { Ok(()) }));
+    ic_admin.expect_simulate_proposal().once().returning(|_, _| Box::pin(async { Ok(()) }));
     ic_admin
         .expect_submit_proposal()
         .once()

--- a/rs/cli/src/unit_tests/version.rs
+++ b/rs/cli/src/unit_tests/version.rs
@@ -33,7 +33,7 @@ async fn guest_os_elect_version_tests() {
     let captured_cmd_clone = captured_cmd.clone();
 
     let mut ic_admin = MockIcAdmin::new();
-    ic_admin.expect_simulate_proposal().returning(|_| Box::pin(async { Ok(()) }));
+    ic_admin.expect_simulate_proposal().returning(|_, _| Box::pin(async { Ok(()) }));
     let captured_cmd_clone = captured_cmd_clone.clone();
     ic_admin.expect_submit_proposal().returning(move |cmd, _forum_post| {
         *captured_cmd_clone.write().unwrap() = Some(cmd.clone());


### PR DESCRIPTION
### Primary Changes

- **Forum Post Link Simulation**:
  - Added `forum_post_link_for_simulation` method to `ForumParameters` to generate a link for simulation purposes.
  - Updated `simulate` function implementations in `GovernanceCanisterProposalExecutor`, `ProposalExecutionViaGovernanceCanister`, and `IcAdmin` traits to include an optional forum post link description when simulating proposals.
  - Modified functions to print the forum post link description during simulations for better traceability.

- **Unit Tests**:
  - Adjusted unit tests to accommodate the additional forum post link parameter in proposal simulation.