### PR TITLE
Quiet down logging for pydiscourse.client

### DIFF
--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -762,6 +762,7 @@ def main() -> None:
         load_dotenv()
 
     conventional_logging(opts.one_line_logs, opts.verbose)
+    logging.getLogger("pydiscourse.client").setLevel(logging.INFO)
 
     # Prep the program for longer timeouts.
     socket.setdefaulttimeout(60)


### PR DESCRIPTION
This change enables INFO level logging for the `pydiscourse.client` module.  At DEBUG level, `pydiscourse.client` produces enormously long lines with all the content of the forum posts, which then get chopped up by our logging infrastructure and appear as random noise on our dashboards.

This will require a quick rollout of the reconciler.