### PR TITLE
A twofer: fix ugly error message in annotator, and enhance docs.

### DIFF
--- a/docs/be-dr-dre.md
+++ b/docs/be-dr-dre.md
@@ -43,8 +43,8 @@ The release process [is documented here](https://www.notion.so/dfinityorg/IC-OS-
 
 ### 2. **Review alerts for our clusters**
 
-* All alerts that our clusters send are aggregated in our [Jira ops board](https://dfinity.atlassian.net/jira/ops/teams/og-a6d6c0d5-2641-4c54-8a2c-5860ef5e8f53/alerts?view=list&query=responders%3A+og-a6d6c0d5-2641-4c54-8a2c-5860ef5e8f53)
-* Heartbeats are present [here](https://dfinity.atlassian.net/jira/ops/teams/og-a6d6c0d5-2641-4c54-8a2c-5860ef5e8f53/heartbeats)
+* All alerts that our clusters send are aggregated in our [Jira ops board](https://dfinity.atlassian.net/jira/ops/teams/og-a6d6c0d5-2641-4c54-8a2c-5860ef5e8f53/alerts?view=list&query=responders%3A%20og-a6d6c0d5-2641-4c54-8a2c-5860ef5e8f53%20AND%20%28status%3A%20%22snoozed%22%20OR%20status%3A%20%22acknowledged%22%20OR%20status%3A%20%22open%22%29).
+* Heartbeats are present [here](https://dfinity.atlassian.net/jira/ops/teams/og-a6d6c0d5-2641-4c54-8a2c-5860ef5e8f53/heartbeats).
 
 ??? tip "What should I do if there are alerts?"
     

--- a/release-controller/git_repo.py
+++ b/release-controller/git_repo.py
@@ -92,7 +92,9 @@ class GitRepoAnnotator(object):
         cachekey = f"{namespace}-{object}"
         if cachekey not in self.cache:
             try:
-                self.cache[cachekey] = self.repo._notes(namespace, "show", object)
+                self.cache[cachekey] = self.repo._notes(
+                    namespace, "show", object, silence_stderr=True
+                )
             except subprocess.CalledProcessError:
                 # It's not there!
                 self.cache[cachekey] = None


### PR DESCRIPTION
The first thing in this commit is to remove this message from the standard error:

```
error: no note found for object 7d4e057cbb17f4bf2a108d547402cb5e7bf3eacc.
```

which is unnnecessary.  I had even added the functionality to do this very thing into the `notes()` function before, but forgot to call it when it was appropriate.  The code does the right thing -- but it just looks ugly when doing it.

The second thing is the URL to the Jira ops board which should be fixed to exclude closed alerts because they are noise and should not be shown by default.  So we I it here.

I'll handle rollout of the annotator after this.