### PR TITLE
Make DRE CLI tests cacheable.

### DIFF
--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -42,7 +42,8 @@ rust_binary(
 )
 
 rust_binary(
-    name = "dre-embedded", # Variant does not have an embedded git revision, which permits caching of dependents.
+    # Variant does not have an embedded git revision, which permits caching of dependents.
+    name = "dre-embedded",
     srcs = glob(["src/**/*.rs"]),
     aliases = aliases(),
     rustc_env_files = [],
@@ -78,7 +79,7 @@ rust_test(
         normal_dev = True,
         proc_macro_dev = True,
     ),
-    crate = ":dre",
+    crate = ":dre-embedded",
     proc_macro_deps = all_crate_deps(
         proc_macro_dev = True,
     ),


### PR DESCRIPTION
Each time a push happens to a PR, `dre` gets rebuilt, because the version changes.  CLI unit tests depend on this target.  As a result, the tests are run all over again, wastefully, for no good reason at all.

This PR fixes that.

This change does *not* make the build of the `dre` target cacheable!  This change only makes the tests depend on the cacheable version of the target.

Before:

![image](https://github.com/user-attachments/assets/3385f4ff-b416-46ef-b015-3afc3691385d)

After:

![image](https://github.com/user-attachments/assets/1c1e717b-f478-4b1a-bfe9-a39c44f0829b)

Rant:

We should strongly consider not adding any version junk into any of our binaries **unless those binaries are going to go through an actual release pipeline** (e.g. the actual `dre` binary built for user download).  Stuff shipped in containers _does not need a version number!_  The container already has that information in the tag.