### PR TITLE
Update k8s deployments action to use push-token and create PR

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -149,7 +149,7 @@ jobs:
         uses: ./.github/workflows/update-k8s-deployments
         with:
           push-token: ${{ secrets.K8S_API_TOKEN }}
-          component: container-images
+          component: containers
 
       ########################################
       # Clean up runner

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -148,7 +148,8 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
-          github_api_token: ${{ secrets.K8S_API_TOKEN }}
+          push-token: ${{ secrets.K8S_API_TOKEN }}
+          component: container-images
 
       ########################################
       # Clean up runner

--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -44,7 +44,7 @@ runs:
         # this regex matches the first group (ie the image name) and uses \1
         # called a back-reference to insert the first group matched, the second
         # part is to match the 40 characters hash that we replace with the $GITHUB_SHA
-        prev_commit=$(sed -rn 's~(.*)'"(.*):"'([a-f0-9]{40}).*~\3~p' $files | head -1)
+        prev_commit=$(sed -rn 's~(.*)'"(.*):"'([a-f0-9]{40}).*~\3~p' $files | head -n 1)
         sed -i "s~\(\([[:alpha:]]\|-\)\+\):[[:alnum:]]\{40\}~\1:${GITHUB_SHA}~g" $files
 
         # commit changes if there are any

--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -44,6 +44,7 @@ runs:
         # this regex matches the first group (ie the image name) and uses \1
         # called a back-reference to insert the first group matched, the second
         # part is to match the 40 characters hash that we replace with the $GITHUB_SHA
+        prev_commit=$(sed -rn 's~(.*)'"(.*):"'([a-f0-9]{40}).*~\3~p' $files | head -1)
         sed -i "s~\(\([[:alpha:]]\|-\)\+\):[[:alnum:]]\{40\}~\1:${GITHUB_SHA}~g" $files
 
         # commit changes if there are any

--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -2,36 +2,42 @@ name: Update k8s deployments
 description: Reusable action for updating k8s deployments
 
 inputs:
-  github_api_token:
-    description: "A Github API token with access to the k8s repository"
+  push-token:
+    description: "The Github token needed to create PRs"
+    required: true
+  component:
+    description: "Which component to update"
     required: true
 
 runs:
   using: composite
   steps:
-    - name: "☸️ Update k8s deployments"
-      id: "update_k8s"
+    - name: Check out k8s repository
+      uses: actions/checkout@v4
+      with:
+        repository: dfinity-ops/k8s
+        token: ${{ inputs.push-token }}
+        ref: main
+        fetch-depth: 10
+        path: k8s
+    - name: "Create rollout commit with updated container images"
+      id: "create-rollout-commit"
       env:
-        GITHUB_API_TOKEN: ${{ inputs.github_api_token }}
+        PUSH_TOKEN: ${{ inputs.push-token }}
       shell: bash
       run: |
-        set -eExou pipefail
+        set -eExu -o pipefail
 
         # List of files can be update in
         # .github/workflows/main.yaml
         echo "Should change following files:"
         echo $files
-
-        cd .git
-
-        # checkout branch
-        git clone --depth 10 --branch "main" "https://${GITHUB_API_TOKEN}@github.com/dfinity-ops/k8s.git"
-
         cd k8s
+
         git config user.email "idx@dfinity.org"
         git config user.name "IDX Automation"
-        DRE_REPO_BRANCH="${{ github.head_ref || github.ref_name }}"
-        K8S_REPO_BRANCH="update-dre-images-$DRE_REPO_BRANCH"
+        SOURCE_BRANCH="${{ github.head_ref || github.ref_name }}"
+        K8S_REPO_BRANCH="update-$( basename $GITHUB_REPOSITORY)-$COMPONENT-images-from-$SOURCE_BRANCH"
         git checkout -b "${K8S_REPO_BRANCH}"
 
         # Update the internal dashboard image refs
@@ -48,26 +54,56 @@ runs:
         fi
 
         # Push changes and create a new merge request
-        git commit -m "Updating DRE container images from $DRE_REPO_BRANCH branch"
+        git commit -m "New $COMPONENT release from $SOURCE_BRANCH branch"
         git push \
           --force --set-upstream origin "${K8S_REPO_BRANCH}" || \
           git push --force --set-upstream origin "${K8S_REPO_BRANCH}"
 
         echo "k8s_branch=$K8S_REPO_BRANCH" >> $GITHUB_OUTPUT
