### PR TITLE
Fix creation of rollout PRs for containers in k8s

### DIFF
--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -34,7 +34,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "📦 Push images to GitHub Container Registry"
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         run: |
           docker push ghcr.io/dfinity/dre/ic-management-frontend:$GITHUB_SHA
 
@@ -42,7 +42,7 @@ jobs:
       # Update k8s deployments
       ########################################
       - name: "🤖 Update k8s deployments"
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'container') || startsWith(github.ref, 'refs/heads/container') || (github.ref == 'refs/heads/main') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
           files-to-update: bases/apps/mainnet-dashboard/frontend/deployment.yaml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: "📦 Push images to GitHub Container Registry"
         id: push-images
         uses: ./.github/workflows/push
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         with:
           spec: kind("oci_push", ...) except //release-controller/...
           push-token: ${{ secrets.GITHUB_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
       # Update k8s deployments
       ########################################
       - name: "🤖 Update k8s deployments"
-        if: ${{ github.ref == 'refs/heads/main' && steps.push-images.outputs.pushed == 'true' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
           files-to-update: bases/apps/mainnet-dashboard/backend/base/deployment.yaml bases/apps/mainnet-dashboard/statefulset-slack.yaml bases/apps/service-discovery/service-discovery.yaml .github/workflows/dre-vector-configs.yaml

--- a/.github/workflows/release-controller.yaml
+++ b/.github/workflows/release-controller.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: "📦 Push images to GitHub Container Registry"
         id: push-images
         uses: ./.github/workflows/push
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         with:
           spec: kind("oci_push", ...) intersect //release-controller/...
           push-token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
       ########################################
 
       - name: "🤖 Update k8s deployments for release controller"
-        if: ${{ github.ref == 'refs/heads/main' && steps.push-images.outputs.pushed == 'true' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
           files-to-update: bases/apps/ic-release-controller/controller/controller.yaml bases/apps/ic-release-controller/commit-annotator/commit-annotator.yaml

--- a/.github/workflows/trusted-neurons-alerts.yaml
+++ b/.github/workflows/trusted-neurons-alerts.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: "📦 Push images to GitHub Container Registry"
         id: push-images
         uses: ./.github/workflows/push
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         with:
           spec: kind("oci_push", ...) intersect //trusted-neurons-alerts/...
           push-token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
       ########################################
 
       - name: "🤖 Update k8s deployments for trusted neurons alerts"
-        if: ${{ github.ref == 'refs/heads/main' && steps.push-images.outputs.pushed == 'true' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         uses: ./.github/workflows/update-k8s-deployments
         with:
           files-to-update: bases/apps/trusted-neurons-slack-app/manifests.yaml


### PR DESCRIPTION
For some reason now Bazel is not actually printing when it's pushing containers out to the container registry.  This broke the creation of PRs to update containers in k8s.

Thus, we now unconditionally create or update the rollout PRs when merging to `main`, and additionally when the workflow is manually dispatched.