### PR TITLE
Commit annotator: speed up target determination somewhat

### DIFF
--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -1,6 +1,8 @@
 import argparse
+import concurrent.futures
 import logging
 import os
+import pathlib
 import subprocess
 import sys
 import re
@@ -59,10 +61,8 @@ def release_branch_date(branch: str) -> typing.Optional[datetime]:
     retry=retry_if_exception_type(subprocess.CalledProcessError),
     after=after_log(_LOGGER, logging.ERROR),
 )
-def target_determinator(ic_repo: GitRepoAnnotator, object: str) -> bool:
-    logger = _LOGGER.getChild("target_determinator").getChild(object)
-    logger.debug("Attempting to determine target")
-    ic_repo.checkout(object)
+def target_determinator(cwd: pathlib.Path, parent_object: str) -> bool:
+    logger = _LOGGER.getChild("target_determinator").getChild(parent_object)
     p = subprocess.run(
         [
             resolve_binary("target-determinator"),
@@ -70,38 +70,56 @@ def target_determinator(ic_repo: GitRepoAnnotator, object: str) -> bool:
             f"-bazel={resolve_binary("bazel")}",
             "--targets",
             GUESTOS_BAZEL_TARGETS,
-            ic_repo.parent(object),
+            parent_object,
         ],
-        cwd=ic_repo.dir,
+        cwd=cwd,
         check=True,
         stdout=subprocess.PIPE,
+        text=True,
     )
-    output = p.stdout.decode().strip()
-    logger.debug(f"stdout of target determinator for {object}: %s", output)
+    output = p.stdout.strip()
+    logger.debug(
+        f"stdout of target determinator for {parent_object}: %s",
+        output,
+    )
     return output != ""
 
 
 def annotate_object(ic_repo: GitRepoAnnotator, object: str) -> None:
     logger = _LOGGER.getChild("annotate_object").getChild(object)
     logger.debug("Attempting to annotate")
+    start = time.time()
     ic_repo.checkout(object)
-    logger.debug("Running bazel query")
-    bazel_query_output = subprocess.check_output(
-        [
-            resolve_binary("bazel"),
-            "query",
-            f"deps({GUESTOS_BAZEL_TARGETS})",
-        ],
-        text=True,
-        cwd=ic_repo.dir,
-    ).splitlines()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        logger.debug(f"Running bazel query deps({GUESTOS_BAZEL_TARGETS})")
+        bazel_query_output_future = executor.submit(
+            subprocess.check_output,
+            [
+                resolve_binary("bazel"),
+                "query",
+                f"deps({GUESTOS_BAZEL_TARGETS})",
+            ],
+            text=True,
+            cwd=ic_repo.dir,
+        )
+        target_determinator_future = executor.submit(
+            target_determinator, ic_repo.dir, ic_repo.parent(object)
+        )
+        bazel_query_output = bazel_query_output_future.result()
+        lap = time.time() - start
+        logger.debug("Bazel query finished in %.2f seconds", lap)
+        target_determinator_output = target_determinator_future.result()
+        lap = time.time() - start
+        logger.debug("Target determinator finished in %.2f seconds", lap)
+
     ic_repo.add(
         object=object,
         namespace=GUESTOS_TARGETS_NOTES_NAMESPACE,
         content="\n".join(
             [
                 line
-                for line in bazel_query_output
+                for line in bazel_query_output.splitlines()
                 if line.strip() and not line.startswith("@")
             ]
         ),
@@ -109,8 +127,10 @@ def annotate_object(ic_repo: GitRepoAnnotator, object: str) -> None:
     ic_repo.add(
         object=object,
         namespace=GUESTOS_CHANGED_NOTES_NAMESPACE,
-        content=str(target_determinator(ic_repo=ic_repo, object=object)),
+        content=str(target_determinator_output),
     )
+    lap = time.time() - start
+    logger.debug("Annotation finished in %.2f seconds", lap)
 
 
 def annotate_branch(annotator: GitRepoAnnotator, branch: str) -> None:


### PR DESCRIPTION
Prior to this PR, commit annotator was executing the bazel cquery and the target determination processes as sequential operations, each of which checked out a commit -- so every commit was checked out twice.

There is no implicit sequential dependency between the two, though.  Thus, this change makes commit annotator check out the commit only once, and make the target determination run in parallel with the bazel cquery, using the same local checkout in both cases.

This provides a measurable speedup primarily due to a reduction in disk access waste, but also due to the fact that now more cores can be active churning results.  A couple of seconds saved per commit means a couple minutes saved in anything beyond 30 commits to annotate.