### PR TITLE
Revert "Log the standard output of Bazel in debugging mode, to diagnose if there were unexpected output issues during the Bazel execution. (#1413)"

### DIFF
--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -94,18 +94,14 @@ def annotate_object(ic_repo: GitRepoAnnotator, object: str) -> None:
         ],
         text=True,
         cwd=ic_repo.dir,
-    )
-    logger.debug(
-        f"stdout of bazel query deps({GUESTOS_BAZEL_TARGETS}) for {object}: %s",
-        bazel_query_output.rstrip(),
-    )
+    ).splitlines()
     ic_repo.add(
         object=object,
         namespace=GUESTOS_TARGETS_NOTES_NAMESPACE,
         content="\n".join(
             [
                 line
-                for line in bazel_query_output.splitlines()
+                for line in bazel_query_output
                 if line.strip() and not line.startswith("@")
             ]
         ),


### PR DESCRIPTION
This reverts commit 4d9335b438b9e62d8c4db14bc03db8483942d1e7.

Said commit is no longer necessary and it litters the debugging output unnecessarily.