### PR TITLE
Update setup-bazelisk to v3 to fix our CI

### DIFF
--- a/.github/workflows/manage-runner-pre/action.yaml
+++ b/.github/workflows/manage-runner-pre/action.yaml
@@ -41,7 +41,7 @@ runs:
         tool-cache: true
         large-packages: true  # this is slow
 
-    - uses: bazelbuild/setup-bazelisk@v2
+    - uses: bazelbuild/setup-bazelisk@v3
 
     ########################################
     # Download and unpack cache
@@ -56,7 +56,7 @@ runs:
         # https://github.com/actions/cache/blob/main/examples.md#---bazel
         key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE.bazel', 'Cargo.Bazel.lock', 'requirements.lock') }}
         restore-keys: |
-            ${{ runner.os }}-bazel-
+          ${{ runner.os }}-bazel-
 
     - name: "🧹 Clean bazel cache if we're preparing a new release"
       if: ${{ startsWith(github.ref, 'refs/tags/v') && !startsWith(runner.name, 'dre-runner-custom') }}


### PR DESCRIPTION
V2 started failing since yesterday.
bazelbuild was archived by the owner on Mar 11, 2024. It is now read-only. 
We should update to https://github.com/bazel-contrib/setup-bazel
