### PR TITLE
fix: codeowners parsing

### DIFF
--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -206,7 +206,9 @@ def parse_codeowners(codeowners_path: str | pathlib.Path) -> dict[str, list[str]
         parsed = {}
         for line in filtered:
             result = line.split()
-            teams = [team.split("@dfinity/")[1] for team in result[1:] if "@dfinity/" in team]
+            if len(result) <= 1:
+                continue
+            teams = [team.split("@dfinity/")[1] for team in result[1:]]
             pattern = result[0]
             pattern = pattern if pattern.startswith("/") else "/" + pattern
             pattern = pattern if not pattern.endswith("/") else pattern + "*"

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -206,7 +206,7 @@ def parse_codeowners(codeowners_path: str | pathlib.Path) -> dict[str, list[str]
         parsed = {}
         for line in filtered:
             result = line.split()
-            teams = [team.split("@dfinity/")[1] for team in result[1:]]
+            teams = [team.split("@dfinity/")[1] for team in result[1:] if "@dfinity/" in team]
             pattern = result[0]
             pattern = pattern if pattern.startswith("/") else "/" + pattern
             pattern = pattern if not pattern.endswith("/") else pattern + "*"


### PR DESCRIPTION
Fixing the following issue:
```bash
IndexError: list index out of range
II:git_repo             — Updating repository in /root/.cache/git/github.com/dfinity/dre.git to latest origin/main
II:reconciler           — GuestOS versions active on subnets or unassigned nodes: 6e64281a8e0b4faa1d859f115fc138eee6e136f8, de6e339b323f59fc07b18c23f37c3cd2aa8ceb55, f6f5e0927d14886e4bd67f776ee889f31cec2364
II:reconciler           — Dealing with the following releases:
II:reconciler           — 1. rc--2025-03-20_03-11 (base)
II:reconciler           — 2. rc--2025-03-14_03-10 (base)
II:reconciler           — 3. rc--2025-03-06_03-10 (base, disable-best-effort-messaging)
II:reconciler           — 4. rc--2025-02-27_03-09 (base, disable-best-effort-messaging)
II:reconciler.rc--2025-03-20_03-11.release-2025-03-20_03-11-base — No proposal for version 2fe8aefafcb2fbee6fdb2785374d5de715560269.  Proposal needed.  Beginning process.
II:git_repo             — Updating repository in /root/.cache/git/github.com/dfinity/dre.git to latest origin/main
II:reconciler.rc--2025-03-20_03-11.release-2025-03-20_03-11-base — No release notes found in editor.  Creating.
II:reconciler.rc--2025-03-20_03-11.release-2025-03-20_03-11-base — It's an ordinary release.  Generating full changelog.
II:git_repo             — Updating repository in /root/.cache/git/authed/github.com/dfinity/ic.git to latest origin/master
II:git_repo             — RC rc--2025-03-20_03-11: pushing tag release-2025-03-20_03-11-base to the origin
II:git_repo             — Updating repository in /root/.cache/git/authed/github.com/dfinity/ic.git to latest origin/master
II:reconciler.rc--2025-03-20_03-11.release-2025-03-20_03-11-base — Preparing release notes.
II:git_repo             — Updating repository in /root/.cache/git/github.com/dfinity/ic.git to latest origin/master
EE:root                 — Failed to reconcile.  Retrying in 60 seconds.  Traceback:
Traceback (most recent call last):
  File "/release-controller/release-controller.runfiles/_main/release-controller/reconciler.py", line 549, in main
    reconciler.reconcile()
  File "/release-controller/release-controller.runfiles/_main/release-controller/reconciler.py", line 312, in reconcile
    content = prepare_release_notes(request)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/release-controller/release_notes.py", line 333, in prepare_release_notes
    changes = release_changes(
              ^^^^^^^^^^^^^^^^
  File "/release-controller/release_notes.py", line 267, in release_changes
    change = get_change_description_for_commit(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/release-controller/release_notes.py", line 397, in get_change_description_for_commit
    codeowners = parse_codeowners(ic_repo.file(".github/CODEOWNERS"))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/release-controller/release_notes.py", line 209, in parse_codeowners
    teams = [team.split("@dfinity/")[1] for team in result[1:]]
             ~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```