### PR TITLE
Change log level of CODEOWNERS parsing to debug

### DIFF
--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -217,7 +217,7 @@ def parse_codeowners(
             filtered = [line for line in filtered if line and not line.startswith("#")]
             parsed = {}
             for line in filtered:
-                _LOGGER.info("Parsing CODEOWNERS, line: %s" % line)
+                _LOGGER.debug("Parsing CODEOWNERS, line: %s" % line)
                 result = line.split()
                 if len(result) <= 1:
                     continue


### PR DESCRIPTION
This commit updates the log level from info to debug for lines parsed from the CODEOWNERS file during the release notes generation process. This change may provide more detailed output for troubleshooting purposes, without affecting the primary functionality of the system.