### PR TITLE
Reform Github checks

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,12 +8,14 @@ on:
       - "replica-releases/**"
       - "release-controller/**"
       - "node-labels/**"
+      - "facts-db/**"
   pull_request:
     paths-ignore:
       - "release-index.yaml"
       - "replica-releases/**"
       - "release-controller/**"
       - "node-labels/**"
+      - "facts-db/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       labels: dre-runner-custom
     # This image is based on ubuntu:20.04
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625
-    name: Release index checks
+    name: Check changed release index files
     steps:
       - uses: actions/checkout@v4
       - name: Run checks for release index

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run checks for release index
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           rye sync
           export PYTHONPATH=$PWD/release-controller

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,12 @@ name: Release index checks
 
 on:
   pull_request:
+    paths:
+      - "release-index.yaml"
+      - "replica-releases/**"
+      - "release-controller/**"
+      - "node-labels/**"
+      - "facts-db/**"
   workflow_dispatch:
 
 jobs:
@@ -13,36 +19,6 @@ jobs:
     name: Release index checks
     steps:
       - uses: actions/checkout@v4
-      - name: Get all changed release files
-        id: changed-files
-        uses: step-security/changed-files@v45
-        with:
-          files: |
-            release-index.yaml
-            replica-releases/**
-            node-labels/**
-            facts-db/**
-
-      - name: Suppress bazel pipeline # because it should not run if only release files changed
-        uses: Sibz/github-status-action@v1
-        if: ${{ steps.changed-files.outputs.all_changed_files_count > 0 && steps.changed-files.outputs.other_changed_files_count == 0  }}
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "bazel"
-          description: "Passed"
-          state: "success"
-          sha: ${{github.event.pull_request.head.sha || github.sha}}
-
-      - name: Mark bazel-release-controller as success # because it should not run if only release files changed
-        uses: Sibz/github-status-action@v1
-        if: ${{ steps.changed-files.outputs.all_changed_files_count > 0 && steps.changed-files.outputs.other_changed_files_count == 0  }}
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "bazel-release-controller"
-          description: "Passed"
-          state: "success"
-          sha: ${{github.event.pull_request.head.sha || github.sha}}
-
       - name: Run checks for release index
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       - "release-controller/**"
       - "node-labels/**"
       - "facts-db/**"
+      - .github/**
   workflow_dispatch:
 
 jobs:

--- a/scripts/release_index_ci_check.py
+++ b/scripts/release_index_ci_check.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as log:
             print("## Release checks", file=log)
 
-    index = yaml.load(open(args.path, "r", encoding="utf8"), Loader=yaml.FullLoader)
+    index = yaml.load(open(args.path, "r", encoding="utf8"), Loader=yaml.SafeLoader)
 
     errors = []
 


### PR DESCRIPTION
* Simplify the release index checks.  It no longer attempts to mark actions as successful, because those actions are now only running when pertinent.
* Add an additional `paths-ignore` entry in the relevant places, based on the release index checks paths.