### PR TITLE
Quiet down the release controller's components

### DIFF
--- a/release-controller/git_repo.py
+++ b/release-controller/git_repo.py
@@ -290,7 +290,7 @@ class GitRepo:
     def fetch(self) -> None:
         """Fetch the repository."""
         if (self.dir / ".git").exists():
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Updating repository in %s to latest origin/%s",
                 self.dir,
                 self.main_branch,

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -687,7 +687,8 @@ class Reconciler:
                     proposal_id_retriever=self.state.version_proposal,
                 )
 
-        logger.info("Iteration completed. %s releases processed.", len(releases))
+        if versions:
+            logger.info("Iteration completed. %s releases processed.", len(versions))
 
 
 dre_repo = "dfinity/dre"


### PR DESCRIPTION
- Changed the log level of `GitRepo.fetch` from `INFO` to `DEBUG` to provide more detailed information about repository updates.
- Added a conditional check in `Reconciler` to only log the number of releases processed if there are any versions.