### PR TITLE
Add extra telemetry to allow distinguishing between failure states.

### DIFF
--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -22,6 +22,10 @@ GUESTOS_TARGETS_NOTES_NAMESPACE = "guestos-targets"
 GUESTOS_BAZEL_TARGETS = "//ic-os/guestos/envs/prod:update-img.tar.zst union //ic-os/setupos/envs/prod:disk-img.tar.zst"
 CUTOFF_COMMIT = "8646665552677436c8a889ce970857e531fee49b"
 
+LAST_CYCLE_END_TIMESTAMP_SECONDS = Gauge(
+    "last_cycle_end_timestamp_seconds",
+    "The UNIX timestamp of the last cycle that completed",
+)
 LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS = Gauge(
     "last_cycle_success_timestamp_seconds",
     "The UNIX timestamp of the last cycle that completed successfully",
@@ -252,7 +256,9 @@ def main() -> None:
                         )
                         continue
                     annotate_branch(annotator, branch=b)
-            LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS.set(int(time.time()))
+            and_now = time.time()
+            LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS.set(int(and_now))
+            LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
             LAST_CYCLE_SUCCESSFUL.set(1)
             watchdog.report_healthy()
             if opts.loop_every <= 0:
@@ -268,6 +274,9 @@ def main() -> None:
             if opts.loop_every <= 0:
                 raise
             else:
+                and_now = time.time()
+                LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
+                LAST_CYCLE_SUCCESSFUL.set(0)
                 logger.exception(
                     f"Failed to annotate.  Retrying in {opts.loop_every} seconds.  Traceback:"
                 )

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -38,6 +38,10 @@ from util import version_name, conventional_logging, sha256sum_http_response
 from watchdog import Watchdog
 
 
+LAST_CYCLE_END_TIMESTAMP_SECONDS = Gauge(
+    "last_cycle_end_timestamp_seconds",
+    "The UNIX timestamp of the last cycle that completed",
+)
 LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS = Gauge(
     "last_cycle_success_timestamp_seconds",
     "The UNIX timestamp of the last cycle that completed successfully",
@@ -547,7 +551,9 @@ def main() -> None:
             now = time.time()
             LAST_CYCLE_START_TIMESTAMP_SECONDS.set(int(now))
             reconciler.reconcile()
-            LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS.set(int(time.time()))
+            and_now = time.time()
+            LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS.set(int(and_now))
+            LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
             LAST_CYCLE_SUCCESSFUL.set(1)
             watchdog.report_healthy()
             if opts.loop_every <= 0:
@@ -563,6 +569,8 @@ def main() -> None:
             if opts.loop_every <= 0:
                 raise
             else:
+                and_now = time.time()
+                LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
                 LAST_CYCLE_SUCCESSFUL.set(0)
                 LOGGER.exception(
                     f"Failed to reconcile.  Retrying in {opts.loop_every} seconds.  Traceback:"


### PR DESCRIPTION
This commit adds a new Prometheus Gauge metric `last_cycle_end_timestamp_seconds` to track the UNIX timestamp of the last cycle that completed, so that we can reliably detect stalled conditions separately from failures.

A companion PR to reform the alerts is coming.