### PR TITLE
Release controller rollout cadence separate from other containers.

### DIFF
--- a/.github/workflows/check-modified-files-as-step/action.yaml
+++ b/.github/workflows/check-modified-files-as-step/action.yaml
@@ -3,7 +3,7 @@ description: Reusable action for checking if a file path is modified as a step. 
 
 inputs:
   path:
-    description: 'Path to check'
+    description: "Path to check"
     required: true
 
 runs:
@@ -13,7 +13,7 @@ runs:
     # Check to see if files changed
     ########################################
     - name: "🔍 Check if $PATH_TO_CHECK is modified in last commit "
-      env: 
+      env:
         PATH_TO_CHECK: ${{ inputs.path }}
       shell: bash
       run: |
@@ -21,7 +21,7 @@ runs:
 
         echo "=============== list modified files ==============="
         git diff --name-only HEAD^ HEAD
-        
+
         echo "========== check paths of modified files =========="
         git diff --name-only HEAD^ HEAD > files.txt
         while IFS= read -r file
@@ -29,9 +29,11 @@ runs:
         echo $file
         if [[ $file != $PATH_TO_CHECK ]]; then
           echo "changed=false" >> $GITHUB_ENV
+          echo "changed=false" >> $GITHUB_OUTPUT
         else
           echo "File $file matches $PATH_TO_CHECK"
           echo "changed=true" >> $GITHUB_ENV
+          echo "changed=true" >> $GITHUB_OUTPUT
           break
         fi
         done < files.txt

--- a/.github/workflows/check-modified-files-as-step/action.yaml
+++ b/.github/workflows/check-modified-files-as-step/action.yaml
@@ -28,12 +28,10 @@ runs:
         do
         echo $file
         if [[ $file != $PATH_TO_CHECK ]]; then
-          echo "changed=false" >> $GITHUB_ENV
-          echo "changed=false" >> $GITHUB_OUTPUT
+          echo "changed=false" > $GITHUB_OUTPUT
         else
           echo "File $file matches $PATH_TO_CHECK"
-          echo "changed=true" >> $GITHUB_ENV
-          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "changed=true" > $GITHUB_OUTPUT
           break
         fi
         done < files.txt

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -108,13 +108,17 @@ jobs:
         with:
           path: dashboard/*
 
+      - name: "❓ Check if release-controller/* changed in last commit"
+        id: check-release-controller-modified
+        uses: ./.github/workflows/check-modified-files-as-step
+        with:
+          path: release-controller/*
+
       - name: "💲 Setting correct paths to update"
         id: paths
         shell: bash
         run: |
           files=(
-            bases/apps/ic-release-controller/controller/controller.yaml
-            bases/apps/ic-release-controller/commit-annotator/commit-annotator.yaml
             bases/apps/mainnet-dashboard/backend/base/deployment.yaml
             bases/apps/mainnet-dashboard/statefulset-slack.yaml
             bases/apps/service-discovery/service-discovery.yaml
@@ -130,6 +134,7 @@ jobs:
           echo "Output of this step:"
           echo ${files[@]}
           echo "files=${files[@]}" >> $GITHUB_ENV
+          echo "files=${files[@]}" >> $GITHUB_OUTPUT
 
       ########################################
       # Deploy to github pages
@@ -148,8 +153,17 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
+          files-to-update: ${{ steps.paths.outputs.files }}
           push-token: ${{ secrets.K8S_API_TOKEN }}
           component: containers
+
+      - name: "🤖 Update k8s deployments for release controller"
+        if: ${{ github.ref == 'refs/heads/main' && steps.check-release-controller-modified.outputs.changed == 'true' }}
+        uses: ./.github/workflows/update-k8s-deployments
+        with:
+          files-to-update: bases/apps/ic-release-controller/controller/controller.yaml bases/apps/ic-release-controller/commit-annotator/commit-annotator.yaml
+          push-token: ${{ secrets.K8S_API_TOKEN }}
+          component: release controller
 
       ########################################
       # Clean up runner

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,7 +103,7 @@ jobs:
       # it also needs to be updated in k8s
       ########################################
       - name: "❓ Check if dashboard/* changed in last commit"
-        id: check
+        id: check-dashboard-frontend-modified
         uses: ./.github/workflows/check-modified-files-as-step
         with:
           path: dashboard/*
@@ -117,6 +117,8 @@ jobs:
       - name: "💲 Setting correct paths to update"
         id: paths
         shell: bash
+        env:
+          FRONTEND_CHANGED: ${{ steps.check-dashboard-frontend-modified.outputs.changed }}
         run: |
           files=(
             bases/apps/mainnet-dashboard/backend/base/deployment.yaml
@@ -124,7 +126,7 @@ jobs:
             bases/apps/service-discovery/service-discovery.yaml
             .github/workflows/dre-vector-configs.yaml
           )
-          if [[ $changed == "true" ]]; then
+          if [[ "$FRONTEND_CHANGED" == "true" ]]; then
             echo "Adding frontend to list of files"
             files+=( bases/apps/mainnet-dashboard/frontend/deployment.yaml )
           else

--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -2,6 +2,9 @@ name: Update k8s deployments
 description: Reusable action for updating k8s deployments
 
 inputs:
+  files-to-update:
+    description: "A space-separated list of files to update"
+    required: true
   push-token:
     description: "The Github token needed to create PRs"
     required: true
@@ -24,6 +27,7 @@ runs:
       id: "create-rollout-commit"
       env:
         PUSH_TOKEN: ${{ inputs.push-token }}
+        FILES_TO_UPDATE: ${{ inputs.files-to-update }}
         COMPONENT: ${{ inputs.component }}
       shell: bash
       run: |
@@ -31,8 +35,8 @@ runs:
 
         # List of files can be update in
         # .github/workflows/main.yaml
-        echo "Should change following files:"
-        echo $files
+        echo "Should change following files:" >&2
+        echo $FILES_TO_UPDATE >&2
         cd k8s
 
         git config user.email "idx@dfinity.org"
@@ -45,8 +49,8 @@ runs:
         # this regex matches the first group (ie the image name) and uses \1
         # called a back-reference to insert the first group matched, the second
         # part is to match the 40 characters hash that we replace with the $GITHUB_SHA
-        prev_commit=$(sed -rn 's~(.*)'"(.*):"'([a-f0-9]{40}).*~\3~p' $files | head -n 1)
-        sed -i "s~\(\([[:alpha:]]\|-\)\+\):[[:alnum:]]\{40\}~\1:${GITHUB_SHA}~g" $files
+        prev_commit=$(sed -rn 's~(.*)'"(.*):"'([a-f0-9]{40}).*~\3~p' $FILES_TO_UPDATE | head -n 1)
+        sed -i "s~\(\([[:alpha:]]\|-\)\+\):[[:alnum:]]\{40\}~\1:${GITHUB_SHA}~g" $FILES_TO_UPDATE
 
         # commit changes if there are any
         git add .


### PR DESCRIPTION
We use (and enhance) an existing trick to dynamically detect if the release controller needs to be updated, and if it does, then we run the necessary k8s action — a new, separately-invoked update-k8s-deployment action just for release controller and commit annotator.

In the existing update-k8s-deployment action invocation, we delete the release controller manifest files that were formerly edited by it.

Finally, the detection of changes between commits gains outputs to be used later on, which is easier to reason about than $GITHUB_ENV.