### PR TITLE
Instruction counter metrics.

### DIFF
--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -92,7 +92,7 @@ fn post_upgrade() {
 #[query(hidden = true, decoding_quota = 10000)]
 fn http_request(request: HttpRequest) -> HttpResponse {
     match request.path() {
-        "/metrics" => serve_metrics(|encoder| telemetry::PROMETHEUS_METRICS.with(|m| telemetry::encode_metrics(&m.borrow(), encoder))),
+        "/metrics" => serve_metrics(|encoder| telemetry::PROMETHEUS_METRICS.with(|m| m.borrow().encode_metrics(encoder))),
         _ => HttpResponseBuilder::not_found().build(),
     }
 }

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -18,43 +18,30 @@ mod telemetry;
 const HOUR_IN_SECONDS: u64 = 60 * 60;
 const DAY_IN_SECONDS: u64 = HOUR_IN_SECONDS * 24;
 
-struct InstructionCounter {
-    start: u64,
-    total: u64,
-}
-
-impl InstructionCounter {
-    fn new() -> Self {
-        Self {
-            start: ic_cdk::api::instruction_counter(),
-            total: 0,
-        }
-    }
-    fn add_up(&mut self) -> u64 {
-        let now = ic_cdk::api::instruction_counter();
-        self.start = now;
-        self.total += now;
-        self.total
-    }
-}
-
 /// Sync the local registry and subnets metrics with remote
 ///
 /// - Sync local registry stored from the remote registry canister
 /// - Sync subnets metrics from the management canister of the different subnets
 async fn sync_all() {
-    let mut counter = InstructionCounter::new();
+    let mut counter = telemetry::InstructionCounter::new();
     telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_sync_start());
     let registry_store = REGISTRY_STORE.with(|m| m.clone());
 
-    counter.add_up();
-    match registry_store.schedule_registry_sync().await {
+    counter.lap();
+    let result = registry_store.schedule_registry_sync().await;
+    let registry_sync_instructions = counter.lap();
+
+    let mut subnet_list_instructions: u64 = 0;
+    let mut update_subnet_metrics_instructions: u64 = 0;
+
+    match result {
         Ok(_) => {
             let metrics_manager = METRICS_MANAGER.with(|m| m.clone());
+            counter.lap();
             let subnets_list = registry_store.subnets_list();
-
-            counter.add_up();
+            subnet_list_instructions = counter.lap();
             metrics_manager.update_subnets_metrics(subnets_list).await;
+            update_subnet_metrics_instructions = counter.lap();
 
             telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_sync_success());
             ic_cdk::println!("Successfully synced subnets metrics and local registry");
@@ -65,7 +52,12 @@ async fn sync_all() {
         }
     }
 
-    telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.record_instructions(counter.add_up()));
+    telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| {
+        m.record_sync_instructions(counter.sum());
+        m.record_registry_sync_instructions(registry_sync_instructions);
+        m.record_subnet_list_instructions(subnet_list_instructions);
+        m.record_update_subnet_metrics_instructions(update_subnet_metrics_instructions)
+    });
 }
 
 fn setup_timers() {

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -92,7 +92,7 @@ pub fn encode_metrics(metrics: &telemetry::PrometheusMetrics, w: &mut ic_metrics
     // * Any other positive number -> at least one calculation has started.
     w.encode_gauge(
         "last_calculation_start_timestamp_seconds",
-        metrics.last_calculation_start,
+        metrics.last_sync_start,
         "Last time the calculation of metrics started.  If this metric is present but zero, the first calculation during this canister's current execution has not yet begun or taken place.",
     )?;
     // Calculation finish timestamp seconds.
@@ -101,7 +101,7 @@ pub fn encode_metrics(metrics: &telemetry::PrometheusMetrics, w: &mut ic_metrics
     // * last_calculation_end_timestamp_seconds - last_calculation_start_timestamp_seconds < 0 -> calculation ongoing, not finished yet
     w.encode_gauge(
         "last_calculation_end_timestamp_seconds",
-        metrics.last_calculation_end,
+        metrics.last_sync_end,
         "Last time the calculation of metrics ended (successfully or with failure).  If this metric is present but zero, the first calculation during this canister's current execution has not started or finished yet, either successfully or with errors.   Else, subtracting this from the last calculation start should yield a positive value if the calculation ended (successfully or with errors), and a negative value if the calculation is still ongoing but has not finished.",
     )?;
     // Calculation success timestamp seconds.
@@ -110,7 +110,7 @@ pub fn encode_metrics(metrics: &telemetry::PrometheusMetrics, w: &mut ic_metrics
     // * last_calculation_end_timestamp_seconds != last_calculation_success_timestamp_seconds -> last calculation failed
     w.encode_gauge(
         "last_calculation_success_timestamp_seconds",
-        metrics.last_calculation_success,
+        metrics.last_sync_success,
         "Last time the calculation of metrics succeeded.  If this metric is present but zero, no calculation has yet succeeded during this canister's current execution.  Else, subtracting this number from last_calculation_start_timestamp_seconds gives a positive time delta when the last calculation succeeded, or a negative value if either the last calculation failed or a calculation is currently being performed.  By definition, this and last_calculation_end_timestamp_seconds will be identical when the last calculation succeeded.",
     )?;
 

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -53,10 +53,12 @@ async fn sync_all() {
     }
 
     telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| {
-        m.record_sync_instructions(counter.sum());
-        m.record_registry_sync_instructions(registry_sync_instructions);
-        m.record_subnet_list_instructions(subnet_list_instructions);
-        m.record_update_subnet_metrics_instructions(update_subnet_metrics_instructions)
+        m.record_last_sync_instructions(
+            counter.sum(),
+            registry_sync_instructions,
+            subnet_list_instructions,
+            update_subnet_metrics_instructions,
+        )
     });
 }
 

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -23,7 +23,7 @@ const DAY_IN_SECONDS: u64 = HOUR_IN_SECONDS * 24;
 /// - Sync local registry stored from the remote registry canister
 /// - Sync subnets metrics from the management canister of the different subnets
 async fn sync_all() {
-    telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_calculation_start());
+    telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_sync_start());
     let registry_store = REGISTRY_STORE.with(|m| m.clone());
 
     match registry_store.schedule_registry_sync().await {
@@ -32,11 +32,11 @@ async fn sync_all() {
             let subnets_list = registry_store.subnets_list();
 
             metrics_manager.update_subnets_metrics(subnets_list).await;
-            telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_calculation_success());
+            telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_sync_success());
             ic_cdk::println!("Successfully synced subnets metrics and local registry");
         }
         Err(e) => {
-            telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_calculation_end());
+            telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_sync_end());
             ic_cdk::println!("Failed to sync local registry: {:?}", e)
         }
     }
