### PR TITLE
chore: Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get all changed release files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f # v46.0.1
         with:
           files: |
             release-index.yaml


### PR DESCRIPTION
**Context**
This PR updates our GitHub Actions workflow to pin tj-actions/changed-files to a specific commit SHA instead of using a mutable version tag. This change is necessary due to a recent security incident where a compromised version of the action was temporarily pushed.

**What’s Changed?**
Updated the workflow to reference commit [531f5f7d163941f0c1c04e0ff4d8bb243ac4366f](https://github.com/tj-actions/changed-files/commit/531f5f7d163941f0c1c04e0ff4d8bb243ac4366f), which corresponds to the latest safe release (v46.0.1).