### PR TITLE
Call the watchdog when there's a handled exception.

### DIFF
--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -475,6 +475,7 @@ def main() -> None:
             if opts.loop_every <= 0:
                 raise
             else:
+                watchdog.report_healthy()
                 and_now = time.time()
                 LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
                 LAST_CYCLE_SUCCESSFUL.set(0)

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -885,6 +885,7 @@ def main() -> None:
             if opts.loop_every <= 0:
                 raise
             else:
+                watchdog.report_healthy()
                 and_now = time.time()
                 LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
                 LOGGER.exception(


### PR DESCRIPTION
This makes it so that the watchdog only crashes and restarts the process when the process is truly stuck.