### PR TITLE
Push images and update deployments only when containers are actually pushed.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,20 +99,13 @@ jobs:
       ########################################
       # Upload container images
       ########################################
-      - name: "🔧 Login to GitHub Container Registry"
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "📦 Push images to GitHub Container Registry"
-        if: ${{ startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
-        shell: bash
-        run: |
-          set -ex -o pipefail
-          bazel query --noshow_progress 'kind("oci_push", ...) except //release-controller/...' \
-            | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}
+        id: push-images
+        uses: ./.github/workflows/push
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          spec: kind("oci_push", ...) except //release-controller/...
 
       ########################################
       # Deploy to github pages
@@ -128,7 +121,7 @@ jobs:
       # Update k8s deployments
       ########################################
       - name: "🤖 Update k8s deployments"
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && steps.push-images.outputs.pushed == 'true' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
           files-to-update: bases/apps/mainnet-dashboard/backend/base/deployment.yaml bases/apps/mainnet-dashboard/statefulset-slack.yaml bases/apps/service-discovery/service-discovery.yaml .github/workflows/dre-vector-configs.yaml

--- a/.github/workflows/push/action.yaml
+++ b/.github/workflows/push/action.yaml
@@ -1,0 +1,46 @@
+name: Push OCI containers
+description: Reusable action for pushing containers with bazel
+
+inputs:
+  spec:
+    description: "Bazel query specification returning what targets to push"
+    required: false
+    default: >-
+      kind("oci_push", ...)'
+
+outputs:
+  pushed:
+    description: Whether any OCI containers were pushed
+    value: ${{ steps.push.outputs.pushed }}
+
+runs:
+  using: composite
+  steps:
+    - id: login
+      name: "🔧 Login to GitHub Container Registry"
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - id: push
+      name: "📦 Push images to GitHub Container Registry"
+      shell: bash
+      env:
+        SPEC: ${{ inputs.spec }}
+      run: |
+        set -ex -o pipefail
+        t=$(mktemp) ; trap 'rm -f "$t"' EXIT
+        bazel query --noshow_progress "$SPEC" \
+          | xargs -I_target bazel run --test_env=HOME=/home/runner _target -- --tag ${GITHUB_SHA} | tee "$t" >&2
+        if grep -q 'pushed blob' "$t"
+        then
+          echo "pushed=true" >> $GITHUB_OUTPUT
+          echo "## Container images" >> $GITHUB_STEP_SUMMARY
+          echo >> $GITHUB_STEP_SUMMARY
+          echo Containers matching expression '`'"$SPEC"'`' were pushed to the container registry. >> $GITHUB_STEP_SUMMARY
+          echo >> $GITHUB_STEP_SUMMARY
+        else
+          echo "pushed=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/release-controller.yaml
+++ b/.github/workflows/release-controller.yaml
@@ -82,29 +82,19 @@ jobs:
       # Upload container images
       ########################################
 
-      - name: "🔧 Login to GitHub Container Registry"
-        if: ${{ startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: "📦 Push images to GitHub Container Registry"
-        if: ${{ startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
-        shell: bash
-        run: |
-          set -ex -o pipefail
-          bazel query --noshow_progress 'kind("oci_push", ...) intersect //release-controller/...' \
-            | xargs -I_target bazel run _target -- --tag ${GITHUB_SHA}
+        id: push-images
+        uses: ./.github/workflows/push
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          spec: kind("oci_push", ...) intersect //release-controller/...
 
       ########################################
       # Update k8s deployments
-      # FIXME: probably can use registry_publish event to dispatch a separate pipeline.
       ########################################
 
       - name: "🤖 Update k8s deployments for release controller"
-        if: ${{ startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
+        if: ${{ github.ref == 'refs/heads/main' && steps.push-images.outputs.pushed == 'true' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
           files-to-update: bases/apps/ic-release-controller/controller/controller.yaml bases/apps/ic-release-controller/commit-annotator/commit-annotator.yaml


### PR DESCRIPTION
We use Bazel's `pushed blob` status update to detect when a container was actually pushed to the container registry.