-        echo "dre_branch=$DRE_REPO_BRANCH" >> $GITHUB_OUTPUT
-
-    - name: "Create mr on k8s repo"
-      if: ${{ steps.update_k8s.outputs.k8s_branch != '' }}
+        echo "source_branch=$SOURCE_BRANCH" >> $GITHUB_OUTPUT
+        echo "previous_ref=$prev_commit" >> $GITHUB_OUTPUT
+        echo "current_ref=$GITHUB_SHA" >> $GITHUB_OUTPUT
+    - name: "Create PR to roll out with updated container images"
+      id: create-rollout-pr
+      if: ${{ steps.create-rollout-commit.outputs.k8s_branch != '' }}
       uses: actions/github-script@v7
-      continue-on-error: true
       with:
-        github-token: ${{ inputs.github_api_token }}
+        github-token: ${{ inputs.push-token }}
         script: |
-          const result = await github.rest.pulls.create({
-            title: '[nomrbot] - Updating DRE container images',
-            owner: 'dfinity-ops',
-            repo: 'k8s',
-            head: '${{ steps.update_k8s.outputs.k8s_branch }}',
-            base: 'main',
-            body: 'Updating the DRE container images based on the latest changes in the DRE repository - [here](https://github.com/dfinity/dre/commits/${{ steps.update_k8s.outputs.dre_branch }})'
+          const owner = 'dfinity-ops';
+          const repo = 'k8s';
+          const base = 'main';
+          const head = '${{ steps.create-rollout-commit.outputs.k8s_branch }}';
+          const title = 'Rollout of ${{ inputs.component }} from ${{ github.repository }}@${{ github.head_ref || github.ref_name }}';
+          const pulls = await github.rest.pulls.list({
+            owner: owner,
+            repo: repo,
+            base: base,
+            state: 'open'
           });
+          const pulldata = pulls.data.filter((pull) => pull.title == title);
+          if (pulldata.length > 0) {
+            console.log("Existing PRs:");
+            console.log(pulldata);
+            var result = await github.rest.pulls.update({
+              owner: owner,
+              repo: repo,
+              pull_number: pulldata[0].number,
+              body: 'Updating container images to incorporate [these changes](https://github.com/${{ github.repository }}/compare/${{ steps.create-rollout-commit.outputs.previous_ref }}..${{ steps.create-rollout-commit.outputs.current_ref }}).',
+            });
+            console.log("Updated pull request " + pulldata[0].number);
+            return result;
+          } else {
+            var result = await github.rest.pulls.create({
+              title: title,
+              owner: owner,
+              repo: repo,
+              head: head,
+              base: base,
+              maintainer_can_modify: true,
+              body: 'Updating container images to incorporate [these changes](https://github.com/${{ github.repository }}/compare/${{ steps.create-rollout-commit.outputs.previous_ref }}..${{ steps.create-rollout-commit.outputs.current_ref }}).'
+            });
+            console.log("Created pull request:");
+            console.log(result);
+            return result;
+          }

--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -37,7 +37,7 @@ runs:
         git config user.email "idx@dfinity.org"
         git config user.name "IDX Automation"
         SOURCE_BRANCH="${{ github.head_ref || github.ref_name }}"
-        K8S_REPO_BRANCH="update-$( basename $GITHUB_REPOSITORY)-$COMPONENT-images-from-$SOURCE_BRANCH"
+        K8S_REPO_BRANCH="update-$(basename $GITHUB_REPOSITORY)-$COMPONENT-images-from-$SOURCE_BRANCH"
         git checkout -b "${K8S_REPO_BRANCH}"
 
         # Update the internal dashboard image refs


### PR DESCRIPTION
Updated the GitHub workflow for updating k8s deployments.
- Renamed input from 'github_api_token' to 'push-token'.
- Added step to check out the k8s repository using the 'actions/checkout@v4' action.
- Updated the commit message and PR title to include component information.
- Implemented logic to update or create a pull request based on existing PRs.

I will shut off any possible rollout PRs created by this merge, as they will tno be necessary.