### PR TITLE
Fix: Redirect stderr to stdout for bazel command in GitHub action

### DIFF
--- a/.github/workflows/push/action.yaml
+++ b/.github/workflows/push/action.yaml
@@ -36,7 +36,7 @@ runs:
         set -ex -o pipefail
         t=$(mktemp) ; trap 'rm -f "$t"' EXIT
         bazel query --noshow_progress "$SPEC" \
-          | xargs -I_target bazel run --test_env=HOME=/home/runner _target -- --tag ${GITHUB_SHA} | tee "$t" >&2
+          | xargs -I_target bazel run --test_env=HOME=/home/runner _target -- --tag ${GITHUB_SHA} 2>&1 | tee "$t" >&2
         if grep -q 'pushed blob' "$t"
         then
           echo "pushed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This update redirects the standard error stream (stderr) to the standard output stream (stdout) for the bazel command within the GitHub action workflow. This change ensures that all command outputs are captured in the tee file, to capture the actual pushed blob text needed to trigger the caller action to create or update the PR.