### PR TITLE
NPR Canister: Store DailyNodeMetrics directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,7 +3186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3198,7 +3198,7 @@ version = "0.17.1"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3238,7 +3238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3251,7 +3251,7 @@ version = "0.11.0"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3710,9 +3710,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-icrc1",
  "ic-icrc1-tokens-u64",
@@ -3739,9 +3739,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certification 3.0.2",
  "ic-crypto-tree-hash",
  "ic-icrc1",
@@ -3851,7 +3851,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -4184,7 +4184,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "candid",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -4217,7 +4217,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -4236,7 +4236,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4254,7 +4254,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4265,7 +4265,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -4277,7 +4277,7 @@ name = "ic-nervous-system-timers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk-timers 0.11.0",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slotmap",
 ]
 
@@ -4310,7 +4310,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nns-constants",
@@ -4353,9 +4353,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
  "ic-ledger-core",
@@ -4472,7 +4472,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -4528,7 +4528,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
  "ic-nns-common",
@@ -4805,9 +4805,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
  "ic-ledger-core",
@@ -4907,7 +4907,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -4961,9 +4961,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
@@ -4992,9 +4992,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
@@ -5044,7 +5044,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5318,7 +5318,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -6158,7 +6158,7 @@ dependencies = [
  "candid",
  "chrono",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic-protobuf",
  "ic-types",
  "indexmap 2.8.0",
@@ -6179,9 +6179,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-timers 0.11.0 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic-interfaces-registry",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -7382,7 +7382,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",

--- a/rs/dre-canisters/node-provider-rewards/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/src/lib.rs
@@ -174,6 +174,7 @@ fn get_node_providers_xdr_rewards(args: RewardPeriodArgs) -> Result<RewardsPerNo
     let registry_store = REGISTRY_STORE.with(|m| m.clone());
 
     let daily_metrics_by_node = metrics_manager.daily_metrics_by_node(*reward_period.start_ts, *reward_period.end_ts);
+
     let rewards_table = registry_store.get_rewards_table();
     let rewardable_nodes = registry_store.get_rewardable_nodes(*reward_period.start_ts, *reward_period.end_ts);
 

--- a/rs/dre-canisters/node-provider-rewards/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/src/lib.rs
@@ -170,13 +170,16 @@ pub struct RewardPeriodArgs {
 #[candid_method(update)]
 fn get_node_providers_xdr_rewards(args: RewardPeriodArgs) -> Result<RewardsPerNodeProviderResponse, String> {
     let reward_period = RewardPeriod::new(args.start_ts, args.end_ts).map_err(|e| format!("Error creating period: {}", e))?;
+    let start_ts = reward_period.start_ts.get();
+    let end_ts = reward_period.end_ts.get();
+
     let metrics_manager = METRICS_MANAGER.with(|m| m.clone());
     let registry_store = REGISTRY_STORE.with(|m| m.clone());
 
-    let daily_metrics_by_node = metrics_manager.daily_metrics_by_node(*reward_period.start_ts, *reward_period.end_ts);
+    let daily_metrics_by_node = metrics_manager.daily_metrics_by_node(start_ts, end_ts);
 
     let rewards_table = registry_store.get_rewards_table();
-    let rewardable_nodes = registry_store.get_rewardable_nodes(*reward_period.start_ts, *reward_period.end_ts);
+    let rewardable_nodes = registry_store.get_rewardable_nodes(start_ts, end_ts);
 
     let rewards = calculate_rewards(&reward_period, &rewards_table, &daily_metrics_by_node, &rewardable_nodes)
         .map_err(|e| format!("Error calculating rewards: {}", e))?;

--- a/rs/dre-canisters/node-provider-rewards/src/metrics.rs
+++ b/rs/dre-canisters/node-provider-rewards/src/metrics.rs
@@ -1,4 +1,4 @@
-use crate::metrics_types::{KeyRange, StorableSubnetMetrics, StorableSubnetMetricsKey, SubnetIdStored, SubnetNodeMetricsDaily};
+use crate::metrics_types::{KeyRange, NodeMetricsDailyStored, SubnetIdStored, SubnetMetricsStoredKey, SubnetMetricsStoredValue};
 use async_trait::async_trait;
 use candid::Principal;
 use ic_base_types::{NodeId, SubnetId};
@@ -41,7 +41,7 @@ where
     Memory: ic_stable_structures::Memory,
 {
     pub(crate) client: Box<dyn ManagementCanisterClient>,
-    pub(crate) subnets_metrics: RefCell<StableBTreeMap<StorableSubnetMetricsKey, StorableSubnetMetrics, Memory>>,
+    pub(crate) subnets_metrics: RefCell<StableBTreeMap<SubnetMetricsStoredKey, SubnetMetricsStoredValue, Memory>>,
     pub(crate) subnets_to_retry: RefCell<StableBTreeMap<SubnetIdStored, RetryCount, Memory>>,
     pub(crate) last_timestamp_per_subnet: RefCell<StableBTreeMap<SubnetIdStored, TimestampNanos, Memory>>,
 }
@@ -51,7 +51,7 @@ where
     Memory: ic_stable_structures::Memory + 'static,
 {
     pub async fn retry_failed_subnets(&self) {
-        let subnets_to_retry: Vec<SubnetId> = self.subnets_to_retry.borrow().keys().map(|key| *key).collect();
+        let subnets_to_retry: Vec<SubnetId> = self.subnets_to_retry.borrow().keys().map(|key| key.0).collect();
 
         if !subnets_to_retry.is_empty() {
             ic_cdk::println!("Retrying metrics for subnets: {:?}", subnets_to_retry);
@@ -60,32 +60,40 @@ where
     }
 
     /// Update the daily metrics for each node in the subnet.
-    fn update_nodes_metrics_daily(&self, subnet_id: SubnetId, is_new_subnet: bool, mut subnet_updates_daily: Vec<NodeMetricsHistoryResponse>) {
+    fn update_nodes_metrics_daily(
+        &self,
+        subnet_id: SubnetId,
+        last_stored_ts: Option<TimestampNanos>,
+        mut subnet_update: Vec<NodeMetricsHistoryResponse>,
+    ) {
         // Extract initial total metrics for each node in the subnet.
         let mut initial_total_metrics_per_node: HashMap<_, _> = HashMap::new();
 
-        if !is_new_subnet {
-            initial_total_metrics_per_node = subnet_updates_daily
-                .remove(0)
-                .node_metrics
-                .iter()
-                .map(|node_metrics| {
-                    (
-                        node_metrics.node_id,
-                        (node_metrics.num_blocks_proposed_total, node_metrics.num_block_failures_total),
-                    )
-                })
-                .collect()
+        subnet_update.sort_by_key(|metrics| metrics.timestamp_nanos);
+        if let Some(first_metrics) = subnet_update.first() {
+            if Some(first_metrics.timestamp_nanos) == last_stored_ts {
+                initial_total_metrics_per_node = subnet_update
+                    .remove(0)
+                    .node_metrics
+                    .iter()
+                    .map(|node_metrics| {
+                        (
+                            node_metrics.node_id,
+                            (node_metrics.num_blocks_proposed_total, node_metrics.num_block_failures_total),
+                        )
+                    })
+                    .collect();
+            }
         };
 
         let mut running_total_metrics_per_node = initial_total_metrics_per_node;
-        for one_day_subnet_update in subnet_updates_daily {
-            let key = StorableSubnetMetricsKey {
+        for one_day_update in subnet_update {
+            let key = SubnetMetricsStoredKey {
                 subnet_id,
-                timestamp_nanos: one_day_subnet_update.timestamp_nanos,
+                timestamp_nanos: one_day_update.timestamp_nanos,
             };
 
-            let daily_nodes_metrics = one_day_subnet_update
+            let daily_nodes_metrics = one_day_update
                 .node_metrics
                 .into_iter()
                 .map(|node_metrics| {
@@ -94,9 +102,7 @@ where
 
                     let (mut running_proposed_total, mut running_failed_total) = running_total_metrics_per_node
                         .remove(&node_metrics.node_id)
-                        // Default is needed if:
-                        //  1- the node joined the subnet after last_stored_ts.
-                        //  2- the subnet has never been stored.
+                        // Default is needed if the node joined the subnet after last_stored_ts.
                         .unwrap_or_default();
 
                     // This can happen if the node was redeployed.
@@ -108,7 +114,7 @@ where
                     // Update the total metrics for the next iteration.
                     running_total_metrics_per_node.insert(node_metrics.node_id, (current_proposed_total, current_failed_total));
 
-                    SubnetNodeMetricsDaily {
+                    NodeMetricsDailyStored {
                         node_id: node_metrics.node_id.into(),
                         num_blocks_proposed: current_proposed_total - running_proposed_total,
                         num_blocks_failed: current_failed_total - running_failed_total,
@@ -116,32 +122,35 @@ where
                 })
                 .collect();
 
-            self.subnets_metrics.borrow_mut().insert(key, StorableSubnetMetrics(daily_nodes_metrics));
+            self.subnets_metrics
+                .borrow_mut()
+                .insert(key, SubnetMetricsStoredValue(daily_nodes_metrics));
         }
     }
 
     /// Fetches subnets metrics for the specified subnets from their last timestamp.
     async fn fetch_subnets_metrics(
         &self,
-        last_timestamp_per_subnet: &BTreeMap<SubnetId, TimestampNanos>,
-    ) -> BTreeMap<SubnetId, CallResult<(Vec<NodeMetricsHistoryResponse>,)>> {
+        last_timestamp_per_subnet: &BTreeMap<SubnetId, Option<TimestampNanos>>,
+    ) -> BTreeMap<(SubnetId, Option<TimestampNanos>), CallResult<(Vec<NodeMetricsHistoryResponse>,)>> {
         let mut subnets_history = Vec::new();
 
         for (subnet_id, last_stored_ts) in last_timestamp_per_subnet {
+            let refresh_ts = last_stored_ts.unwrap_or_default();
             // For nodes assigned to the subnet before the current update, the TOTAL metrics at last_stored_ts
             // are required since only DAILY metrics for each node are stored.
             ic_cdk::println!(
                 "Updating node metrics for subnet {}: Refreshing metrics from timestamp {}",
                 subnet_id,
-                last_stored_ts
+                refresh_ts
             );
 
             let contract = NodeMetricsHistoryArgs {
                 subnet_id: subnet_id.get(),
-                start_at_timestamp_nanos: *last_stored_ts,
+                start_at_timestamp_nanos: refresh_ts,
             };
 
-            subnets_history.push(async move { (*subnet_id, self.client.node_metrics_history(contract).await) });
+            subnets_history.push(async move { ((*subnet_id, *last_stored_ts), self.client.node_metrics_history(contract).await) });
         }
 
         futures::future::join_all(subnets_history).await.into_iter().collect()
@@ -152,41 +161,29 @@ where
     /// This function fetches the nodes metrics for the given subnets from the management canisters
     /// updating the local metrics with the fetched metrics.
     pub async fn update_subnets_metrics(&self, subnets: Vec<SubnetId>) {
-        let mut new_subnets: Vec<SubnetId> = Vec::new();
-        let last_timestamp_per_subnet: BTreeMap<SubnetId, TimestampNanos> = subnets
+        let last_timestamp_per_subnet: BTreeMap<SubnetId, _> = subnets
             .into_iter()
             .map(|subnet| {
                 let last_timestamp = self.last_timestamp_per_subnet.borrow().get(&SubnetIdStored(subnet));
 
-                (
-                    subnet,
-                    last_timestamp.unwrap_or_else(|| {
-                        new_subnets.push(subnet);
-                        TimestampNanos::default()
-                    }),
-                )
+                (subnet, last_timestamp)
             })
             .collect();
 
         let subnets_metrics = self.fetch_subnets_metrics(&last_timestamp_per_subnet).await;
-        for (subnet_id, call_result) in subnets_metrics {
+        for ((subnet_id, last_stored_ts), call_result) in subnets_metrics {
             match call_result {
-                Ok((mut subnet_updates_daily,)) => {
-                    subnet_updates_daily.sort_by_key(|metrics| metrics.timestamp_nanos);
-                    if subnet_updates_daily.is_empty() {
+                Ok((subnet_update,)) => {
+                    if subnet_update.is_empty() {
                         ic_cdk::println!("No updates for subnet {}", subnet_id);
-                        continue;
+                    } else {
+                        // Update the last timestamp for this subnet.
+                        let last_timestamp = subnet_update.last().map(|metrics| metrics.timestamp_nanos).expect("Not empty");
+                        self.last_timestamp_per_subnet.borrow_mut().insert(subnet_id.into(), last_timestamp);
+
+                        self.update_nodes_metrics_daily(subnet_id, last_stored_ts, subnet_update);
                     }
 
-                    // Update the last timestamp for this subnet.
-                    let last_timestamp = subnet_updates_daily.last().map(|metrics| metrics.timestamp_nanos).expect("Not empty");
-                    self.last_timestamp_per_subnet.borrow_mut().insert(subnet_id.into(), last_timestamp);
-
-                    // Update node metrics daily for this subnet.
-                    let is_new_subnet = new_subnets.contains(&subnet_id);
-                    self.update_nodes_metrics_daily(subnet_id, is_new_subnet, subnet_updates_daily);
-
-                    // Remove the subnet from the retry list if present.
                     self.subnets_to_retry.borrow_mut().remove(&subnet_id.into());
                 }
                 Err((code, msg)) => {
@@ -204,13 +201,13 @@ where
 
     /// Fetches subnets metrics for the specified subnets from their last timestamp.
     pub fn daily_metrics_by_node(&self, start_ts: TimestampNanos, end_ts: TimestampNanos) -> BTreeMap<NodeId, Vec<NodeMetricsDaily>> {
-        let first_key = StorableSubnetMetricsKey {
+        let first_key = SubnetMetricsStoredKey {
             timestamp_nanos: start_ts,
-            ..StorableSubnetMetricsKey::min_key()
+            ..SubnetMetricsStoredKey::min_key()
         };
-        let last_key = StorableSubnetMetricsKey {
+        let last_key = SubnetMetricsStoredKey {
             timestamp_nanos: end_ts,
-            ..StorableSubnetMetricsKey::max_key()
+            ..SubnetMetricsStoredKey::max_key()
         };
 
         // Group node metrics by node_id within the given time range and return its daily metrics.

--- a/rs/dre-canisters/node-provider-rewards/src/metrics.rs
+++ b/rs/dre-canisters/node-provider-rewards/src/metrics.rs
@@ -1,12 +1,12 @@
-use crate::metrics_types::{KeyRange, StorableSubnetMetrics, StorableSubnetMetricsKey, SubnetIdStored};
+use crate::metrics_types::{KeyRange, StorableSubnetMetrics, StorableSubnetMetricsKey, SubnetIdStored, SubnetNodeMetricsDaily};
 use async_trait::async_trait;
 use candid::Principal;
-use ic_base_types::{NodeId, PrincipalId, SubnetId};
+use ic_base_types::{NodeId, SubnetId};
 use ic_cdk::api::call::CallResult;
-use ic_management_canister_types_private::{NodeMetrics, NodeMetricsHistoryArgs, NodeMetricsHistoryResponse};
+use ic_management_canister_types_private::{NodeMetricsHistoryArgs, NodeMetricsHistoryResponse};
 use ic_stable_structures::StableBTreeMap;
 use itertools::Itertools;
-use node_provider_rewards::metrics::NodeDailyMetrics;
+use node_provider_rewards::metrics::NodeMetricsDaily;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 
@@ -59,31 +59,92 @@ where
         }
     }
 
+    /// Update the daily metrics for each node in the subnet.
+    fn update_nodes_metrics_daily(&self, subnet_id: SubnetId, is_new_subnet: bool, mut subnet_updates_daily: Vec<NodeMetricsHistoryResponse>) {
+        // Extract initial total metrics for each node in the subnet.
+        let mut initial_total_metrics_per_node: HashMap<_, _> = HashMap::new();
+
+        if !is_new_subnet {
+            initial_total_metrics_per_node = subnet_updates_daily
+                .remove(0)
+                .node_metrics
+                .iter()
+                .map(|node_metrics| {
+                    (
+                        node_metrics.node_id,
+                        (node_metrics.num_blocks_proposed_total, node_metrics.num_block_failures_total),
+                    )
+                })
+                .collect()
+        };
+
+        let mut running_total_metrics_per_node = initial_total_metrics_per_node;
+        for one_day_subnet_update in subnet_updates_daily {
+            let key = StorableSubnetMetricsKey {
+                subnet_id,
+                timestamp_nanos: one_day_subnet_update.timestamp_nanos,
+            };
+
+            let daily_nodes_metrics = one_day_subnet_update
+                .node_metrics
+                .into_iter()
+                .map(|node_metrics| {
+                    let current_proposed_total = node_metrics.num_blocks_proposed_total;
+                    let current_failed_total = node_metrics.num_block_failures_total;
+
+                    let (mut running_proposed_total, mut running_failed_total) = running_total_metrics_per_node
+                        .remove(&node_metrics.node_id)
+                        // Default is needed if:
+                        //  1- the node joined the subnet after last_stored_ts.
+                        //  2- the subnet has never been stored.
+                        .unwrap_or_default();
+
+                    // This can happen if the node was redeployed.
+                    if running_proposed_total > current_proposed_total || running_failed_total > current_failed_total {
+                        running_proposed_total = 0;
+                        running_failed_total = 0;
+                    };
+
+                    // Update the total metrics for the next iteration.
+                    running_total_metrics_per_node.insert(node_metrics.node_id, (current_proposed_total, current_failed_total));
+
+                    SubnetNodeMetricsDaily {
+                        node_id: node_metrics.node_id.into(),
+                        num_blocks_proposed: current_proposed_total - running_proposed_total,
+                        num_blocks_failed: current_failed_total - running_failed_total,
+                    }
+                })
+                .collect();
+
+            self.subnets_metrics.borrow_mut().insert(key, StorableSubnetMetrics(daily_nodes_metrics));
+        }
+    }
+
     /// Fetches subnets metrics for the specified subnets from their last timestamp.
     async fn fetch_subnets_metrics(
         &self,
         last_timestamp_per_subnet: &BTreeMap<SubnetId, TimestampNanos>,
     ) -> BTreeMap<SubnetId, CallResult<(Vec<NodeMetricsHistoryResponse>,)>> {
-        let mut subnets_node_metrics = Vec::new();
+        let mut subnets_history = Vec::new();
 
-        for (subnet_id, last_metrics_ts) in last_timestamp_per_subnet {
-            let refresh_ts = last_metrics_ts + 1;
+        for (subnet_id, last_stored_ts) in last_timestamp_per_subnet {
+            // For nodes assigned to the subnet before the current update, the TOTAL metrics at last_stored_ts
+            // are required since only DAILY metrics for each node are stored.
             ic_cdk::println!(
-                "Updating node metrics for subnet {}: Latest timestamp persisted: {}  Refreshing metrics from timestamp {}",
+                "Updating node metrics for subnet {}: Refreshing metrics from timestamp {}",
                 subnet_id,
-                last_metrics_ts,
-                refresh_ts
+                last_stored_ts
             );
 
             let contract = NodeMetricsHistoryArgs {
                 subnet_id: subnet_id.get(),
-                start_at_timestamp_nanos: refresh_ts,
+                start_at_timestamp_nanos: *last_stored_ts,
             };
 
-            subnets_node_metrics.push(async move { (*subnet_id, self.client.node_metrics_history(contract).await) });
+            subnets_history.push(async move { (*subnet_id, self.client.node_metrics_history(contract).await) });
         }
 
-        futures::future::join_all(subnets_node_metrics).await.into_iter().collect()
+        futures::future::join_all(subnets_history).await.into_iter().collect()
     }
 
     /// Updates the stored subnets metrics from remote management canisters.
@@ -91,36 +152,39 @@ where
     /// This function fetches the nodes metrics for the given subnets from the management canisters
     /// updating the local metrics with the fetched metrics.
     pub async fn update_subnets_metrics(&self, subnets: Vec<SubnetId>) {
+        let mut new_subnets: Vec<SubnetId> = Vec::new();
         let last_timestamp_per_subnet: BTreeMap<SubnetId, TimestampNanos> = subnets
             .into_iter()
             .map(|subnet| {
                 let last_timestamp = self.last_timestamp_per_subnet.borrow().get(&SubnetIdStored(subnet));
 
-                (subnet, last_timestamp.unwrap_or_default())
+                (
+                    subnet,
+                    last_timestamp.unwrap_or_else(|| {
+                        new_subnets.push(subnet);
+                        TimestampNanos::default()
+                    }),
+                )
             })
             .collect();
 
         let subnets_metrics = self.fetch_subnets_metrics(&last_timestamp_per_subnet).await;
         for (subnet_id, call_result) in subnets_metrics {
             match call_result {
-                Ok((nodes_metrics_history,)) => {
-                    // Update the last timestamp for this subnet.
-                    let last_timestamp = nodes_metrics_history
-                        .iter()
-                        .map(|entry| entry.timestamp_nanos)
-                        .max()
-                        .unwrap_or(*last_timestamp_per_subnet.get(&subnet_id).expect("timestamp exists"));
+                Ok((mut subnet_updates_daily,)) => {
+                    subnet_updates_daily.sort_by_key(|metrics| metrics.timestamp_nanos);
+                    if subnet_updates_daily.is_empty() {
+                        ic_cdk::println!("No updates for subnet {}", subnet_id);
+                        continue;
+                    }
 
+                    // Update the last timestamp for this subnet.
+                    let last_timestamp = subnet_updates_daily.last().map(|metrics| metrics.timestamp_nanos).expect("Not empty");
                     self.last_timestamp_per_subnet.borrow_mut().insert(subnet_id.into(), last_timestamp);
 
-                    // Insert each fetched metric entry into our node metrics map.
-                    nodes_metrics_history.into_iter().for_each(|entry| {
-                        let key = StorableSubnetMetricsKey {
-                            subnet_id,
-                            timestamp_nanos: entry.timestamp_nanos,
-                        };
-                        self.subnets_metrics.borrow_mut().insert(key, StorableSubnetMetrics(entry.node_metrics));
-                    });
+                    // Update node metrics daily for this subnet.
+                    let is_new_subnet = new_subnets.contains(&subnet_id);
+                    self.update_nodes_metrics_daily(subnet_id, is_new_subnet, subnet_updates_daily);
 
                     // Remove the subnet from the retry list if present.
                     self.subnets_to_retry.borrow_mut().remove(&subnet_id.into());
@@ -139,7 +203,7 @@ where
     }
 
     /// Fetches subnets metrics for the specified subnets from their last timestamp.
-    pub fn daily_metrics_by_node(&self, start_ts: TimestampNanos, end_ts: TimestampNanos) -> BTreeMap<NodeId, Vec<NodeDailyMetrics>> {
+    pub fn daily_metrics_by_node(&self, start_ts: TimestampNanos, end_ts: TimestampNanos) -> BTreeMap<NodeId, Vec<NodeMetricsDaily>> {
         let first_key = StorableSubnetMetricsKey {
             timestamp_nanos: start_ts,
             ..StorableSubnetMetricsKey::min_key()
@@ -149,64 +213,23 @@ where
             ..StorableSubnetMetricsKey::max_key()
         };
 
-        // Group node metrics by node_id within the given time range
-        let nodes_in_range: HashMap<PrincipalId, Vec<(StorableSubnetMetricsKey, NodeMetrics)>> = self
-            .subnets_metrics
+        // Group node metrics by node_id within the given time range and return its daily metrics.
+        self.subnets_metrics
             .borrow()
-            .range(first_key.clone()..=last_key.clone())
+            .range(first_key..=last_key)
             .flat_map(|(key, value)| value.0.into_iter().map(move |metrics| (key.clone(), metrics)))
-            .into_group_map_by(|(_, metrics)| metrics.node_id);
-
-        // Find the last metric before start_ts for each node
-        let mut first_metrics: HashMap<PrincipalId, Option<NodeMetrics>> = HashMap::new();
-
-        for node_id in nodes_in_range.keys() {
-            let latest_metric_before_start = self
-                .subnets_metrics
-                .borrow()
-                .range(..first_key.clone())
-                .flat_map(|(_, value)| value.0.into_iter())
-                .filter(|m| m.node_id == *node_id)
-                .next_back();
-
-            first_metrics.insert(*node_id, latest_metric_before_start);
-        }
-
-        // Compute daily metrics for each node in range
-        nodes_in_range
+            .into_group_map_by(|(_, metrics)| metrics.node_id)
             .into_iter()
-            .map(|(node_id, entries)| {
-                let initial_counters = first_metrics
-                    .remove(&node_id)
-                    .expect("first metrics key must exist for each node_id")
-                    .map(|init| (init.num_blocks_proposed_total, init.num_block_failures_total))
-                    .unwrap_or((0, 0));
+            .map(|(node_id, daily_metrics_stored)| {
+                let daily_metrics_in_range = daily_metrics_stored
+                    .into_iter()
+                    .sorted_by_key(|(key, _)| key.timestamp_nanos)
+                    .map(|(key, metrics)| {
+                        NodeMetricsDaily::new(key.timestamp_nanos, key.subnet_id, metrics.num_blocks_proposed, metrics.num_blocks_failed)
+                    })
+                    .collect();
 
-                let (daily_metrics, _) = entries.into_iter().fold(
-                    (Vec::new(), initial_counters),
-                    |(mut acc, (prev_proposed, prev_failed)), (key, node_metrics)| {
-                        let current_proposed = node_metrics.num_blocks_proposed_total;
-                        let current_failed = node_metrics.num_block_failures_total;
-
-                        // Ensure counters don't decrease (i.e., reset detection)
-                        let (num_blocks_proposed, num_blocks_failed) = if prev_proposed > current_proposed || prev_failed > current_failed {
-                            (current_proposed, current_failed)
-                        } else {
-                            (current_proposed - prev_proposed, current_failed - prev_failed)
-                        };
-
-                        acc.push(NodeDailyMetrics::new(
-                            key.timestamp_nanos,
-                            key.subnet_id,
-                            num_blocks_proposed,
-                            num_blocks_failed,
-                        ));
-
-                        (acc, (current_proposed, current_failed))
-                    },
-                );
-
-                (NodeId::from(node_id), daily_metrics)
+                (node_id, daily_metrics_in_range)
             })
             .collect()
     }

--- a/rs/dre-canisters/node-provider-rewards/src/metrics/tests.rs
+++ b/rs/dre-canisters/node-provider-rewards/src/metrics/tests.rs
@@ -1,11 +1,14 @@
 use crate::metrics::MetricsManager;
-use crate::metrics_types::StorableSubnetMetricsKey;
-use ic_base_types::{PrincipalId, SubnetId};
+use crate::metrics_types::{StorableSubnetMetricsKey, SubnetNodeMetricsDaily};
+use futures::StreamExt;
+use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use ic_cdk::api::call::{CallResult, RejectionCode};
-use ic_management_canister_types_private::NodeMetricsHistoryResponse;
+use ic_management_canister_types_private::{NodeMetrics, NodeMetricsHistoryArgs, NodeMetricsHistoryResponse};
 use ic_stable_structures::memory_manager::{MemoryId, VirtualMemory};
 use ic_stable_structures::DefaultMemoryImpl;
+use itertools::Itertools;
 use std::cell::RefCell;
+use std::collections::HashMap;
 
 mod mock {
     use super::*;
@@ -28,6 +31,9 @@ pub type VM = VirtualMemory<DefaultMemoryImpl>;
 const ONE_DAY_NANOS: u64 = 24 * 60 * 60 * 1_000_000_000;
 fn subnet_id(id: u64) -> ic_base_types::SubnetId {
     PrincipalId::new_subnet_test_id(id).into()
+}
+fn node_id(id: u64) -> ic_base_types::NodeId {
+    PrincipalId::new_node_test_id(id).into()
 }
 
 impl MetricsManager<VM> {
@@ -191,4 +197,162 @@ async fn partial_failures_are_handled_correctly() {
         subnet_id: subnet_2,
     };
     assert!(mm.subnets_metrics.borrow().get(&key).is_some(), "Metrics should be present for subnet 2");
+}
+
+fn node_metrics_history(node_id: NodeId, proposed_failed_blocks: Vec<(u64, u64)>) -> Vec<NodeMetricsHistoryResponse> {
+    let mut result = Vec::new();
+    for (idx, (num_proposed, num_failed)) in proposed_failed_blocks.into_iter().enumerate() {
+        result.push(NodeMetricsHistoryResponse {
+            timestamp_nanos: idx as u64 * ONE_DAY_NANOS,
+            node_metrics: vec![NodeMetrics {
+                num_blocks_proposed_total: num_proposed,
+                num_block_failures_total: num_failed,
+                node_id: node_id.get(),
+            }],
+        });
+    }
+    result
+}
+
+const MAX_TIMES: usize = 20;
+
+#[derive(Clone)]
+struct NodeMetricsHistoryResponseTracker {
+    current_subnet: SubnetId,
+    current_node: NodeId,
+    current_ts: u64,
+    subnets_responses: HashMap<SubnetId, Vec<NodeMetricsHistoryResponse>>,
+}
+
+impl NodeMetricsHistoryResponseTracker {
+    pub fn new() -> Self {
+        Self {
+            current_subnet: subnet_id(0),
+            current_node: node_id(0),
+            current_ts: 0,
+            subnets_responses: HashMap::new(),
+        }
+    }
+
+    fn with_subnet(mut self, subnet_id: SubnetId) -> Self {
+        self.subnets_responses.entry(subnet_id).or_default();
+        self.current_subnet = subnet_id;
+        self
+    }
+
+    fn with_node(mut self, node_id: NodeId) -> Self {
+        self.current_node = node_id;
+        self
+    }
+
+    fn change_ts(mut self, ts: u64) -> Self {
+        self.current_ts = ts;
+        self.subnets_responses
+            .get_mut(&self.current_subnet)
+            .unwrap()
+            .push(NodeMetricsHistoryResponse {
+                timestamp_nanos: ts,
+                node_metrics: Vec::new(),
+            });
+        self
+    }
+
+    fn with_node_metrics_single(mut self, blocks_proposed_total: u64, blocks_failed_total: u64) -> Self {
+        let responses = self.subnets_responses.get_mut(&self.current_subnet).unwrap();
+
+        // Ensure we have at least one response with the current timestamp
+        if responses.is_empty() || responses.last().unwrap().timestamp_nanos != self.current_ts {
+            responses.push(NodeMetricsHistoryResponse {
+                timestamp_nanos: self.current_ts,
+                node_metrics: Vec::new(),
+            });
+        }
+
+        // Now we can safely add the metrics to the last response
+        responses.last_mut().unwrap().node_metrics.push(NodeMetrics {
+            num_blocks_proposed_total: blocks_proposed_total,
+            num_block_failures_total: blocks_failed_total,
+            node_id: self.current_node.get(),
+        });
+
+        self
+    }
+    fn add_node_metrics(mut self, proposed_failed: Vec<(u64, u64)>) -> Self {
+        let len = proposed_failed.len();
+        for (i, (proposed, failed)) in proposed_failed.into_iter().enumerate() {
+            self = self.with_node_metrics_single(proposed, failed);
+            if i < len - 1 {
+                let new_ts = self.current_ts + ONE_DAY_NANOS;
+                self = self.change_ts(new_ts);
+            }
+        }
+        self
+    }
+
+    fn next(&self, response_step: usize, contract: NodeMetricsHistoryArgs) -> Vec<NodeMetricsHistoryResponse> {
+        self.subnets_responses
+            .get(&SubnetId::from(contract.subnet_id))
+            .unwrap()
+            .clone()
+            .into_iter()
+            .filter(|metric| metric.timestamp_nanos >= contract.start_at_timestamp_nanos)
+            .take(response_step)
+            .collect()
+    }
+}
+
+async fn daily_metrics_are_correctly_computed(response_step: usize) {
+    // (blocks_proposed, blocks_failed)
+    let tracker = NodeMetricsHistoryResponseTracker::new()
+        .with_subnet(subnet_id(1))
+        .with_node(node_id(1))
+        .add_node_metrics(vec![(7, 5), (10, 6), (15, 6), (25, 50), (10, 6)]);
+
+    let mut mock = mock::MockCanisterClient::new();
+    mock.expect_node_metrics_history().times(MAX_TIMES).returning(move |contract| {
+        let call_elem = tracker.next(response_step, contract);
+
+        println!("{:?}", call_elem);
+        CallResult::Ok((call_elem,))
+    });
+    let mm = MetricsManager::new(mock);
+
+    for _ in 0..MAX_TIMES {
+        mm.update_subnets_metrics(vec![subnet_id(1)]).await;
+    }
+    let node_1_daily_metrics: Vec<SubnetNodeMetricsDaily> = mm
+        .subnets_metrics
+        .borrow()
+        .values()
+        .map(|node_metrics| node_metrics.0[0].clone())
+        .collect();
+
+    // (7, 5)
+    assert_eq!(node_1_daily_metrics[0].num_blocks_proposed, 7);
+    assert_eq!(node_1_daily_metrics[0].num_blocks_failed, 5);
+
+    // (10 - 7, 6 - 5) = (5, 1)
+    assert_eq!(node_1_daily_metrics[1].num_blocks_proposed, 3);
+    assert_eq!(node_1_daily_metrics[1].num_blocks_failed, 1);
+
+    // (15 - 10, 6 - 6) = (5, 0)
+    assert_eq!(node_1_daily_metrics[2].num_blocks_proposed, 5);
+    assert_eq!(node_1_daily_metrics[2].num_blocks_failed, 0);
+
+    // (25 - 15, 50 - 6) = (10, 44)
+    assert_eq!(node_1_daily_metrics[3].num_blocks_proposed, 10);
+    assert_eq!(node_1_daily_metrics[3].num_blocks_failed, 44);
+
+    // Node is redeployed and added to the same subnet!
+    // (10, 6)
+    assert_eq!(node_1_daily_metrics[4].num_blocks_proposed, 10);
+    assert_eq!(node_1_daily_metrics[4].num_blocks_failed, 6);
+}
+
+#[tokio::test]
+async fn daily_metrics_are_correctly_computed_over_multiple_updates() {
+    daily_metrics_are_correctly_computed(2).await;
+    daily_metrics_are_correctly_computed(3).await;
+    daily_metrics_are_correctly_computed(4).await;
+    daily_metrics_are_correctly_computed(5).await;
 }

--- a/rs/dre-canisters/node-provider-rewards/src/metrics_types.rs
+++ b/rs/dre-canisters/node-provider-rewards/src/metrics_types.rs
@@ -1,7 +1,6 @@
 use crate::metrics::TimestampNanos;
 use candid::{CandidType, Decode, Encode, Principal};
-use ic_base_types::{PrincipalId, SubnetId};
-use ic_management_canister_types_private::NodeMetrics;
+use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use serde::Deserialize;
@@ -101,8 +100,15 @@ impl Storable for StorableSubnetMetricsKey {
     };
 }
 
+#[derive(Clone, Debug, CandidType, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SubnetNodeMetricsDaily {
+    pub node_id: NodeId,
+    pub num_blocks_proposed: u64,
+    pub num_blocks_failed: u64,
+}
+
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct StorableSubnetMetrics(pub Vec<NodeMetrics>);
+pub struct StorableSubnetMetrics(pub Vec<SubnetNodeMetricsDaily>);
 
 impl Storable for StorableSubnetMetrics {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
@@ -117,7 +123,7 @@ impl Storable for StorableSubnetMetrics {
 }
 
 impl Deref for StorableSubnetMetrics {
-    type Target = Vec<NodeMetrics>;
+    type Target = Vec<SubnetNodeMetricsDaily>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/rs/dre-canisters/node-provider-rewards/src/metrics_types.rs
+++ b/rs/dre-canisters/node-provider-rewards/src/metrics_types.rs
@@ -5,7 +5,6 @@ use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use serde::Deserialize;
 use std::borrow::Cow;
-use std::ops::Deref;
 
 // Maximum sizes for the storable types chosen as result of test `max_bound_size`
 const MAX_BYTES_SUBNET_ID_STORED: u32 = 38;
@@ -18,7 +17,7 @@ pub const MAX_PRINCIPAL_ID: PrincipalId = PrincipalId(Principal::from_slice(&[0x
 #[test]
 fn max_bound_size() {
     let max_subnet_id_stored = SubnetIdStored(MAX_PRINCIPAL_ID.into());
-    let max_subnet_metrics_stored_key = StorableSubnetMetricsKey {
+    let max_subnet_metrics_stored_key = SubnetMetricsStoredKey {
         timestamp_nanos: u64::MAX,
         subnet_id: MAX_PRINCIPAL_ID.into(),
     };
@@ -45,13 +44,6 @@ impl Storable for SubnetIdStored {
     };
 }
 
-impl Deref for SubnetIdStored {
-    type Target = SubnetId;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl From<SubnetId> for SubnetIdStored {
     fn from(subnet_id: SubnetId) -> Self {
         Self(subnet_id)
@@ -64,12 +56,12 @@ pub trait KeyRange {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct StorableSubnetMetricsKey {
+pub struct SubnetMetricsStoredKey {
     pub timestamp_nanos: TimestampNanos,
     pub subnet_id: SubnetId,
 }
 
-impl KeyRange for StorableSubnetMetricsKey {
+impl KeyRange for SubnetMetricsStoredKey {
     fn min_key() -> Self {
         Self {
             timestamp_nanos: u64::MIN,
@@ -85,7 +77,7 @@ impl KeyRange for StorableSubnetMetricsKey {
     }
 }
 
-impl Storable for StorableSubnetMetricsKey {
+impl Storable for SubnetMetricsStoredKey {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         Cow::Owned(Encode!(self).unwrap())
     }
@@ -101,16 +93,16 @@ impl Storable for StorableSubnetMetricsKey {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SubnetNodeMetricsDaily {
+pub struct NodeMetricsDailyStored {
     pub node_id: NodeId,
     pub num_blocks_proposed: u64,
     pub num_blocks_failed: u64,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct StorableSubnetMetrics(pub Vec<SubnetNodeMetricsDaily>);
+pub struct SubnetMetricsStoredValue(pub Vec<NodeMetricsDailyStored>);
 
-impl Storable for StorableSubnetMetrics {
+impl Storable for SubnetMetricsStoredValue {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         Cow::Owned(Encode!(self).unwrap())
     }
@@ -120,11 +112,4 @@ impl Storable for StorableSubnetMetrics {
     }
 
     const BOUND: Bound = Bound::Unbounded;
-}
-
-impl Deref for StorableSubnetMetrics {
-    type Target = Vec<SubnetNodeMetricsDaily>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
 }

--- a/rs/node-provider-rewards/src/execution_context/performance_multipliers_calculator/tests.rs
+++ b/rs/node-provider-rewards/src/execution_context/performance_multipliers_calculator/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::metrics::{nodes_failure_rates_in_period, subnets_failure_rates, NodeDailyMetrics};
+use crate::metrics::{nodes_failure_rates_in_period, subnets_failure_rates, NodeMetricsDaily};
 use crate::reward_period::{RewardPeriod, TimestampNanos, TimestampNanosAtDayEnd, NANOS_PER_DAY};
 use crate::types::RewardableNode;
 use ic_base_types::PrincipalId;
@@ -20,7 +20,7 @@ fn ts_day_end(day: u64) -> TimestampNanos {
 
 pub struct FailureRatesBuilder {
     daily_data: BTreeMap<TimestampNanos, Vec<(SubnetId, NodeId, Decimal)>>,
-    nodes_daily_metrics: BTreeMap<NodeId, Vec<NodeDailyMetrics>>,
+    nodes_daily_metrics: BTreeMap<NodeId, Vec<NodeMetricsDaily>>,
 }
 
 impl FailureRatesBuilder {
@@ -64,7 +64,7 @@ impl FailureRatesBuilder {
             node_id,
             metrics
                 .into_iter()
-                .map(|(ts, subnet_id, proposed, failed)| NodeDailyMetrics::new(ts, subnet_id, proposed, failed))
+                .map(|(ts, subnet_id, proposed, failed)| NodeMetricsDaily::new(ts, subnet_id, proposed, failed))
                 .collect(),
         );
 
@@ -83,7 +83,7 @@ impl FailureRatesBuilder {
         let mut metrics_by_node = self.nodes_daily_metrics;
         for (day, entries) in self.daily_data.into_iter() {
             for (subnet, node, rate) in entries {
-                let metrics = NodeDailyMetrics {
+                let metrics = NodeMetricsDaily {
                     ts: TimestampNanosAtDayEnd::from(day),
                     subnet_assigned: subnet,
                     num_blocks_proposed: 0,

--- a/rs/node-provider-rewards/src/execution_context/performance_multipliers_calculator/tests.rs
+++ b/rs/node-provider-rewards/src/execution_context/performance_multipliers_calculator/tests.rs
@@ -15,7 +15,7 @@ fn subnet_id(id: u64) -> SubnetId {
 }
 
 fn ts_day_end(day: u64) -> TimestampNanos {
-    *TimestampNanosAtDayEnd::from(day * NANOS_PER_DAY)
+    TimestampNanosAtDayEnd::from(day * NANOS_PER_DAY).get()
 }
 
 pub struct FailureRatesBuilder {
@@ -94,8 +94,8 @@ impl FailureRatesBuilder {
             }
         }
 
-        let start_ts = metrics_by_node.values().flat_map(|v| v.iter().map(|m| *m.ts)).min().unwrap();
-        let end_ts = metrics_by_node.values().flat_map(|v| v.iter().map(|m| *m.ts)).max().unwrap();
+        let start_ts = metrics_by_node.values().flat_map(|v| v.iter().map(|m| m.ts.get())).min().unwrap();
+        let end_ts = metrics_by_node.values().flat_map(|v| v.iter().map(|m| m.ts.get())).max().unwrap();
         let reward_period = RewardPeriod::new(start_ts, end_ts).unwrap();
         let all_nodes = metrics_by_node.keys().cloned().collect_vec();
 

--- a/rs/node-provider-rewards/src/lib.rs
+++ b/rs/node-provider-rewards/src/lib.rs
@@ -82,10 +82,10 @@ fn validate_input(
     for (node_id, metrics_entries) in metrics_by_node {
         for entry in metrics_entries {
             // Check if all metrics are within the reward period
-            if !reward_period.contains(*entry.ts) {
+            if !reward_period.contains(entry.ts.get()) {
                 return Err(RewardCalculationError::NodeMetricsOutOfRange {
                     node_id: *node_id,
-                    timestamp: *entry.ts,
+                    timestamp: entry.ts.get(),
                     reward_period: reward_period.clone(),
                 });
             }
@@ -94,7 +94,7 @@ fn validate_input(
         // Metrics with the same timestamp and different subnet are allowed.
         let unique_timestamp_subnet = metrics_entries
             .iter()
-            .map(|daily_metrics| (*daily_metrics.ts, daily_metrics.subnet_assigned))
+            .map(|daily_metrics| (daily_metrics.ts.get(), daily_metrics.subnet_assigned))
             .collect::<HashSet<_>>();
         if unique_timestamp_subnet.len() != metrics_entries.len() {
             return Err(RewardCalculationError::DuplicateMetrics(*node_id));

--- a/rs/node-provider-rewards/src/lib.rs
+++ b/rs/node-provider-rewards/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::execution_context::{nodes_ids, ExecutionContext, RewardsCalculationResult};
-use crate::metrics::{nodes_failure_rates_in_period, subnets_failure_rates, NodeDailyMetrics};
+use crate::metrics::{nodes_failure_rates_in_period, subnets_failure_rates, NodeMetricsDaily};
 use crate::reward_period::{RewardPeriod, TimestampNanos};
 use crate::types::{rewardable_nodes_by_provider, RewardableNode};
 use ::tabled::Table;
@@ -32,7 +32,7 @@ pub struct RewardsPerNodeProvider {
 pub fn calculate_rewards(
     reward_period: &RewardPeriod,
     rewards_table: &NodeRewardsTable,
-    daily_metrics_by_node: &BTreeMap<NodeId, Vec<NodeDailyMetrics>>,
+    daily_metrics_by_node: &BTreeMap<NodeId, Vec<NodeMetricsDaily>>,
     rewardable_nodes: &[RewardableNode],
 ) -> Result<RewardsPerNodeProvider, RewardCalculationError> {
     let mut rewards_per_provider = BTreeMap::new();
@@ -65,7 +65,7 @@ pub fn calculate_rewards(
 
 fn validate_input(
     reward_period: &RewardPeriod,
-    metrics_by_node: &BTreeMap<NodeId, Vec<NodeDailyMetrics>>,
+    metrics_by_node: &BTreeMap<NodeId, Vec<NodeMetricsDaily>>,
     all_nodes: &[NodeId],
 ) -> Result<(), RewardCalculationError> {
     if all_nodes.is_empty() {

--- a/rs/node-provider-rewards/src/metrics.rs
+++ b/rs/node-provider-rewards/src/metrics.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 /// Represents the daily metrics recorded for a node.
 #[derive(Clone, PartialEq, Debug)]
-pub struct NodeDailyMetrics {
+pub struct NodeMetricsDaily {
     pub ts: TimestampNanosAtDayEnd,
     pub subnet_assigned: SubnetId,
     pub num_blocks_proposed: u64,
@@ -16,7 +16,7 @@ pub struct NodeDailyMetrics {
     pub failure_rate: Decimal,
 }
 
-impl fmt::Display for NodeDailyMetrics {
+impl fmt::Display for NodeMetricsDaily {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -26,7 +26,7 @@ impl fmt::Display for NodeDailyMetrics {
     }
 }
 
-impl NodeDailyMetrics {
+impl NodeMetricsDaily {
     /// Constructs a new set of daily metrics for a node.
     pub fn new(ts: TimestampNanos, subnet_assigned: SubnetId, num_blocks_proposed: u64, num_blocks_failed: u64) -> Self {
         let total_blocks = num_blocks_proposed + num_blocks_failed;
@@ -35,7 +35,7 @@ impl NodeDailyMetrics {
         } else {
             Decimal::from_f64(num_blocks_failed as f64 / total_blocks as f64).unwrap()
         };
-        NodeDailyMetrics {
+        NodeMetricsDaily {
             ts: TimestampNanosAtDayEnd::from(ts),
             num_blocks_proposed,
             num_blocks_failed,
@@ -88,7 +88,7 @@ const SUBNET_FAILURE_RATE_PERCENTILE: f64 = 0.75;
 /// The failure rate for a subnet on a given day is defined as the `SUBNET_FAILURE_RATE_PERCENTILE`
 /// of the failure rates of all nodes assigned to that subnet. Days with no recorded
 /// metrics for a subnet are omitted.
-pub fn subnets_failure_rates(metrics_by_node: &BTreeMap<NodeId, Vec<NodeDailyMetrics>>) -> BTreeMap<SubnetId, Vec<SubnetDailyFailureRate>> {
+pub fn subnets_failure_rates(metrics_by_node: &BTreeMap<NodeId, Vec<NodeMetricsDaily>>) -> BTreeMap<SubnetId, Vec<SubnetDailyFailureRate>> {
     let mut rates_map: BTreeMap<(SubnetId, TimestampNanos), Vec<Decimal>> = BTreeMap::new();
 
     // Aggregate failure rates by (subnet, timestamp)
@@ -121,7 +121,7 @@ pub fn subnets_failure_rates(metrics_by_node: &BTreeMap<NodeId, Vec<NodeDailyMet
 pub fn nodes_failure_rates_in_period(
     nodes: &[NodeId],
     reward_period: &RewardPeriod,
-    metrics_by_node: &BTreeMap<NodeId, Vec<NodeDailyMetrics>>,
+    metrics_by_node: &BTreeMap<NodeId, Vec<NodeMetricsDaily>>,
 ) -> BTreeMap<NodeId, Vec<NodeDailyFailureRate>> {
     let days_in_period = reward_period.days_between();
 
@@ -150,7 +150,7 @@ pub fn nodes_failure_rates_in_period(
         .collect()
 }
 
-fn node_failure_rate(one_day_metrics: Vec<&NodeDailyMetrics>) -> NodeFailureRate {
+fn node_failure_rate(one_day_metrics: Vec<&NodeMetricsDaily>) -> NodeFailureRate {
     // Node is assigned in reward period but has no metrics for the day.
     if one_day_metrics.is_empty() {
         return NodeFailureRate::Undefined;

--- a/rs/node-provider-rewards/src/metrics.rs
+++ b/rs/node-provider-rewards/src/metrics.rs
@@ -94,7 +94,7 @@ pub fn subnets_failure_rates(metrics_by_node: &BTreeMap<NodeId, Vec<NodeMetricsD
     // Aggregate failure rates by (subnet, timestamp)
     for metrics in metrics_by_node.values().flatten() {
         rates_map
-            .entry((metrics.subnet_assigned, *metrics.ts))
+            .entry((metrics.subnet_assigned, metrics.ts.get()))
             .or_default()
             .push(metrics.failure_rate);
     }
@@ -132,7 +132,7 @@ pub fn nodes_failure_rates_in_period(
         .map(|node_id| {
             let failure_rates_in_period = (0..days_in_period)
                 .map(|day| {
-                    let ts = TimestampNanosAtDayEnd::from(*reward_period.start_ts + day * NANOS_PER_DAY);
+                    let ts = TimestampNanosAtDayEnd::from(reward_period.start_ts.get() + day * NANOS_PER_DAY);
 
                     let value = match metrics_by_node.get(node_id) {
                         Some(metrics) => {
@@ -141,7 +141,7 @@ pub fn nodes_failure_rates_in_period(
                         }
                         None => NodeFailureRate::Undefined,
                     };
-                    NodeDailyFailureRate { ts: *ts, value }
+                    NodeDailyFailureRate { ts: ts.get(), value }
                 })
                 .collect_vec();
 

--- a/rs/node-provider-rewards/src/tests.rs
+++ b/rs/node-provider-rewards/src/tests.rs
@@ -18,9 +18,9 @@ fn provider_id(id: u64) -> PrincipalId {
     PrincipalId::new_user_test_id(id)
 }
 
-fn create_metrics_by_node() -> BTreeMap<NodeId, Vec<NodeDailyMetrics>> {
+fn create_metrics_by_node() -> BTreeMap<NodeId, Vec<NodeMetricsDaily>> {
     let mut metrics_by_node = BTreeMap::new();
-    metrics_by_node.insert(node_id(1), vec![NodeDailyMetrics::new(NANOS_PER_DAY, subnet_id(1), 0, 0)]);
+    metrics_by_node.insert(node_id(1), vec![NodeMetricsDaily::new(NANOS_PER_DAY, subnet_id(1), 0, 0)]);
     metrics_by_node
 }
 
@@ -46,7 +46,7 @@ fn test_metrics_out_of_range() {
     let reward_period = RewardPeriod::new(NANOS_PER_DAY, 30 * NANOS_PER_DAY).unwrap();
     let mut metrics_by_node = create_metrics_by_node();
 
-    let metrics_out_of_range = NodeDailyMetrics::new(0, subnet_id(1), 0, 0);
+    let metrics_out_of_range = NodeMetricsDaily::new(0, subnet_id(1), 0, 0);
     metrics_by_node.get_mut(&node_id(1)).unwrap().push(metrics_out_of_range.clone());
 
     let result = validate_input(&reward_period, &metrics_by_node, &[node_id(1)]);
@@ -69,7 +69,7 @@ fn test_same_day_metrics_same_sub() {
     metrics_by_node
         .get_mut(&node_id(1))
         .unwrap()
-        .push(NodeDailyMetrics::new(NANOS_PER_DAY, subnet_id(1), 0, 0));
+        .push(NodeMetricsDaily::new(NANOS_PER_DAY, subnet_id(1), 0, 0));
     let result = validate_input(&reward_period, &metrics_by_node, &[node_id(1)]);
 
     assert_eq!(result, Err(RewardCalculationError::DuplicateMetrics(node_id(1))));
@@ -83,7 +83,7 @@ fn test_same_day_metrics_different_subs() {
     metrics_by_node
         .get_mut(&node_id(1))
         .unwrap()
-        .push(NodeDailyMetrics::new(NANOS_PER_DAY, subnet_id(2), 0, 0));
+        .push(NodeMetricsDaily::new(NANOS_PER_DAY, subnet_id(2), 0, 0));
     let result = validate_input(&reward_period, &metrics_by_node, &[node_id(1)]);
 
     assert_eq!(result, Ok(()));
@@ -116,7 +116,7 @@ fn test_node_provider_below_min_limit() {
 struct NPRInput {
     reward_period: RewardPeriod,
     rewards_table: NodeRewardsTable,
-    metrics_by_node: BTreeMap<NodeId, Vec<NodeDailyMetrics>>,
+    metrics_by_node: BTreeMap<NodeId, Vec<NodeMetricsDaily>>,
     rewardables: Vec<RewardableNode>,
 }
 
@@ -129,7 +129,7 @@ impl NPRInput {
 struct NPRInputBuilder {
     reward_period: Option<RewardPeriod>,
     rewards_table: Option<NodeRewardsTable>,
-    metrics_by_node: BTreeMap<NodeId, Vec<NodeDailyMetrics>>,
+    metrics_by_node: BTreeMap<NodeId, Vec<NodeMetricsDaily>>,
     rewardables: Vec<RewardableNode>,
 }
 
@@ -184,10 +184,10 @@ impl NPRInputBuilder {
     }
 
     pub fn with_node_metrics(&mut self, node_id: NodeId, ts_start: u64, failure_rates: Vec<Decimal>, subnet_id: SubnetId) -> &mut NPRInputBuilder {
-        let daily_metrics: Vec<NodeDailyMetrics> = failure_rates
+        let daily_metrics: Vec<NodeMetricsDaily> = failure_rates
             .iter()
             .enumerate()
-            .map(|(i, rate)| NodeDailyMetrics {
+            .map(|(i, rate)| NodeMetricsDaily {
                 ts: TimestampNanosAtDayEnd::from(ts_start + i as u64 * NANOS_PER_DAY),
                 subnet_assigned: subnet_id,
                 num_blocks_proposed: 0,

--- a/rs/node-provider-rewards/src/tests.rs
+++ b/rs/node-provider-rewards/src/tests.rs
@@ -55,7 +55,7 @@ fn test_metrics_out_of_range() {
         result,
         Err(RewardCalculationError::NodeMetricsOutOfRange {
             node_id: node_id(1),
-            timestamp: *metrics_out_of_range.ts,
+            timestamp: metrics_out_of_range.ts.get(),
             reward_period,
         })
     );


### PR DESCRIPTION
Changes:

- Store `DailyNodeMetrics` directly instead of storing totals and compute daily metrics on query time
- Added tests for `DailyNodeMetrics` computation
- Decreased `instruction_counter` to 300K instructions for 1 month of metrics

TODO:
- Go through the NPR lib to decrease `instruction_counter` also there (currently 2.5B instructions used)