@@ -71,56 +71,10 @@ fn post_upgrade() {
     setup_timers();
 }
 
-pub fn encode_metrics(metrics: &telemetry::PrometheusMetrics, w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
-    // General resource consumption.
-    w.encode_gauge(
-        "canister_stable_memory_size_bytes",
-        ic_nervous_system_common::stable_memory_size_bytes() as f64,
-        "Size of the stable memory allocated by this canister measured in bytes.",
-    )?;
-    w.encode_gauge(
-        "canister_total_memory_size_bytes",
-        ic_nervous_system_common::total_memory_size_bytes() as f64,
-        "Size of the total memory allocated by this canister measured in bytes.",
-    )?;
-
-    // Calculation signals.
-
-    // Calculation start timestamp seconds.
-    //
-    // * 0.0 -> first calculation not yet begun since canister started.
-    // * Any other positive number -> at least one calculation has started.
-    w.encode_gauge(
-        "last_calculation_start_timestamp_seconds",
-        metrics.last_sync_start,
-        "Last time the calculation of metrics started.  If this metric is present but zero, the first calculation during this canister's current execution has not yet begun or taken place.",
-    )?;
-    // Calculation finish timestamp seconds.
-    // * 0.0 -> first calculation not yet finished since canister started.
-    // * last_calculation_end_timestamp_seconds - last_calculation_start_timestamp_seconds > 0 -> last calculation finished, next calculation not started yet
-    // * last_calculation_end_timestamp_seconds - last_calculation_start_timestamp_seconds < 0 -> calculation ongoing, not finished yet
-    w.encode_gauge(
-        "last_calculation_end_timestamp_seconds",
-        metrics.last_sync_end,
-        "Last time the calculation of metrics ended (successfully or with failure).  If this metric is present but zero, the first calculation during this canister's current execution has not started or finished yet, either successfully or with errors.   Else, subtracting this from the last calculation start should yield a positive value if the calculation ended (successfully or with errors), and a negative value if the calculation is still ongoing but has not finished.",
-    )?;
-    // Calculation success timestamp seconds.
-    // * 0.0 -> no calculation has yet succeeded since canister started.
-    // * last_calculation_end_timestamp_seconds == last_calculation_success_timestamp_seconds -> last calculation finished successfully
-    // * last_calculation_end_timestamp_seconds != last_calculation_success_timestamp_seconds -> last calculation failed
-    w.encode_gauge(
-        "last_calculation_success_timestamp_seconds",
-        metrics.last_sync_success,
-        "Last time the calculation of metrics succeeded.  If this metric is present but zero, no calculation has yet succeeded during this canister's current execution.  Else, subtracting this number from last_calculation_start_timestamp_seconds gives a positive time delta when the last calculation succeeded, or a negative value if either the last calculation failed or a calculation is currently being performed.  By definition, this and last_calculation_end_timestamp_seconds will be identical when the last calculation succeeded.",
-    )?;
-
-    Ok(())
-}
-
 #[query(hidden = true, decoding_quota = 10000)]
 fn http_request(request: HttpRequest) -> HttpResponse {
     match request.path() {
-        "/metrics" => serve_metrics(|encoder| telemetry::PROMETHEUS_METRICS.with(|m| encode_metrics(&m.borrow(), encoder))),
+        "/metrics" => serve_metrics(|encoder| telemetry::PROMETHEUS_METRICS.with(|m| telemetry::encode_metrics(&m.borrow(), encoder))),
         _ => HttpResponseBuilder::not_found().build(),
     }
 }

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -23,13 +23,13 @@ const DAY_IN_SECONDS: u64 = HOUR_IN_SECONDS * 24;
 /// - Sync local registry stored from the remote registry canister
 /// - Sync subnets metrics from the management canister of the different subnets
 async fn sync_all() {
-    let mut counter = telemetry::InstructionCounter::new();
+    let mut instruction_counter = telemetry::InstructionCounter::new();
     telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_sync_start());
     let registry_store = REGISTRY_STORE.with(|m| m.clone());
 
