### PR TITLE
chore: update IC-OS verification instructions to use the new repro-check

### DIFF
--- a/release-controller/release_index_loader.py
+++ b/release-controller/release_index_loader.py
@@ -22,11 +22,11 @@ def _verify_release_instructions(version: str, security_fix: bool) -> str:
     return f"""
 # IC-OS Verification
 {with_security_caveat}
-To build and verify the IC-OS disk image, run:
+To build and verify the IC-OS disk image, after installing curl if necessary (`sudo apt install curl`), run:
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c {version} --guestos
+curl -fsSL https://raw.githubusercontent.com/dfinity/ic/master/ci/tools/repro-check | python3 - -c {version} --guestos
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.

--- a/release-controller/tests/test_release_index_loader.py
+++ b/release-controller/tests/test_release_index_loader.py
@@ -106,11 +106,11 @@ Full list of changes (including the ones that are not relevant to GuestOS) can b
 
 # IC-OS Verification
 
-To build and verify the IC-OS disk image, run:
+To build and verify the IC-OS disk image, after installing curl if necessary (`sudo apt install curl`), run:
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-sudo apt-get install -y curl && curl --proto \'=https\' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/35bfcadd0f2a474057e42393917b8b3ac269627a/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c 35bfcadd0f2a474057e42393917b8b3ac269627a --guestos
+curl -fsSL https://raw.githubusercontent.com/dfinity/ic/master/ci/tools/repro-check | python3 - -c 35bfcadd0f2a474057e42393917b8b3ac269627a --guestos
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -1181,11 +1181,11 @@ pub fn format_regular_version_upgrade_summary(version: &str, release_artifact: &
 
 # IC-OS Verification
 
-To build and verify the IC-OS disk image, run:
+To build and verify the IC-OS disk image, after installing curl if necessary (`sudo apt install curl`), run:
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-sudo apt-get install -y curl && curl --proto '=https' --tlsv1.2 -sSLO https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check.sh && chmod +x repro-check.sh && ./repro-check.sh -c {version} --guestos
+curl -fsSL https://raw.githubusercontent.com/dfinity/ic/master/ci/tools/repro-check | python3 - -c {version} --guestos
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image,


### PR DESCRIPTION
### Major Changes

- Update the IC-OS disk image verification instructions by replacing the shell script method with a direct curl and python execution.
