### PR TITLE
Improve HostOS release notes generation.

### DIFF
--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -36,7 +36,7 @@ env = {
 py_binary(
     name = "release-controller",
     main = "reconciler.py",
-    srcs = glob(["*.py"], exclude = ["commit_annotator.py"]),
+    srcs = glob(["*.py"]),
     tags = ["typecheck"],
     env = {
         "DRE_PATH": "$(rootpath //rs/cli:dre-embedded)",
@@ -44,7 +44,7 @@ py_binary(
     deps = deps + [
         requirement("prometheus-client"),
     ],
-    data = ["//rs/cli:dre-embedded"],
+    data = ["//rs/cli:dre-embedded"] + [":bazelisk", ":target_determinator"],
 )
 
 py_binary(

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -62,11 +62,13 @@ py_binary(
 py_binary(
     name = "release-notes",
     main = "release_notes.py",
-    srcs = ["release_notes.py", "git_repo.py", "const.py", "release_index.py", "util.py"],
+    srcs = ["release_notes.py", "git_repo.py", "const.py", "release_index.py", "util.py", "commit_annotator.py", "watchdog.py"],
     tags = ["typecheck"],
-    data = [],
+    data = [":bazelisk", ":target_determinator"],
     env = env,
-    deps = deps
+    deps = deps + [
+        requirement("prometheus-client"),
+    ]
 )
 
 native_binary(

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -252,14 +252,14 @@ bazel run //release-controller:release-notes -- \
   --verbose
 ```
 
-The form of the command above uses an internal commit annotator that
-uses the annotatiosn already saved in the IC repository by the production
-commit annotator.  If you want to use a local commit annotator, running
-on your machine, add option `--commit-annotator-url http://localhost:9469/`.
-If you want to recalculate the commit annotations instead of using cached
-ones, you can use option `--commit-annotator-url recreate`.  This last
-option is useful when testing the effects of changes made to the commit
-annotator code or Bazel query formulas the annotator uses.
+The form of the command above requires you to run a commit annotator in
+parallel.  If you want to use the internal commit annotator that does not
+need a commit annotator running in parallel, add option
+`--commit-annotator-url local` instead.  If you want to *recalculate* the
+commit annotations instead of using cached ones, you can use option
+`--commit-annotator-url recreate`.  This last option is useful when
+testing the effects of changes made to the commit annotator code or Bazel
+query formulas the annotator uses.
 
 Please consult `--help` for additional options.
 

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -238,6 +238,31 @@ bazel run //release-controller:commit-annotator \
 
 Please consult `--help` for additional options.
 
+### Generate release notes locally
+
+Release notes can be generated locally, using the following command:
+
+```sh
+PREV_RC=rc--2025-03-27_03-14-base
+PREV_COMMIT=3ae3649a2366aaca83404b692fc58e4c6e604a25
+CURR_RC=rc--2025-04-03_03-15
+CURR_COMMIT=68fc31a141b25f842f078c600168d8211339f422
+bazel run //release-controller:release-notes -- \
+   $PREV_RC $PREV_COMMIT $CURR_RC $CURR_COMMIT \
+  --verbose
+```
+
+The form of the command above uses an internal commit annotator that
+uses the annotatiosn already saved in the IC repository by the production
+commit annotator.  If you want to use a local commit annotator, running
+on your machine, add option `--commit-annotator-url http://localhost:9469/`.
+If you want to recalculate the commit annotations instead of using cached
+ones, you can use option `--commit-annotator-url recreate`.  This last
+option is useful when testing the effects of changes made to the commit
+annotator code or Bazel query formulas the annotator uses.
+
+Please consult `--help` for additional options.
+
 ### Tests
 
 #### Unit tests

--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -142,15 +142,9 @@ def compute_annotations_for_object(
         text=True,
         cwd=annotator.dir,
     )
-    lap = time.time() - start
-    logger.debug("bazel query finished in %.2f seconds", lap)
-
     target_determinator_output = target_determinator(
         annotator.dir, annotator.parent(object), targets
     )
-    lap = time.time() - start
-    logger.debug("target-determinator finished in %.2f seconds", lap)
-
     lap = time.time() - start
     logger.debug("Annotation finished in %.2f seconds", lap)
     return (
@@ -161,7 +155,13 @@ def compute_annotations_for_object(
                 if line.strip() and not line.startswith("@")
             ]
         ),
-        target_determinator_output,
+        "\n".join(
+            [
+                line
+                for line in target_determinator_output.splitlines()
+                if line.strip() and not line.startswith("@")
+            ]
+        ),
         (COMMIT_BELONGS if target_determinator_output else COMMIT_DOES_NOT_BELONG),
     )
 

--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -328,7 +328,7 @@ def main() -> None:
         "--no-save-annotations",
         action="store_false",
         dest="save_annotations",
-        help="The default is to save annotations locally.  This option turns it off.  The upside is that, on every loop, the annotator attempts to re-annotate the same commits it had annotated before",
+        help="The default is to save annotations locally.  This option turns it off.  The upside is that, on every loop, the annotator attempts to re-annotate the same commits it had annotated before.",
     )
     parser.add_argument(
         "--no-fetch-annotations",
@@ -336,12 +336,18 @@ def main() -> None:
         dest="fetch_annotations",
         help="The default is to fetch annotations from the repository on every loop, overwriting local annotations. This option turns off that behavior.",
     )
-    parser.add_argument("--verbose", "--debug", action="store_true", dest="verbose")
+    parser.add_argument(
+        "--verbose",
+        "--debug",
+        action="store_true",
+        dest="verbose",
+        help="Bump log level.",
+    )
     parser.add_argument(
         "--one-line-logs",
         action="store_true",
         dest="one_line_logs",
-        help="Make log lines one-line without timestamps (useful in production container for better filtering)",
+        help="Make log lines one-line without timestamps (useful in production container for better filtering).",
     )
     parser.add_argument(
         "--loop-every",
@@ -364,7 +370,7 @@ def main() -> None:
         default="master,rc--*",
         type=str,
         dest="branch_globs",
-        help="Use this branch glob (or comma-separated list of globs) to determine which branches to annotate",
+        help="Use this branch glob (or comma-separated list of globs) to determine which branches to annotate.",
     )
     parser.add_argument(
         "--skip-branch-older-than",

--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -9,6 +9,7 @@ import re
 import threading
 import time
 import typing
+import urllib
 from prometheus_client import start_http_server, Gauge
 
 sys.path.append(os.path.join(os.path.dirname(__file__)))
@@ -255,6 +256,127 @@ def annotate_commits_of_branch(
         logger.info("Successfully annotated %s commits", len(commits))
     else:
         COMMITS_BEHIND.labels(branch).set(0)
+
+
+class NotReady(Exception):
+    """Exception raised when a commit is not yet annotated."""
+
+    pass
+
+
+class LocalCommitChangeDeterminator(object):
+    """Retrieves annotations from a local Git repository."""
+
+    def __init__(self, ic_repo: GitRepo):
+        """
+        Creates a new commit change determinator.
+
+        Upon creation, the freshest notes are fetched.
+        """
+        self.annotator = GitRepoAnnotator(
+            ic_repo,
+            list(CHANGED_NOTES_NAMESPACES.values()),
+            save_annotations=False,
+        )
+        self.annotator.fetch()
+
+    def commit_changes_artifact(
+        self, commit: str, os_kind: OsKind
+    ) -> CommitInclusionState:
+        """
+        Check if the os_kind (artifact) changed in the specifed commit
+        by querying the local repo for git notes populated and pushed
+        by commit annotator.
+        """
+        namespace = CHANGED_NOTES_NAMESPACES[os_kind]
+        try:
+            changed = (
+                self.annotator.get(namespace=namespace, object=commit)
+                .decode("utf-8")
+                .strip()
+            )
+        except KeyError:
+            raise NotReady(
+                f"Could not find {os_kind} label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."
+            )
+        assert changed in [
+            COMMIT_BELONGS,
+            COMMIT_DOES_NOT_BELONG,
+            COMMIT_COULD_NOT_BE_ANNOTATED,
+        ], "Expected a specific CommitInclusionState, not %r" % changed
+        return typing.cast(CommitInclusionState, changed)
+
+
+class RecreatingCommitChangeDeterminator(object):
+    """
+    Computes annotations on the fly from a local Git repository, ignoring existing annotations.
+
+    Annotations made this way are never saved or published to the Git repository.
+    """
+
+    def __init__(self, ic_repo: GitRepo):
+        """
+        Creates a new commit change determinator.
+
+        Upon creation, the freshest notes are fetched.
+        """
+        self.annotator = GitRepoAnnotator(
+            ic_repo,
+            list(CHANGED_NOTES_NAMESPACES.values()),
+            save_annotations=False,
+        )
+
+    def commit_changes_artifact(
+        self, commit: str, os_kind: OsKind
+    ) -> CommitInclusionState:
+        """
+        Check if the os_kind (artifact) changed in the specifed commit
+        by querying the local repo for git notes populated and pushed
+        by commit annotator.
+        """
+
+        _, _, belongs = compute_annotations_for_object(self.annotator, commit, os_kind)
+        assert belongs in [
+            COMMIT_BELONGS,
+            COMMIT_DOES_NOT_BELONG,
+            COMMIT_COULD_NOT_BE_ANNOTATED,
+        ], "Expected a specific CommitInclusionState, not %r" % belongs
+        return belongs
+
+
+class CommitAnnotatorClientCommitChangeDeterminator(object):
+    """Retrieves annotations from a commit annotator API server."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+
+    def commit_changes_artifact(
+        self, commit: str, os_kind: OsKind
+    ) -> CommitInclusionState:
+        """
+        Check if the os_kind (artifact) changed in the specifed commit
+        by querying the commit annotator for git notes.
+        """
+        namespace = CHANGED_NOTES_NAMESPACES[os_kind]
+        url = (
+            self.base_url.rstrip("/")
+            + f"/api/v1/commit/{commit}/annotation/{namespace}"
+        )
+        try:
+            with urllib.request.urlopen(url) as response:
+                changed = response.read().decode("utf-8").strip()
+        except urllib.error.HTTPError as he:
+            if he.code == 404:
+                raise NotReady(
+                    f"Could not find {os_kind} label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."
+                ) from he
+            raise
+        assert changed in [
+            COMMIT_BELONGS,
+            COMMIT_DOES_NOT_BELONG,
+            COMMIT_COULD_NOT_BE_ANNOTATED,
+        ], "Expected a specific CommitInclusionState, not %r" % changed
+        return typing.cast(CommitInclusionState, changed)
 
 
 class APIHandler(http.server.BaseHTTPRequestHandler):

--- a/release-controller/google_docs.py
+++ b/release-controller/google_docs.py
@@ -10,7 +10,8 @@ from pydrive2.drive import GoogleDrive
 
 from const import OsKind, GUESTOS
 from git_repo import GitRepo
-from release_notes import PreparedReleaseNotes, LocalCommitChangeDeterminator
+from release_notes import PreparedReleaseNotes
+from commit_annotator import LocalCommitChangeDeterminator
 
 md = markdown.Markdown(
     extensions=["pymdownx.tilde", "pymdownx.details"],

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -707,17 +707,23 @@ def main() -> None:
         default="http://localhost:9469/",
         help="Base URL of a commit annotator to use in order to determine commit"
         " relevance for a target when composing release notes.  If the string"
-        ""
-        " 'local' is specified, it uses local annotations from the Git repository;"
-        " this mode allows for execution without a commit annotator running"
-        " in parallel on your computer.",
+        " 'local' is specified, it retrieves annotations using an embedded client"
+        " that consults a local Git repository clone of the IC; local mode allows"
+        " running the release controller without a commit annotator running"
+        " simultaneously on this computer.",
     )
-    parser.add_argument("--verbose", "--debug", action="store_true", dest="verbose")
+    parser.add_argument(
+        "--verbose",
+        "--debug",
+        action="store_true",
+        dest="verbose",
+        help="Bump log level.",
+    )
     parser.add_argument(
         "--one-line-logs",
         action="store_true",
         dest="one_line_logs",
-        help="Make log lines one-line without timestamps (useful in production container for better filtering)",
+        help="Make log lines one-line without timestamps (useful in production container for better filtering).",
     )
     parser.add_argument(
         "--loop-every",

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -33,9 +33,11 @@ from release_notes import (
     prepare_release_notes,
     SecurityReleaseNotesRequest,
     OrdinaryReleaseNotesRequest,
+    OSChangeDeterminator,
+)
+from commit_annotator import (
     LocalCommitChangeDeterminator,
     CommitAnnotatorClientCommitChangeDeterminator,
-    OSChangeDeterminator,
     NotReady,
 )
 from util import version_name, conventional_logging, sha256sum_http_response

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -782,7 +782,8 @@ def main() -> None:
         help="Base URL of a commit annotator to use in order to determine commit"
         " relevance for a target when composing release notes; if none specified or 'local'"
         " specified, it uses local annotations; if 'internal' specified, it uses an"
-        " annotator that runs locally in-process and ignores existing annotations",
+        " annotator that runs locally in-process and ignores existing annotations,"
+        " re-annotating every commit involved in the release notes-making process",
     )
     parser.add_argument(
         "--os-kind",

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 import textwrap
 import typing
-import urllib
 
 from dataclasses import dataclass
 
@@ -24,10 +23,14 @@ from const import (  # noqa: E402
     GUESTOS,
     COMMIT_BELONGS,
     COMMIT_COULD_NOT_BE_ANNOTATED,
-    COMMIT_DOES_NOT_BELONG,
     CommitInclusionState,
 )
-from git_repo import GitRepo, GitRepoAnnotator, FileChange, CHANGED_NOTES_NAMESPACES  # noqa: E402
+from commit_annotator import (  # noqa: E402
+    RecreatingCommitChangeDeterminator,
+    LocalCommitChangeDeterminator,
+    CommitAnnotatorClientCommitChangeDeterminator,
+)
+from git_repo import GitRepo, FileChange  # noqa: E402
 from util import auto_progressbar_with_item_descriptions, conventional_logging  # noqa: E402
 
 import markdown  # noqa: E402
@@ -339,12 +342,6 @@ class PreparedReleaseNotes(str):
     pass
 
 
-class NotReady(Exception):
-    """Exception raised when a commit is not yet annotated."""
-
-    pass
-
-
 def prepare_release_notes(
     request: SecurityReleaseNotesRequest | OrdinaryReleaseNotesRequest,
     ic_repo: GitRepo,
@@ -646,125 +643,6 @@ Changes [were removed](https://github.com/dfinity/ic/compare/{release_tag}...{ba
         for change in non_belonging_change:
             notes += format_change(change)
     return notes
-
-
-class LocalCommitChangeDeterminator(object):
-    """Retrieves annotations from a local Git repository."""
-
-    def __init__(self, ic_repo: GitRepo):
-        """
-        Creates a new commit change determinator.
-
-        Upon creation, the freshest notes are fetched.
-        """
-        self.annotator = GitRepoAnnotator(
-            ic_repo,
-            list(CHANGED_NOTES_NAMESPACES.values()),
-            save_annotations=False,
-        )
-        self.annotator.fetch()
-
-    def commit_changes_artifact(
-        self, commit: str, os_kind: OsKind
-    ) -> CommitInclusionState:
-        """
-        Check if the os_kind (artifact) changed in the specifed commit
-        by querying the local repo for git notes populated and pushed
-        by commit annotator.
-        """
-        namespace = CHANGED_NOTES_NAMESPACES[os_kind]
-        try:
-            changed = (
-                self.annotator.get(namespace=namespace, object=commit)
-                .decode("utf-8")
-                .strip()
-            )
-        except KeyError:
-            raise NotReady(
-                f"Could not find {os_kind} label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."
-            )
-        assert changed in [
-            COMMIT_BELONGS,
-            COMMIT_DOES_NOT_BELONG,
-            COMMIT_COULD_NOT_BE_ANNOTATED,
-        ], "Expected a specific CommitInclusionState, not %r" % changed
-        return typing.cast(CommitInclusionState, changed)
-
-
-class RecreatingCommitChangeDeterminator(object):
-    """
-    Computes annotations on the fly from a local Git repository, ignoring existing annotations.
-
-    Annotations made this way are never saved or published to the Git repository.
-    """
-
-    def __init__(self, ic_repo: GitRepo):
-        """
-        Creates a new commit change determinator.
-
-        Upon creation, the freshest notes are fetched.
-        """
-        self.annotator = GitRepoAnnotator(
-            ic_repo,
-            list(CHANGED_NOTES_NAMESPACES.values()),
-            save_annotations=False,
-        )
-        self.annotator.fetch()
-
-    def commit_changes_artifact(
-        self, commit: str, os_kind: OsKind
-    ) -> CommitInclusionState:
-        """
-        Check if the os_kind (artifact) changed in the specifed commit
-        by querying the local repo for git notes populated and pushed
-        by commit annotator.
-        """
-        import commit_annotator
-
-        _, _, belongs = commit_annotator.compute_annotations_for_object(
-            self.annotator, commit, os_kind
-        )
-        assert belongs in [
-            COMMIT_BELONGS,
-            COMMIT_DOES_NOT_BELONG,
-            COMMIT_COULD_NOT_BE_ANNOTATED,
-        ], "Expected a specific CommitInclusionState, not %r" % belongs
-        return belongs
-
-
-class CommitAnnotatorClientCommitChangeDeterminator(object):
-    """Retrieves annotations from a commit annotator API server."""
-
-    def __init__(self, base_url: str):
-        self.base_url = base_url
-
-    def commit_changes_artifact(
-        self, commit: str, os_kind: OsKind
-    ) -> CommitInclusionState:
-        """
-        Check if the os_kind (artifact) changed in the specifed commit
-        by querying the commit annotator for git notes.
-        """
-        namespace = CHANGED_NOTES_NAMESPACES[os_kind]
-        url = (
-            self.base_url.rstrip("/")
-            + f"/api/v1/commit/{commit}/annotation/{namespace}"
-        )
-        try:
-            with urllib.request.urlopen(url) as response:
-                changed = response.read().decode("utf-8").strip()
-        except urllib.error.HTTPError as he:
-            if he.code == 404:
-                raise NotReady(
-                    f"Could not find {os_kind} label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."
-                ) from he
-            raise
-        assert changed in [
-            COMMIT_BELONGS,
-            COMMIT_DOES_NOT_BELONG,
-            COMMIT_COULD_NOT_BE_ANNOTATED,
-        ], "Expected a specific CommitInclusionState, not %r" % changed
-        return typing.cast(CommitInclusionState, changed)
 
 
 def main() -> None:

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -717,15 +717,15 @@ class InternalCommitChangeDeterminator(object):
         """
         import commit_annotator
 
-        _, changed = commit_annotator.compute_annotations_for_object(
+        _, _, belongs = commit_annotator.compute_annotations_for_object(
             self.annotator, commit, os_kind
         )
-        assert changed in [
+        assert belongs in [
             COMMIT_BELONGS,
             COMMIT_DOES_NOT_BELONG,
             COMMIT_COULD_NOT_BE_ANNOTATED,
-        ], "Expected a specific CommitInclusionState, not %r" % changed
-        return changed
+        ], "Expected a specific CommitInclusionState, not %r" % belongs
+        return belongs
 
 
 class CommitAnnotatorClientCommitChangeDeterminator(object):

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -28,7 +28,7 @@ from const import (  # noqa: E402
     CommitInclusionState,
 )
 from git_repo import GitRepo, GitRepoAnnotator, FileChange, CHANGED_NOTES_NAMESPACES  # noqa: E402
-from util import auto_progressbar_with_item_descriptions  # noqa: E402
+from util import auto_progressbar_with_item_descriptions, conventional_logging  # noqa: E402
 
 import markdown  # noqa: E402
 
@@ -777,32 +777,44 @@ def main() -> None:
         "--max-commits",
         type=int,
         default=os.environ.get("MAX_COMMITS", 1000),
-        help="Maximum number of commits to include in the release notes",
+        help="Maximum number of commits to include in the release notes.",
     )
     parser.add_argument(
         "--commit-annotator-url",
         type=str,
-        default=None,
+        dest="commit_annotator_url",
+        default="http://localhost:9469/",
         help="Base URL of a commit annotator to use in order to determine commit"
-        " relevance for a target when composing release notes; if none specified or 'local'"
-        " specified, it uses local annotations; if 'recreate' specified, it uses an"
-        " annotator that runs locally in-process and ignores existing annotations,"
-        " re-annotating every commit involved in the release notes-making process",
+        " relevance for a target when composing release notes; if the value 'local'"
+        " is specified, it retrieves annotations using an embedded client that"
+        " consults a local Git repository clone of the IC; if 'recreate' is specified"
+        " as a value, it ignores any existing annotations and runs a process that"
+        " re-annotates every commit involved in the release notes-making process"
+        " (this is very slow -- roughly a minute per commit to annotate).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "--debug",
+        action="store_true",
+        dest="verbose",
+        help="Bump log level.",
     )
     parser.add_argument(
         "--os-kind",
         default=GUESTOS,
         choices=OS_KINDS,
-        help="Release artifact for which the notes should be prepared",
+        help="Release artifact for which the notes should be prepared.",
     )
     parser.add_argument(
         "--output",
         type=pathlib.Path,
         help="Generate an HTML file with the output besides printing"
         " it to standard output, and launch your operating system's HTML viewer;"
-        " when running via Bazel, please ensure this is an absolute path",
+        " when running via Bazel, please ensure this is an absolute path.",
     )
     args = parser.parse_args()
+
+    conventional_logging(False, args.verbose)
 
     ic_repo = GitRepo("https://github.com/dfinity/ic.git", main_branch="master")
 

--- a/release-controller/release_notes.py
+++ b/release-controller/release_notes.py
@@ -691,8 +691,12 @@ class LocalCommitChangeDeterminator(object):
         return typing.cast(CommitInclusionState, changed)
 
 
-class InternalCommitChangeDeterminator(object):
-    """Computes annotations on the fly from a local Git repository, ignoring existing annotations."""
+class RecreatingCommitChangeDeterminator(object):
+    """
+    Computes annotations on the fly from a local Git repository, ignoring existing annotations.
+
+    Annotations made this way are never saved or published to the Git repository.
+    """
 
     def __init__(self, ic_repo: GitRepo):
         """
@@ -781,7 +785,7 @@ def main() -> None:
         default=None,
         help="Base URL of a commit annotator to use in order to determine commit"
         " relevance for a target when composing release notes; if none specified or 'local'"
-        " specified, it uses local annotations; if 'internal' specified, it uses an"
+        " specified, it uses local annotations; if 'recreate' specified, it uses an"
         " annotator that runs locally in-process and ignores existing annotations,"
         " re-annotating every commit involved in the release notes-making process",
     )
@@ -806,10 +810,10 @@ def main() -> None:
         annotator: (
             LocalCommitChangeDeterminator
             | CommitAnnotatorClientCommitChangeDeterminator
-            | InternalCommitChangeDeterminator
+            | RecreatingCommitChangeDeterminator
         ) = LocalCommitChangeDeterminator(ic_repo)
-    elif args.commit_annotator_url == "internal":
-        annotator = InternalCommitChangeDeterminator(ic_repo)
+    elif args.commit_annotator_url == "recreate":
+        annotator = RecreatingCommitChangeDeterminator(ic_repo)
     else:
         annotator = CommitAnnotatorClientCommitChangeDeterminator(
             args.commit_annotator_url

--- a/release-controller/tests/test_release_notes.py
+++ b/release-controller/tests/test_release_notes.py
@@ -7,7 +7,7 @@ from release_notes import (
     SecurityReleaseNotesRequest,
     Change,
 )
-from commit_annotation import LocalCommitChangeDeterminator
+from commit_annotator import LocalCommitChangeDeterminator
 from git_repo import GitRepo
 from const import GUESTOS, COMMIT_BELONGS
 

--- a/release-controller/tests/test_release_notes.py
+++ b/release-controller/tests/test_release_notes.py
@@ -3,11 +3,11 @@ import tempfile
 from release_notes import (
     prepare_release_notes,
     get_change_description_for_commit,
-    LocalCommitChangeDeterminator,
     OrdinaryReleaseNotesRequest,
     SecurityReleaseNotesRequest,
     Change,
 )
+from commit_annotation import LocalCommitChangeDeterminator
 from git_repo import GitRepo
 from const import GUESTOS, COMMIT_BELONGS
 

--- a/release-controller/util.py
+++ b/release-controller/util.py
@@ -114,7 +114,6 @@ def auto_progressbar_with_item_descriptions(
             file=out,
             flush=True,
         )
-        time.sleep(10)
 
     for i, itemmaybetuple in enumerate(it):
         if isinstance(itemmaybetuple, tuple):

--- a/release-controller/util.py
+++ b/release-controller/util.py
@@ -109,11 +109,12 @@ def auto_progressbar_with_item_descriptions(
         progress_width = int(round(progress * size))
         done_width = size - progress_width
         print(
-            f"{pre}[{'█'*progress_width}{('.'*done_width)}]{post}",
-            end="\r",
+            f"\r{pre}[{'█'*progress_width}{('.'*done_width)}]{post}",
+            end="",
             file=out,
             flush=True,
         )
+        time.sleep(10)
 
     for i, itemmaybetuple in enumerate(it):
         if isinstance(itemmaybetuple, tuple):
@@ -125,7 +126,7 @@ def auto_progressbar_with_item_descriptions(
         if sys.stderr.isatty():
             show(i + 1, desc, item)
     if sys.stderr.isatty():
-        print(f"\r{' '*(termsize())}", end="\r", flush=True, file=out)
+        print(f"\r{' '*(termsize())}", end="\n", flush=True, file=out)
 
 
 def auto_progressbar(


### PR DESCRIPTION
In this commit, we change the query we use for Bazel and `target-determinator` to calculate which targets have been affected on each (main) commit.

This change is powered by the newly-created ability of the `release-notes` program (invokable via Bazel) to use a new implementation of change determination based on a 100% cache-free local `internal` calculation of commit changes, whereby instead of consulting Git notes, the release-notes program manually recomputes everything for every single commit.  This ability was expressly added to improve iteration time when making changes to the `BAZEL_TARGETS` variable.

We also add the targets that `target-determinator` discovered as changed in the specific Git note saved for the purpose.

Finally, a small change to the `progressbar` code allows concomitant messages to print cleanly without tampering with the progress bar.  This does not affect the operation of the program in production.

Attached are the before and after notes, you can `meld` then to verify.

* [before.txt](https://github.com/user-attachments/files/19798243/before.txt)
* [after.txt](https://github.com/user-attachments/files/19798245/after.txt)
