### PR TITLE
Add push-token input for OCI image pushing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -96,6 +96,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           spec: kind("oci_push", ...) except //release-controller/...
+          push-token: ${{ secrets.GITHUB_TOKEN }}
 
       ########################################
       # Deploy to github pages

--- a/.github/workflows/push/action.yaml
+++ b/.github/workflows/push/action.yaml
@@ -7,6 +7,9 @@ inputs:
     required: false
     default: >-
       kind("oci_push", ...)'
+  push-token:
+    description: "The token required to push OCI images"
+    required: true
 
 outputs:
   pushed:
@@ -23,7 +26,7 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ inputs.push-token }}
     - id: push
       name: "📦 Push images to GitHub Container Registry"
       shell: bash

--- a/.github/workflows/release-controller.yaml
+++ b/.github/workflows/release-controller.yaml
@@ -88,6 +88,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           spec: kind("oci_push", ...) intersect //release-controller/...
+          push-token: ${{ secrets.GITHUB_TOKEN }}
 
       ########################################
       # Update k8s deployments


### PR DESCRIPTION
The secret is not available in the composite action.

Fixes this:

![image](https://github.com/user-attachments/assets/f831dff3-c8a6-4e54-8aa6-8ca612213259)
