### PR TITLE
Path checking for multiple glob patterns, and container rollout link in job summary.

### DIFF
--- a/.github/workflows/check-modified-files-as-step/action.yaml
+++ b/.github/workflows/check-modified-files-as-step/action.yaml
@@ -3,8 +3,12 @@ description: Reusable action for checking if a file path is modified as a step. 
 
 inputs:
   path:
-    description: "Path to check"
+    description: "Path to check -- can be a space-separated list of bash [[]]-compatible globs"
     required: true
+outputs:
+  changed:
+    description: "Whether any of the files matching the globs specified changed between the base and the head commit"
+    value: ${{ steps.check-changed.outputs.changed }}
 
 runs:
   using: composite
@@ -12,26 +16,37 @@ runs:
     ########################################
     # Check to see if files changed
     ########################################
-    - name: "🔍 Check if $PATH_TO_CHECK is modified in last commit "
+    - name: "🔍 Check whether $PATH_TO_CHECK were modified in between the commit range"
+      id: check-changed
       env:
         PATH_TO_CHECK: ${{ inputs.path }}
       shell: bash
       run: |
-        set -eExou pipefail
+        set -eEou pipefail
 
-        echo "=============== list modified files ==============="
-        git diff --name-only HEAD^ HEAD
-
-        echo "========== check paths of modified files =========="
-        git diff --name-only HEAD^ HEAD > files.txt
+        if [[ -v GITHUB_BASE_REF ]]
+        then
+          base=$GITHUB_BASE_REF
+          src=origin/"$base"
+        else
+          base=${{ github.event.before }}
+          src="$base"
+        fi
+        git fetch origin $base
+        git diff --name-only "$src" "$GITHUB_SHA" > files.txt
+        echo "=============== list modified files ===============" >&2
+        cat files.txt >&2
         while IFS= read -r file
         do
-        echo $file
-        if [[ $file != $PATH_TO_CHECK ]]; then
-          echo "changed=false" > $GITHUB_OUTPUT
-        else
-          echo "File $file matches $PATH_TO_CHECK"
-          echo "changed=true" > $GITHUB_OUTPUT
-          break
-        fi
+          set -f # turn off globbing for what I am about to do
+          for subpath_to_check in $PATH_TO_CHECK
+          do
+            if [[ $file = $subpath_to_check ]]; then
+              echo "File $file matching $subpath_to_check changed between $base and $GITHUB_SHA." >> "$GITHUB_STEP_SUMMARY"
+              echo "changed=true" >> $GITHUB_OUTPUT
+              exit
+            fi
+          done
         done < files.txt
+        echo "No files changed between $base and $GITHUB_SHA." >> "$GITHUB_STEP_SUMMARY"
+        echo "changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,6 +78,7 @@ jobs:
       ########################################
       # Upload test artifacts
       ########################################
+
       - name: "🧪 Upload test artifacts"
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v4
@@ -98,21 +99,17 @@ jobs:
         if: ${{ startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
         run: bazel query --noshow_progress 'kind("oci_push", ...)' | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}
 
-      ########################################
-      # Check if dashboard/* changed to see if
-      # it also needs to be updated in k8s
-      ########################################
       - name: "❓ Check if dashboard/* changed in last commit"
         id: check-dashboard-frontend-modified
         uses: ./.github/workflows/check-modified-files-as-step
         with:
           path: dashboard/*
 
-      - name: "❓ Check if release-controller/* changed in last commit"
+      - name: "❓ Check if files that influence release controller changed in last commit"
         id: check-release-controller-modified
         uses: ./.github/workflows/check-modified-files-as-step
         with:
-          path: release-controller/*
+          path: release-controller/* requirements*.lock pyproject.toml *.bazel .github/*
 
       - name: "💲 Setting correct paths to update"
         id: paths
@@ -132,10 +129,6 @@ jobs:
           else
             echo "Skipping adding of frontend to list of files"
           fi
-
-          echo "Output of this step:"
-          echo ${files[@]}
-          echo "files=${files[@]}" >> $GITHUB_ENV
           echo "files=${files[@]}" >> $GITHUB_OUTPUT
 
       ########################################

--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -42,7 +42,7 @@ runs:
         git config user.email "idx@dfinity.org"
         git config user.name "IDX Automation"
         SOURCE_BRANCH="${{ github.head_ref || github.ref_name }}"
-        K8S_REPO_BRANCH="update-$(basename $GITHUB_REPOSITORY)-$COMPONENT-images-from-$SOURCE_BRANCH"
+        K8S_REPO_BRANCH="$( echo "update-$(basename $GITHUB_REPOSITORY)-$COMPONENT-images-from-$SOURCE_BRANCH" | tr -cd '[:alnum:]._-' )"
         git checkout -b "${K8S_REPO_BRANCH}"
 
         # Update the internal dashboard image refs
@@ -98,6 +98,9 @@ runs:
               body: 'Updating container images to incorporate [these changes](https://github.com/${{ github.repository }}/compare/${{ steps.create-rollout-commit.outputs.previous_ref }}..${{ steps.create-rollout-commit.outputs.current_ref }}).',
             });
             console.log("Updated pull request " + pulldata[0].number);
+            await core.summary
+              .addLink('Pull request to roll out ${{ inputs.component }} updated.', 'https://github.com/dfinity-ops/k8s/pull/' + pulldata[0].number)
+              .write()
             return result;
           } else {
             var result = await github.rest.pulls.create({
@@ -111,5 +114,8 @@ runs:
             });
             console.log("Created pull request:");
             console.log(result);
+            await core.summary
+              .addLink('Pull request to roll out ${{ inputs.component }} created.', 'https://github.com/dfinity-ops/k8s/pull/' + result.data.number)
+              .write()
             return result;
           }

--- a/.github/workflows/update-k8s-deployments/action.yaml
+++ b/.github/workflows/update-k8s-deployments/action.yaml
@@ -21,7 +21,7 @@ runs:
         repository: dfinity-ops/k8s
         token: ${{ inputs.push-token }}
         ref: main
-        fetch-depth: 10
+        fetch-depth: 2
         path: k8s
     - name: "Create rollout commit with updated container images"
       id: "create-rollout-commit"
@@ -100,7 +100,7 @@ runs:
             console.log("Updated pull request " + pulldata[0].number);
             await core.summary
               .addLink('Pull request to roll out ${{ inputs.component }} updated.', 'https://github.com/dfinity-ops/k8s/pull/' + pulldata[0].number)
-              .write()
+              .write();
             return result;
           } else {
             var result = await github.rest.pulls.create({
@@ -116,6 +116,6 @@ runs:
             console.log(result);
             await core.summary
               .addLink('Pull request to roll out ${{ inputs.component }} created.', 'https://github.com/dfinity-ops/k8s/pull/' + result.data.number)
-              .write()
+              .write();
             return result;
           }


### PR DESCRIPTION
This update allows the action to handle space-separated lists of bash [[]]-compatible globs for path checking.

The modified script iterates over each file in the diff and checks it against each pattern, updating the output accordingly.

Globbing is turned off so the second-nested for loop won't get globbing to interfere with it.

As a further enhancement, now the workflow step checks for a diff range rather than just the last commit.  This makes the file modification checker work in many more and varied scenarios.

Finally, the Github workflow job summary feature looks like this:

![image](https://github.com/user-attachments/assets/56f25012-c918-40fd-bdc2-562bf1801638)