-    counter.lap();
+    instruction_counter.lap();
     let result = registry_store.schedule_registry_sync().await;
-    let registry_sync_instructions = counter.lap();
+    let registry_sync_instructions = instruction_counter.lap();
 
     let mut subnet_list_instructions: u64 = 0;
     let mut update_subnet_metrics_instructions: u64 = 0;
@@ -37,11 +37,11 @@ async fn sync_all() {
     match result {
         Ok(_) => {
             let metrics_manager = METRICS_MANAGER.with(|m| m.clone());
-            counter.lap();
+            instruction_counter.lap(); // Reset the lap time.
             let subnets_list = registry_store.subnets_list();
-            subnet_list_instructions = counter.lap();
+            subnet_list_instructions = instruction_counter.lap();
             metrics_manager.update_subnets_metrics(subnets_list).await;
-            update_subnet_metrics_instructions = counter.lap();
+            update_subnet_metrics_instructions = instruction_counter.lap();
 
             telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| m.mark_last_sync_success());
             ic_cdk::println!("Successfully synced subnets metrics and local registry");
@@ -54,7 +54,7 @@ async fn sync_all() {
 
     telemetry::PROMETHEUS_METRICS.with_borrow_mut(|m| {
         m.record_last_sync_instructions(
-            counter.sum(),
+            instruction_counter.sum(),
             registry_sync_instructions,
             subnet_list_instructions,
             update_subnet_metrics_instructions,

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -71,7 +71,7 @@ fn post_upgrade() {
     setup_timers();
 }
 
-pub fn encode_metrics(metrics: &PrometheusMetrics, w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
+pub fn encode_metrics(metrics: &telemetry::PrometheusMetrics, w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     // General resource consumption.
     w.encode_gauge(
         "canister_stable_memory_size_bytes",
@@ -120,7 +120,7 @@ pub fn encode_metrics(metrics: &PrometheusMetrics, w: &mut ic_metrics_encoder::M
 #[query(hidden = true, decoding_quota = 10000)]
 fn http_request(request: HttpRequest) -> HttpResponse {
     match request.path() {
-        "/metrics" => serve_metrics(|encoder| PROMETHEUS_METRICS.with(|m| encode_metrics(&m.borrow(), encoder))),
+        "/metrics" => serve_metrics(|encoder| telemetry::PROMETHEUS_METRICS.with(|m| encode_metrics(&m.borrow(), encoder))),
         _ => HttpResponseBuilder::not_found().build(),
     }
 }

--- a/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
@@ -3,34 +3,72 @@ use std::cell::RefCell;
 #[derive(Default)]
 pub struct PrometheusMetrics {
     /// Records the time the last sync began.
-    pub last_sync_start: f64,
+    last_sync_start: f64,
     /// Records the time that sync last succeeded.
-    pub last_sync_success: f64,
+    last_sync_success: f64,
     /// Records the time that sync last ended (successfully or in failure).
     /// If last_sync_start > last_sync_end, sync is in progress, else sync is not taking place.
     /// If last_sync_success == last_sync_end, last sync was successful.
-    pub last_sync_end: f64,
+    last_sync_end: f64,
 }
+
+static LAST_SYNC_START_HELP: &str = "Last time the calculation of metrics started.  If this metric is present but zero, the first calculation during this canister's current execution has not yet begun or taken place.";
+static LAST_SYNC_END_HELP: &str = "Last time the calculation of metrics ended (successfully or with failure).  If this metric is present but zero, the first calculation during this canister's current execution has not started or finished yet, either successfully or with errors.   Else, subtracting this from the last calculation start should yield a positive value if the calculation ended (successfully or with errors), and a negative value if the calculation is still ongoing but has not finished.";
+static LAST_SYNC_SUCCESS_HELP: &str = "Last time the calculation of metrics succeeded.  If this metric is present but zero, no calculation has yet succeeded during this canister's current execution.  Else, subtracting this number from last_sync_start_timestamp_seconds gives a positive time delta when the last calculation succeeded, or a negative value if either the last calculation failed or a calculation is currently being performed.  By definition, this and last_sync_end_timestamp_seconds will be identical when the last calculation succeeded.";
 
 impl PrometheusMetrics {
     fn new() -> Self {
         Default::default()
     }
 
-    pub fn mark_last_calculation_start(&mut self) {
+    pub fn mark_last_sync_start(&mut self) {
         self.last_sync_start = (ic_cdk::api::time() / 1_000_000_000) as f64
     }
 
-    pub fn mark_last_calculation_success(&mut self) {
+    pub fn mark_last_sync_success(&mut self) {
         self.last_sync_end = (ic_cdk::api::time() / 1_000_000_000) as f64;
         self.last_sync_success = self.last_sync_end
     }
 
-    pub fn mark_last_calculation_end(&mut self) {
+    pub fn mark_last_sync_end(&mut self) {
         self.last_sync_end = (ic_cdk::api::time() / 1_000_000_000) as f64
     }
 }
 
 thread_local! {
     pub(crate) static PROMETHEUS_METRICS: RefCell<PrometheusMetrics> = RefCell::new(PrometheusMetrics::new());
+}
+
+pub fn encode_metrics(metrics: &PrometheusMetrics, w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
+    // General resource consumption.
+    w.encode_gauge(
+        "canister_stable_memory_size_bytes",
+        ic_nervous_system_common::stable_memory_size_bytes() as f64,
+        "Size of the stable memory allocated by this canister measured in bytes.",
+    )?;
+    w.encode_gauge(
+        "canister_total_memory_size_bytes",
+        ic_nervous_system_common::total_memory_size_bytes() as f64,
+        "Size of the total memory allocated by this canister measured in bytes.",
+    )?;
+
+    // Calculation signals.
+
+    // Calculation start timestamp seconds.
+    //
+    // * 0.0 -> first calculation not yet begun since canister started.
+    // * Any other positive number -> at least one calculation has started.
+    w.encode_gauge("last_sync_start_timestamp_seconds", metrics.last_sync_start, LAST_SYNC_START_HELP)?;
+    // Calculation finish timestamp seconds.
+    // * 0.0 -> first calculation not yet finished since canister started.
+    // * last_sync_end_timestamp_seconds - last_sync_start_timestamp_seconds > 0 -> last calculation finished, next calculation not started yet
+    // * last_sync_end_timestamp_seconds - last_sync_start_timestamp_seconds < 0 -> calculation ongoing, not finished yet
+    w.encode_gauge("last_sync_end_timestamp_seconds", metrics.last_sync_end, LAST_SYNC_END_HELP)?;
+    // Calculation success timestamp seconds.
+    // * 0.0 -> no calculation has yet succeeded since canister started.
+    // * last_sync_end_timestamp_seconds == last_sync_success_timestamp_seconds -> last calculation finished successfully
+    // * last_sync_end_timestamp_seconds != last_sync_success_timestamp_seconds -> last calculation failed
+    w.encode_gauge("last_sync_success_timestamp_seconds", metrics.last_sync_success, LAST_SYNC_SUCCESS_HELP)?;
+
+    Ok(())
 }

--- a/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
@@ -12,16 +12,16 @@ impl PrometheusMetrics {
         Default::default()
     }
 
-    fn mark_last_calculation_start(&mut self) {
+    pub fn mark_last_calculation_start(&mut self) {
         self.last_calculation_start = (ic_cdk::api::time() / 1_000_000_000) as f64
     }
 
-    fn mark_last_calculation_success(&mut self) {
+    pub fn mark_last_calculation_success(&mut self) {
         self.last_calculation_end = (ic_cdk::api::time() / 1_000_000_000) as f64;
         self.last_calculation_success = self.last_calculation_end
     }
 
-    fn mark_last_calculation_end(&mut self) {
+    pub fn mark_last_calculation_end(&mut self) {
         self.last_calculation_end = (ic_cdk::api::time() / 1_000_000_000) as f64
     }
 }

--- a/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
@@ -2,9 +2,9 @@ use std::cell::RefCell;
 
 #[derive(Default)]
 pub struct PrometheusMetrics {
-    last_calculation_start: f64,
-    last_calculation_success: f64,
-    last_calculation_end: f64,
+    pub last_calculation_start: f64,
+    pub last_calculation_success: f64,
+    pub last_calculation_end: f64,
 }
 
 impl PrometheusMetrics {

--- a/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
@@ -10,11 +10,13 @@ pub struct PrometheusMetrics {
     /// If last_sync_start > last_sync_end, sync is in progress, else sync is not taking place.
     /// If last_sync_success == last_sync_end, last sync was successful.
     last_sync_end: f64,
+    /// Publishes the instruction count that the last sync incurred.
+    last_sync_instructions: f64,
 }
 
-static LAST_SYNC_START_HELP: &str = "Last time the calculation of metrics started.  If this metric is present but zero, the first calculation during this canister's current execution has not yet begun or taken place.";
-static LAST_SYNC_END_HELP: &str = "Last time the calculation of metrics ended (successfully or with failure).  If this metric is present but zero, the first calculation during this canister's current execution has not started or finished yet, either successfully or with errors.   Else, subtracting this from the last calculation start should yield a positive value if the calculation ended (successfully or with errors), and a negative value if the calculation is still ongoing but has not finished.";
-static LAST_SYNC_SUCCESS_HELP: &str = "Last time the calculation of metrics succeeded.  If this metric is present but zero, no calculation has yet succeeded during this canister's current execution.  Else, subtracting this number from last_sync_start_timestamp_seconds gives a positive time delta when the last calculation succeeded, or a negative value if either the last calculation failed or a calculation is currently being performed.  By definition, this and last_sync_end_timestamp_seconds will be identical when the last calculation succeeded.";
+static LAST_SYNC_START_HELP: &str = "Last time the sync of metrics started.  If this metric is present but zero, the first sync during this canister's current execution has not yet begun or taken place.";
+static LAST_SYNC_END_HELP: &str = "Last time the sync of metrics ended (successfully or with failure).  If this metric is present but zero, the first sync during this canister's current execution has not started or finished yet, either successfully or with errors.   Else, subtracting this from the last sync start should yield a positive value if the sync ended (successfully or with errors), and a negative value if the sync is still ongoing but has not finished.";
+static LAST_SYNC_SUCCESS_HELP: &str = "Last time the sync of metrics succeeded.  If this metric is present but zero, no sync has yet succeeded during this canister's current execution.  Else, subtracting this number from last_sync_start_timestamp_seconds gives a positive time delta when the last sync succeeded, or a negative value if either the last sync failed or a sync is currently being performed.  By definition, this and last_sync_end_timestamp_seconds will be identical when the last sync succeeded.";
 
 impl PrometheusMetrics {
     fn new() -> Self {

--- a/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
@@ -1,0 +1,31 @@
+use std::cell::RefCell;
+
+#[derive(Default)]
+pub struct PrometheusMetrics {
+    last_calculation_start: f64,
+    last_calculation_success: f64,
+    last_calculation_end: f64,
+}
+
+impl PrometheusMetrics {
+    fn new() -> Self {
+        Default::default()
+    }
+
+    fn mark_last_calculation_start(&mut self) {
+        self.last_calculation_start = (ic_cdk::api::time() / 1_000_000_000) as f64
+    }
+
+    fn mark_last_calculation_success(&mut self) {
+        self.last_calculation_end = (ic_cdk::api::time() / 1_000_000_000) as f64;
+        self.last_calculation_success = self.last_calculation_end
+    }
+
+    fn mark_last_calculation_end(&mut self) {
+        self.last_calculation_end = (ic_cdk::api::time() / 1_000_000_000) as f64
+    }
+}
+
+thread_local! {
+    pub(crate) static PROMETHEUS_METRICS: RefCell<PrometheusMetrics> = RefCell::new(PrometheusMetrics::new());
+}

--- a/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
@@ -2,9 +2,14 @@ use std::cell::RefCell;
 
 #[derive(Default)]
 pub struct PrometheusMetrics {
-    pub last_calculation_start: f64,
-    pub last_calculation_success: f64,
-    pub last_calculation_end: f64,
+    /// Records the time the last sync began.
+    pub last_sync_start: f64,
+    /// Records the time that sync last succeeded.
+    pub last_sync_success: f64,
+    /// Records the time that sync last ended (successfully or in failure).
+    /// If last_sync_start > last_sync_end, sync is in progress, else sync is not taking place.
+    /// If last_sync_success == last_sync_end, last sync was successful.
+    pub last_sync_end: f64,
 }
 
 impl PrometheusMetrics {
@@ -13,16 +18,16 @@ impl PrometheusMetrics {
     }
 
     pub fn mark_last_calculation_start(&mut self) {
-        self.last_calculation_start = (ic_cdk::api::time() / 1_000_000_000) as f64
+        self.last_sync_start = (ic_cdk::api::time() / 1_000_000_000) as f64
     }
 
     pub fn mark_last_calculation_success(&mut self) {
-        self.last_calculation_end = (ic_cdk::api::time() / 1_000_000_000) as f64;
-        self.last_calculation_success = self.last_calculation_end
+        self.last_sync_end = (ic_cdk::api::time() / 1_000_000_000) as f64;
+        self.last_sync_success = self.last_sync_end
     }
 
     pub fn mark_last_calculation_end(&mut self) {
-        self.last_calculation_end = (ic_cdk::api::time() / 1_000_000_000) as f64
+        self.last_sync_end = (ic_cdk::api::time() / 1_000_000_000) as f64
     }
 }
 

--- a/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/telemetry.rs
@@ -10,8 +10,6 @@ pub struct PrometheusMetrics {
     /// If last_sync_start > last_sync_end, sync is in progress, else sync is not taking place.
     /// If last_sync_success == last_sync_end, last sync was successful.
     last_sync_end: f64,
-    /// Publishes the instruction count that the last sync incurred.
-    last_sync_instructions: f64,
 }
 
 static LAST_SYNC_START_HELP: &str = "Last time the sync of metrics started.  If this metric is present but zero, the first sync during this canister's current execution has not yet begun or taken place.";


### PR DESCRIPTION
This PR introduces instruction counters (as Prometheus gauges) that allow telemetry observers to see:

* the count of instructions that the last sync incurred,
* specific counts of instructions for subnet list, update metrics, registry sync, specifically during the last sync.