### PR TITLE
Speed up Bazel upload of containers when release controller has not been modified

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,10 +103,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "📦 Push images to GitHub Container Registry"
         if: ${{ startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
+        env:
+          RELEASE_CONTROLLER_CHANGED: ${{ steps.check-release-controller-modified.outputs.changed }}
         run: |
           set -ex -o pipefail
           oci_targets=$(bazel query --noshow_progress 'kind("oci_push", ...)')
-          if [ "{{ steps.check-release-controller-modified.outputs.changed }}" != "true" ]
+          if [ "$RELEASE_CONTROLLER_CHANGED" != "true" ]
           then
             # Oh, not changed?  Then skip pushing the release controller container images.
             oci_targets=$(echo "$oci_targets" | grep -v //release-controller)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,6 +86,12 @@ jobs:
           name: test-artifacts
           path: bazel-out/k8-opt/bin/rs/ic-observability/multiservice-discovery/multiservice-discovery
 
+      - name: "❓ Check if files that influence release controller changed in last commit"
+        id: check-release-controller-modified
+        uses: ./.github/workflows/check-modified-files-as-step
+        with:
+          path: release-controller/* requirements*.lock pyproject.toml *.bazel .github/*
+
       ########################################
       # Upload container images
       ########################################
@@ -97,19 +103,21 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "📦 Push images to GitHub Container Registry"
         if: ${{ startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
-        run: bazel query --noshow_progress 'kind("oci_push", ...)' | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}
+        run: |
+          set -ex -o pipefail
+          oci_targets=$(bazel query --noshow_progress 'kind("oci_push", ...)')
+          if [ "{{ steps.check-release-controller-modified.outputs.changed }}" != "true" ]
+          then
+            # Oh, not changed?  Then skip pushing the release controller container images.
+            oci_targets=$(echo "$oci_targets" | grep -v //release-controller)
+          fi
+          echo "$oci_targets" | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}
 
       - name: "❓ Check if dashboard/* changed in last commit"
         id: check-dashboard-frontend-modified
         uses: ./.github/workflows/check-modified-files-as-step
         with:
           path: dashboard/*
-
-      - name: "❓ Check if files that influence release controller changed in last commit"
-        id: check-release-controller-modified
-        uses: ./.github/workflows/check-modified-files-as-step
-        with:
-          path: release-controller/* requirements*.lock pyproject.toml *.bazel .github/*
 
       - name: "💲 Setting correct paths to update"
         id: paths


### PR DESCRIPTION
The baseline timings are 52 seconds for container pushes.  I hope this will shave 10 to 20 seconds with this concession.  Of course, we will only know for sure once something is merged to `main` that does not involve editing .github or Bazel files.

While it would probably be prudent to do target detection with Bazel, this detection is already in effect, so let's reuse it to speed up the process.