### PR TITLE
Switch release controller components to Ubuntu 24.04 / stop papering over annotation failures

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ddaf297cdcb693eb22ea9f8a6715a04903850f6257848f0bb76f1f09abdeac4c",
+  "checksum": "d4c18e77271938e77f2fa083396236804a282d10ffe5a1b83ddc298d3a54d820",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -12170,6 +12170,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "keyring"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3188,7 +3188,7 @@ version = "0.17.1"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-macros 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3228,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3241,7 +3241,7 @@ version = "0.11.0"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3700,9 +3700,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1",
  "ic-icrc1-tokens-u64",
@@ -3729,9 +3729,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-certification 3.0.2",
  "ic-crypto-tree-hash",
  "ic-icrc1",
@@ -3841,7 +3841,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -4174,7 +4174,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "candid",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -4207,7 +4207,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -4226,7 +4226,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
 ]
 
 [[package]]
@@ -4244,7 +4244,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -4267,7 +4267,7 @@ name = "ic-nervous-system-timers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0",
  "slotmap",
 ]
 
@@ -4300,7 +4300,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nns-constants",
@@ -4343,9 +4343,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
  "ic-ledger-core",
@@ -4462,7 +4462,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -4518,7 +4518,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
  "ic-nns-common",
@@ -4795,9 +4795,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
  "ic-ledger-core",
@@ -4897,7 +4897,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -4951,9 +4951,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
@@ -4982,9 +4982,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
@@ -5034,7 +5034,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5308,7 +5308,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -6167,9 +6167,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
- "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
- "ic-cdk-timers 0.11.0 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-interfaces-registry",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -7357,7 +7357,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
@@ -7464,7 +7464,7 @@ version = "0.6.2"
 dependencies = [
  "chrono",
  "ic-base-types",
- "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk 0.17.1",
  "ic-protobuf",
  "ic-types",
  "itertools 0.13.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -105,6 +105,28 @@ oci.pull(
 )
 use_repo(oci, "bitnami_git_docker_img_linux_arm64", "distroless_cc_debian12", "distroless_cc_debian12_linux_amd64", "distroless_cc_debian12_linux_arm64")
 
+# Ubuntu 24.04 container image for use in Bazel.
+# See images/BUILD.bazel for information on maintenance.
+bazel_dep(name = "rules_distroless", version = "0.5.1")
+oci.pull(
+    name = "ubuntu_24_04_minimal",
+    image = "ubuntu", # Comes from Docker Hub.
+    # Hash of latest Noble 24.04.
+    digest = "sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9",
+    platforms = [
+        "linux/amd64",
+    ],
+)
+use_repo(oci, "ubuntu_24_04_minimal", "ubuntu_24_04_minimal_linux_amd64")
+apt = use_extension("@rules_distroless//apt:extensions.bzl", "apt")
+apt.install(
+    name = "ubuntu_24_04_packages",
+    lock = "//images:ubuntu_24_04_packages.lock.json",
+    manifest = "//images:ubuntu_24_04_packages.yaml",
+)
+use_repo(apt, "ubuntu_24_04_packages")
+# End Ubuntu 24.04 container image.
+
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_file(

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -1,0 +1,93 @@
+# Rules to build container images for application shipped by this
+# repository.
+#
+# Note that some applications still aren't using images built this way.
+#
+# To update the image to a later snapshot:
+#
+# 1. Update the image snapshot digest in /MODULE.bazel with the latest
+#    digest available on https://hub.docker.com/_/ubuntu/ for the
+#    respective tag (Ubuntu 24.04 is so-called `noble`).
+# 2. Update the date in the snapshot directory in the YAML file
+#    corresponding to the image being updated in /MODULE.bazel.
+# 3. Re-lock the lock file for the respective YAML file, e.g.
+#    `bazel run @ubuntu_24_04_packages//:lock` at the root of the repo
+#
+# With these steps, an up-to-date container image will be used by
+# downstream consumers.
+
+load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@rules_distroless//distroless:defs.bzl", "group", "passwd", "cacerts")
+
+package(default_visibility = ["//visibility:public"])
+
+COMPATIBLE_WITH = select({
+    "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
+    "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
+}) + [
+    "@platforms//os:linux",
+]
+
+passwd(
+    name = "passwd",
+    entries = [
+        {
+            "uid": 0,
+            "gid": 0,
+            "home": "/root",
+            "shell": "/bin/bash",
+            "username": "r00t",
+        },
+        {
+            "uid": 100,
+            "gid": 65534,
+            "home": "/home/_apt",
+            "shell": "/usr/sbin/nologin",
+            "username": "_apt",
+        },
+    ],
+)
+
+group(
+    name = "group",
+    entries = [
+        {
+            "name": "root",
+            "gid": 0,
+        },
+        {
+            "name": "_apt",
+            "gid": 65534,
+        },
+    ],
+)
+
+cacerts(
+    name = "cacerts",
+    package = select({
+        "@platforms//cpu:arm64": "@ubuntu_24_04_packages//ca-certificates/arm64:data",
+        "@platforms//cpu:x86_64": "@ubuntu_24_04_packages//ca-certificates/amd64:data",
+    }),
+)
+
+oci_image(
+    name = "ubuntu_24_04",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "@platforms//cpu:x86_64": "amd64",
+    }),
+    os = "linux",
+    # NOTE: this is needed because, otherwise, bazel test //... fails, even
+    # when container_structure_test already has target_compatible_with.
+    # See 136
+    target_compatible_with = COMPATIBLE_WITH,
+    tars = [
+        ":passwd",
+        ":group",
+        ":cacerts",
+        # Packages listed in this manifest (see YAML files in this folder)
+        # get installed in the container by this rule.
+        "@ubuntu_24_04_packages//:ubuntu_24_04_packages",
+    ],
+)

--- a/images/ubuntu_24_04_packages.lock.json
+++ b/images/ubuntu_24_04_packages.lock.json
@@ -1,0 +1,6023 @@
+{
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "ncurses-base_6.4-p-20240113-1ubuntu2_amd64",
+			"name": "ncurses-base",
+			"sha256": "56dbac135d58e580c2c9e33d5fd7c215b48091a54e1d9fa3d41f538f4acbac5f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/ncurses-base_6.4+20240113-1ubuntu2_all.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				}
+			],
+			"key": "libncurses6_6.4-p-20240113-1ubuntu2_amd64",
+			"name": "libncurses6",
+			"sha256": "f2b8efe3a3e2f622c5266d5a1301048306441885d2bbebc02685cb8c2d097537",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/libncurses6_6.4+20240113-1ubuntu2_amd64.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.39-0ubuntu8.4_amd64",
+			"name": "libc6",
+			"sha256": "b2e8d573f5b9275720640e59276dbbfc31f15400398906fb7b47c461d0b4cef7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/glibc/libc6_2.39-0ubuntu8.4_amd64.deb"
+			],
+			"version": "2.39-0ubuntu8.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libgcc-s1",
+			"sha256": "569fda5c9419b14ff5fa03ea7fba36e2bd0e54c62c4e7fd6b4a917e38c422a8d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "gcc-14-base",
+			"sha256": "81d02f705535faac0330bbceb07952ca790f9bf24bc9f19e651c35d543f4c598",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+			"name": "libtinfo6",
+			"sha256": "53e1e1753729d04cf65b05e6e58abe06e2bb76cc07eff0e1b2a638a638ca209b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/libtinfo6_6.4+20240113-1ubuntu2_amd64.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.86ubuntu1_amd64",
+					"name": "debconf",
+					"version": "1.5.86ubuntu1"
+				}
+			],
+			"key": "tzdata_2025b-0ubuntu0.24.04_amd64",
+			"name": "tzdata",
+			"sha256": "1c58af2626cd9c6920cda7494d998ca1c32ab6c689a613c560d06acf8bac5e19",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/t/tzdata/tzdata_2025b-0ubuntu0.24.04_all.deb"
+			],
+			"version": "2025b-0ubuntu0.24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debconf_1.5.86ubuntu1_amd64",
+			"name": "debconf",
+			"sha256": "bb390da466a7461bfc87aa3e6b7cd145dae84af3e26bf437f2c0c218ba226294",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/debconf/debconf_1.5.86ubuntu1_all.deb"
+			],
+			"version": "1.5.86ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_amd64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "debianutils_5.17build1_amd64",
+					"name": "debianutils",
+					"version": "5.17build1"
+				}
+			],
+			"key": "dash_0.5.12-6ubuntu5_amd64",
+			"name": "dash",
+			"sha256": "e97728d8deaa51300255f0572bbd68b9549e0894a184c056dc420fc4e0ba0781",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dash/dash_0.5.12-6ubuntu5_amd64.deb"
+			],
+			"version": "0.5.12-6ubuntu5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "tar_1.35-p-dfsg-3build1_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				}
+			],
+			"key": "dpkg_1.22.6ubuntu6.1_amd64",
+			"name": "dpkg",
+			"sha256": "77d50443e904c1d9509668194fc5fd1cbd475853727c991a0dd7f88e8b273223",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dpkg/dpkg_1.22.6ubuntu6.1_amd64.deb"
+			],
+			"version": "1.22.6ubuntu6.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tar_1.35-p-dfsg-3build1_amd64",
+			"name": "tar",
+			"sha256": "015b65ef176021c1846ec8b6152167d5d266c1949ec30ee3367e95fa2b2ead27",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/t/tar/tar_1.35+dfsg-3build1_amd64.deb"
+			],
+			"version": "1.35+dfsg-3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+			"name": "libselinux1",
+			"sha256": "6abaa6c26f46ef17764c4a753e0e84de1cdadde5634fd2987621fdc617988d19",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libs/libselinux/libselinux1_3.5-2ubuntu2.1_amd64.deb"
+			],
+			"version": "3.5-2ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "110a797a57673d3ee497a141cf988199258058c57525799c63194d81822529a0",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/pcre2/libpcre2-8-0_10.42-4ubuntu2.1_amd64.deb"
+			],
+			"version": "10.42-4ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libacl1_2.3.2-1build1.1_amd64",
+			"name": "libacl1",
+			"sha256": "f2bfd3f8f00413d5f1f04fc723063803c56ac0f1e0efae3bc41f2d7276972ec3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/acl/libacl1_2.3.2-1build1.1_amd64.deb"
+			],
+			"version": "2.3.2-1build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+			"name": "zlib1g",
+			"sha256": "7074b6a2f6367a10d280c00a1cb02e74277709180bab4f2491a2f355ab2d6c20",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_amd64.deb"
+			],
+			"version": "1:1.3.dfsg-3.1ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+			"name": "libzstd1",
+			"sha256": "dfcf25061e07aad7efd3f4f880ba5ad4d4d09ebe7fc8cc77ab6b8a161d6d4727",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2build1.1_amd64.deb"
+			],
+			"version": "1.5.5+dfsg2-2build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmd0_1.1.0-2build1.1_amd64",
+			"name": "libmd0",
+			"sha256": "e5ba01d3c41f256aaf57ec59aa0554857162e3e7f97cdfbff1ed2c0e8d720ee7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libm/libmd/libmd0_1.1.0-2build1.1_amd64.deb"
+			],
+			"version": "1.1.0-2build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+			"name": "liblzma5",
+			"sha256": "4c31cc76391ca47dbb4585edc740728f43fe7b6b090f5b3947fc8072db698aca",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/x/xz-utils/liblzma5_5.6.1+really5.4.5-1ubuntu0.2_amd64.deb"
+			],
+			"version": "5.6.1+really5.4.5-1ubuntu0.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+			"name": "libbz2-1.0",
+			"sha256": "d557ab12b42ab370249142099fae3cbb979948934e4dfa58c2ab59bf5bbbda73",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5.1build0.1_amd64.deb"
+			],
+			"version": "1.0.8-5.1build0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debianutils_5.17build1_amd64",
+			"name": "debianutils",
+			"sha256": "1047a9a57018e18531f76e5b00e226a68554b6f1d147f2a5c1b32518c7b20636",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/debianutils/debianutils_5.17build1_amd64.deb"
+			],
+			"version": "5.17build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debianutils_5.17build1_amd64",
+					"name": "debianutils",
+					"version": "5.17build1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "base-files_13ubuntu10.2_amd64",
+					"name": "base-files",
+					"version": "13ubuntu10.2"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "mawk_1.3.4.20240123-1build1_amd64",
+					"name": "mawk",
+					"version": "1.3.4.20240123-1build1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				}
+			],
+			"key": "bash_5.2.21-2ubuntu4_amd64",
+			"name": "bash",
+			"sha256": "73de311a21e094e29ac01527d2b52226cc87fde0a5b57032902251b426d92c66",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/bash/bash_5.2.21-2ubuntu4_amd64.deb"
+			],
+			"version": "5.2.21-2ubuntu4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "base-files_13ubuntu10.2_amd64",
+			"name": "base-files",
+			"sha256": "61e29c7504f020539b7d6112302b66e8ea5b6da00eb8b685dace384715fb11eb",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/base-files/base-files_13ubuntu10.2_amd64.deb"
+			],
+			"version": "13ubuntu10.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.36-4build1_amd64",
+			"name": "libcrypt1",
+			"sha256": "9474785cd6f398512bf8c305c3901dbb111569dccb6f5832002373c0a8ac5832",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libx/libxcrypt/libcrypt1_4.4.36-4build1_amd64.deb"
+			],
+			"version": "1:4.4.36-4build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "mawk_1.3.4.20240123-1build1_amd64",
+			"name": "mawk",
+			"sha256": "dc7f7f4dad4b48f6012ea65de3198d8376604afef39f06d65ec6167740e203c9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/mawk/mawk_1.3.4.20240123-1build1_amd64.deb"
+			],
+			"version": "1.3.4.20240123-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_amd64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "libattr1_1-2.5.2-1build1.1_amd64",
+					"name": "libattr1",
+					"version": "1:2.5.2-1build1.1"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				}
+			],
+			"key": "coreutils_9.4-3ubuntu6_amd64",
+			"name": "coreutils",
+			"sha256": "0d19c3e94f04ff1aafde46701fe1783da0a068a4904adc3794c30140f1aaeb8f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/coreutils/coreutils_9.4-3ubuntu6_amd64.deb"
+			],
+			"version": "9.4-3ubuntu6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssl3t64_3.0.13-0ubuntu3.5_amd64",
+			"name": "libssl3t64",
+			"sha256": "31df0a4d957c404c01b1898a84beca1190fd71cf2d2ac47ce5036705a24d96fc",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/o/openssl/libssl3t64_3.0.13-0ubuntu3.5_amd64.deb"
+			],
+			"version": "3.0.13-0ubuntu3.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_amd64",
+			"name": "libgmp10",
+			"sha256": "285f8a505dfa8e1b33f357a9d8d3477ad35bf18c0b34771a6df4c25923f3ae0d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2ubuntu6.1_amd64.deb"
+			],
+			"version": "2:6.3.0+dfsg-2ubuntu6.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libattr1_1-2.5.2-1build1.1_amd64",
+			"name": "libattr1",
+			"sha256": "d880fdb65dec669fcc4c5b34c5cbfee6c014ec4bdf6430ecdc7f10efffb28b2e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/attr/libattr1_2.5.2-1build1.1_amd64.deb"
+			],
+			"version": "1:2.5.2-1build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "grep_3.11-4build1_amd64",
+			"name": "grep",
+			"sha256": "fc0fdc5983ea3d3579ccf335e51dec69684a0dd9bb915734999c5733add9507a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/grep/grep_3.11-4build1_amd64.deb"
+			],
+			"version": "3.11-4build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				}
+			],
+			"key": "sed_4.9-2build1_amd64",
+			"name": "sed",
+			"sha256": "a09b856849cf36190f8cd39da33486b14bcaf81b592530b2f3236da17daaad2f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/sed/sed_4.9-2build1_amd64.deb"
+			],
+			"version": "4.9-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "findutils_4.9.0-5build1_amd64",
+			"name": "findutils",
+			"sha256": "96490acdee09245bb47ff4684dc59a7ac3b29619da868ef3e9d8323c61a02ac4",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/f/findutils/findutils_4.9.0-5build1_amd64.deb"
+			],
+			"version": "4.9.0-5build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libsystemd0_255.4-1ubuntu8.6_amd64",
+					"name": "libsystemd0",
+					"version": "255.4-1ubuntu8.6"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "liblz4-1_1.9.4-1build1.1_amd64",
+					"name": "liblz4-1",
+					"version": "1.9.4-1build1.1"
+				},
+				{
+					"key": "libgcrypt20_1.10.3-2build1_amd64",
+					"name": "libgcrypt20",
+					"version": "1.10.3-2build1"
+				},
+				{
+					"key": "libgpg-error0_1.47-3build2.1_amd64",
+					"name": "libgpg-error0",
+					"version": "1.47-3build2.1"
+				},
+				{
+					"key": "libcap2_1-2.66-5ubuntu2.2_amd64",
+					"name": "libcap2",
+					"version": "1:2.66-5ubuntu2.2"
+				},
+				{
+					"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libstdc++6",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libseccomp2_2.5.5-1ubuntu3.1_amd64",
+					"name": "libseccomp2",
+					"version": "2.5.5-1ubuntu3.1"
+				},
+				{
+					"key": "libgnutls30t64_3.8.3-1.1ubuntu3.3_amd64",
+					"name": "libgnutls30t64",
+					"version": "3.8.3-1.1ubuntu3.3"
+				},
+				{
+					"key": "libunistring5_1.1-2build1.1_amd64",
+					"name": "libunistring5",
+					"version": "1.1-2build1.1"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-3ubuntu0.24.04.1_amd64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-3ubuntu0.24.04.1"
+				},
+				{
+					"key": "libp11-kit0_0.25.3-4ubuntu2.1_amd64",
+					"name": "libp11-kit0",
+					"version": "0.25.3-4ubuntu2.1"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_amd64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libnettle8t64_3.9.1-2.2build1.1_amd64",
+					"name": "libnettle8t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libidn2-0_2.3.7-2build1.1_amd64",
+					"name": "libidn2-0",
+					"version": "2.3.7-2build1.1"
+				},
+				{
+					"key": "libhogweed6t64_3.9.1-2.2build1.1_amd64",
+					"name": "libhogweed6t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "ubuntu-keyring_2023.11.28.1_amd64",
+					"name": "ubuntu-keyring",
+					"version": "2023.11.28.1"
+				},
+				{
+					"key": "libapt-pkg6.0t64_2.7.14build2_amd64",
+					"name": "libapt-pkg6.0t64",
+					"version": "2.7.14build2"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libxxhash0_0.8.2-2build1_amd64",
+					"name": "libxxhash0",
+					"version": "0.8.2-2build1"
+				},
+				{
+					"key": "libudev1_255.4-1ubuntu8.6_amd64",
+					"name": "libudev1",
+					"version": "255.4-1ubuntu8.6"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "gpgv_2.4.4-2ubuntu17.2_amd64",
+					"name": "gpgv",
+					"version": "2.4.4-2ubuntu17.2"
+				},
+				{
+					"key": "libnpth0t64_1.6-3.1build1_amd64",
+					"name": "libnpth0t64",
+					"version": "1.6-3.1build1"
+				},
+				{
+					"key": "libassuan0_2.5.6-1build1_amd64",
+					"name": "libassuan0",
+					"version": "2.5.6-1build1"
+				},
+				{
+					"key": "base-passwd_3.6.3build1_amd64",
+					"name": "base-passwd",
+					"version": "3.6.3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libdebconfclient0_0.271ubuntu3_amd64",
+					"name": "libdebconfclient0",
+					"version": "0.271ubuntu3"
+				}
+			],
+			"key": "apt_2.7.14build2_amd64",
+			"name": "apt",
+			"sha256": "72b4e9ba826544fa87e9101857432ebfa61c29ec4e091fcd67396cde9b9c6459",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/apt/apt_2.7.14build2_amd64.deb"
+			],
+			"version": "2.7.14build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsystemd0_255.4-1ubuntu8.6_amd64",
+			"name": "libsystemd0",
+			"sha256": "7283441b2c06cf2b26afafb96e8f255efc11e117cd8b9811aee30dad8a495e0f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/systemd/libsystemd0_255.4-1ubuntu8.6_amd64.deb"
+			],
+			"version": "255.4-1ubuntu8.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.4-1build1.1_amd64",
+			"name": "liblz4-1",
+			"sha256": "319331270d5cc52d5ebffe51c941d7b01b432bc402c2924b557209a64d4ecbad",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/l/lz4/liblz4-1_1.9.4-1build1.1_amd64.deb"
+			],
+			"version": "1.9.4-1build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.10.3-2build1_amd64",
+			"name": "libgcrypt20",
+			"sha256": "ff32bae487706ba6ca646b5b72d89b935e3b8b2811d02e4ad7360cb97d90e2d0",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2build1_amd64.deb"
+			],
+			"version": "1.10.3-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.47-3build2.1_amd64",
+			"name": "libgpg-error0",
+			"sha256": "93654ee8180a73a0363f25c51dc673d67cbabcbecd164187b8a2deb54d007aef",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libg/libgpg-error/libgpg-error0_1.47-3build2.1_amd64.deb"
+			],
+			"version": "1.47-3build2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap2_1-2.66-5ubuntu2.2_amd64",
+			"name": "libcap2",
+			"sha256": "9241539476d657d102b5a51ea3cd80ac3576e8e15f23c59f22b757d8eb4c5301",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu2.2_amd64.deb"
+			],
+			"version": "1:2.66-5ubuntu2.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libstdc++6",
+			"sha256": "94e22b11b7dc0e5d50b795ea7ea0bacce94ad48692f3e3a72feccb220e50d895",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libstdc++6_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libseccomp2_2.5.5-1ubuntu3.1_amd64",
+			"name": "libseccomp2",
+			"sha256": "33fc96f1e008d27c042a3db9bcd16f7f4d49e866f7a3141b758a799328dbdc3f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-1ubuntu3.1_amd64.deb"
+			],
+			"version": "2.5.5-1ubuntu3.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgnutls30t64_3.8.3-1.1ubuntu3.3_amd64",
+			"name": "libgnutls30t64",
+			"sha256": "05ad7013521c78c8d12a7c4142832ceab809557c83a8d0dd1bbac6b364589577",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gnutls28/libgnutls30t64_3.8.3-1.1ubuntu3.3_amd64.deb"
+			],
+			"version": "3.8.3-1.1ubuntu3.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libunistring5_1.1-2build1.1_amd64",
+			"name": "libunistring5",
+			"sha256": "203d7657b5f54633fba1a9c9b784d556ef83c9f6787b3185ba55a88e07b865a3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libu/libunistring/libunistring5_1.1-2build1.1_amd64.deb"
+			],
+			"version": "1.1-2build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.19.0-3ubuntu0.24.04.1_amd64",
+			"name": "libtasn1-6",
+			"sha256": "e16e809c6bc957ef94585e47e94fb4f0959adf844abdf3cafa28edf1fbaf34ed",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3ubuntu0.24.04.1_amd64.deb"
+			],
+			"version": "4.19.0-3ubuntu0.24.04.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.25.3-4ubuntu2.1_amd64",
+			"name": "libp11-kit0",
+			"sha256": "151a0e70407faef701df3a283bca0b2f2e7aeb2b73e5682101bb5543e8213d98",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/p11-kit/libp11-kit0_0.25.3-4ubuntu2.1_amd64.deb"
+			],
+			"version": "0.25.3-4ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libffi8_3.4.6-1build1_amd64",
+			"name": "libffi8",
+			"sha256": "637e6a7744de08cd331a41f4efd0d24e6ea9064843dea9d1c6ca87bdb5f038a2",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libf/libffi/libffi8_3.4.6-1build1_amd64.deb"
+			],
+			"version": "3.4.6-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnettle8t64_3.9.1-2.2build1.1_amd64",
+			"name": "libnettle8t64",
+			"sha256": "6d97fbc1972633083f08f51ccab433606c97bbceb897c631c66495117ca3406f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/nettle/libnettle8t64_3.9.1-2.2build1.1_amd64.deb"
+			],
+			"version": "3.9.1-2.2build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.7-2build1.1_amd64",
+			"name": "libidn2-0",
+			"sha256": "46bfd10df095a23b65f58115de47a547c9a2d14627749bd0423ae78c14be77d3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2build1.1_amd64.deb"
+			],
+			"version": "2.3.7-2build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libhogweed6t64_3.9.1-2.2build1.1_amd64",
+			"name": "libhogweed6t64",
+			"sha256": "a9b5f7e9d49ba9060e1c933567046fbc6feab6096799cbf550b7214dc9b0f49b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/nettle/libhogweed6t64_3.9.1-2.2build1.1_amd64.deb"
+			],
+			"version": "3.9.1-2.2build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "ubuntu-keyring_2023.11.28.1_amd64",
+			"name": "ubuntu-keyring",
+			"sha256": "36de43b15853ccae0028e9a767613770c704833f82586f28eb262f0311adb8a8",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2023.11.28.1_all.deb"
+			],
+			"version": "2023.11.28.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0t64_2.7.14build2_amd64",
+			"name": "libapt-pkg6.0t64",
+			"sha256": "3915b0cdfbaae551d9089400f47be749b89c30914985982b39e57fd2016be852",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/apt/libapt-pkg6.0t64_2.7.14build2_amd64.deb"
+			],
+			"version": "2.7.14build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxxhash0_0.8.2-2build1_amd64",
+			"name": "libxxhash0",
+			"sha256": "75de256c2d162dfc541beb69a83f025742cd13329262af9059eff3ca42a53239",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/x/xxhash/libxxhash0_0.8.2-2build1_amd64.deb"
+			],
+			"version": "0.8.2-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libudev1_255.4-1ubuntu8.6_amd64",
+			"name": "libudev1",
+			"sha256": "6c899bdf3e036d456aebce5e1dd113c0ba07cf40c1356574b002bd088323d7c6",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/systemd/libudev1_255.4-1ubuntu8.6_amd64.deb"
+			],
+			"version": "255.4-1ubuntu8.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gpgv_2.4.4-2ubuntu17.2_amd64",
+			"name": "gpgv",
+			"sha256": "b5ba55520c7311baf621d3159d139fd0b2e2a9e3c84cd86b68c4e28b0cfc9d40",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gnupg2/gpgv_2.4.4-2ubuntu17.2_amd64.deb"
+			],
+			"version": "2.4.4-2ubuntu17.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnpth0t64_1.6-3.1build1_amd64",
+			"name": "libnpth0t64",
+			"sha256": "b380eca1221a9ac855427652452801c5ca9161dd69e12446d300524eba00944e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/npth/libnpth0t64_1.6-3.1build1_amd64.deb"
+			],
+			"version": "1.6-3.1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libassuan0_2.5.6-1build1_amd64",
+			"name": "libassuan0",
+			"sha256": "59c6ee6aa6fffb5d181f37373baec18c26791f5d1c907ceeb62163460b11daf2",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/liba/libassuan/libassuan0_2.5.6-1build1_amd64.deb"
+			],
+			"version": "2.5.6-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "base-passwd_3.6.3build1_amd64",
+			"name": "base-passwd",
+			"sha256": "8514590aa2d82aa32d6beb32525f1e4577949f625eee1990b4b7b71b5ef26679",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/base-passwd/base-passwd_3.6.3build1_amd64.deb"
+			],
+			"version": "3.6.3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdebconfclient0_0.271ubuntu3_amd64",
+			"name": "libdebconfclient0",
+			"sha256": "0a07d284ca6e2ee18208b3bf9ddc19da803d96db8230cdf26d16ac3aae5b7893",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/cdebconf/libdebconfclient0_0.271ubuntu3_amd64.deb"
+			],
+			"version": "0.271ubuntu3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "libperl5.38t64",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-base_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl-base",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_amd64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libgdbm6t64_1.23-5.1build1_amd64",
+					"name": "libgdbm6t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libgdbm-compat4t64_1.23-5.1build1_amd64",
+					"name": "libgdbm-compat4t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_amd64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				}
+			],
+			"key": "perl_5.38.2-3.2ubuntu0.1_amd64",
+			"name": "perl",
+			"sha256": "855229129da9156e21b6ce18b92c878688ae8ccc3a1602aad74b77a8c9aefdca",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/perl_5.38.2-3.2ubuntu0.1_amd64.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_amd64",
+			"name": "libperl5.38t64",
+			"sha256": "2ef79f7c2cd6a0558cba806d2bb6dd203a93faf4f34ba8382807029843310759",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/libperl5.38t64_5.38.2-3.2ubuntu0.1_amd64.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_amd64",
+			"name": "perl-modules-5.38",
+			"sha256": "7856700df3a65bcc4cf8506c61138b069d2512f3b4576ba6b54db59fde93950f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/perl-modules-5.38_5.38.2-3.2ubuntu0.1_all.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-base_5.38.2-3.2ubuntu0.1_amd64",
+			"name": "perl-base",
+			"sha256": "f632150c5105ee5049a8c4e144260e261559c84b1ec55ddc8c3fa7bd71d2b0e3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/perl-base_5.38.2-3.2ubuntu0.1_amd64.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm6t64_1.23-5.1build1_amd64",
+			"name": "libgdbm6t64",
+			"sha256": "18d6d74a5c038b458d95ba0c0909e0f086cd50bb9a0fee32697902724fc5645e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gdbm/libgdbm6t64_1.23-5.1build1_amd64.deb"
+			],
+			"version": "1.23-5.1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm-compat4t64_1.23-5.1build1_amd64",
+			"name": "libgdbm-compat4t64",
+			"sha256": "fb8564afd7b7d74d55207070ba50339478e22d29a39ec740dc482f069ac7ee65",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gdbm/libgdbm-compat4t64_1.23-5.1build1_amd64.deb"
+			],
+			"version": "1.23-5.1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdb5.3t64_5.3.28-p-dfsg2-7_amd64",
+			"name": "libdb5.3t64",
+			"sha256": "a78a25c8fad8fdd0b7bc6b297da5d5685579be1e57732aa47870830e4a13161e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/db5.3/libdb5.3t64_5.3.28+dfsg2-7_amd64.deb"
+			],
+			"version": "5.3.28+dfsg2-7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.86ubuntu1_amd64",
+					"name": "debconf",
+					"version": "1.5.86ubuntu1"
+				},
+				{
+					"key": "openssl_3.0.13-0ubuntu3.5_amd64",
+					"name": "openssl",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_amd64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "ca-certificates_20240203_amd64",
+			"name": "ca-certificates",
+			"sha256": "641de77d8f142cfd62a1a6f964ba67b20754d3337c480efb529d086075a06c9a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/ca-certificates/ca-certificates_20240203_all.deb"
+			],
+			"version": "20240203"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "openssl_3.0.13-0ubuntu3.5_amd64",
+			"name": "openssl",
+			"sha256": "00f9b292ff5636d49832e493789ec91e21cfd4e98ccc9fd23497e92a2cc9c76a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/o/openssl/openssl_3.0.13-0ubuntu3.5_amd64.deb"
+			],
+			"version": "3.0.13-0ubuntu3.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "git-man_1-2.43.0-1ubuntu7.2_amd64",
+					"name": "git-man",
+					"version": "1:2.43.0-1ubuntu7.2"
+				},
+				{
+					"key": "liberror-perl_0.17029-2_amd64",
+					"name": "liberror-perl",
+					"version": "0.17029-2"
+				},
+				{
+					"key": "perl_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "libperl5.38t64",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-base_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl-base",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_amd64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libgdbm6t64_1.23-5.1build1_amd64",
+					"name": "libgdbm6t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libgdbm-compat4t64_1.23-5.1build1_amd64",
+					"name": "libgdbm-compat4t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_amd64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				},
+				{
+					"key": "libexpat1_2.6.1-2ubuntu0.3_amd64",
+					"name": "libexpat1",
+					"version": "2.6.1-2ubuntu0.3"
+				},
+				{
+					"key": "libcurl3t64-gnutls_8.5.0-2ubuntu10.6_amd64",
+					"name": "libcurl3t64-gnutls",
+					"version": "8.5.0-2ubuntu10.6"
+				},
+				{
+					"key": "libssh-4_0.10.6-2build2_amd64",
+					"name": "libssh-4",
+					"version": "0.10.6-2build2"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.20.1-6ubuntu2.5_amd64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libkrb5support0_1.20.1-6ubuntu2.5_amd64",
+					"name": "libkrb5support0",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libk5crypto3_1.20.1-6ubuntu2.5_amd64",
+					"name": "libk5crypto3",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libcom-err2_1.47.0-2.4_exp1ubuntu4.1_amd64",
+					"name": "libcom-err2",
+					"version": "1.47.0-2.4~exp1ubuntu4.1"
+				},
+				{
+					"key": "libkrb5-3_1.20.1-6ubuntu2.5_amd64",
+					"name": "libkrb5-3",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_amd64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libkeyutils1_1.6.3-3build1_amd64",
+					"name": "libkeyutils1",
+					"version": "1.6.3-3build1"
+				},
+				{
+					"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2build7_amd64",
+					"name": "librtmp1",
+					"version": "2.4+20151223.gitfa8646d.1-2build7"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "libpsl5t64_0.21.2-1.1build1_amd64",
+					"name": "libpsl5t64",
+					"version": "0.21.2-1.1build1"
+				},
+				{
+					"key": "libunistring5_1.1-2build1.1_amd64",
+					"name": "libunistring5",
+					"version": "1.1-2build1.1"
+				},
+				{
+					"key": "libidn2-0_2.3.7-2build1.1_amd64",
+					"name": "libidn2-0",
+					"version": "2.3.7-2build1.1"
+				},
+				{
+					"key": "libnghttp2-14_1.59.0-1ubuntu0.2_amd64",
+					"name": "libnghttp2-14",
+					"version": "1.59.0-1ubuntu0.2"
+				},
+				{
+					"key": "libnettle8t64_3.9.1-2.2build1.1_amd64",
+					"name": "libnettle8t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libldap2_2.6.7-p-dfsg-1_exp1ubuntu8.2_amd64",
+					"name": "libldap2",
+					"version": "2.6.7+dfsg-1~exp1ubuntu8.2"
+				},
+				{
+					"key": "libsasl2-2_2.1.28-p-dfsg1-5ubuntu3.1_amd64",
+					"name": "libsasl2-2",
+					"version": "2.1.28+dfsg1-5ubuntu3.1"
+				},
+				{
+					"key": "libsasl2-modules-db_2.1.28-p-dfsg1-5ubuntu3.1_amd64",
+					"name": "libsasl2-modules-db",
+					"version": "2.1.28+dfsg1-5ubuntu3.1"
+				},
+				{
+					"key": "libgnutls30t64_3.8.3-1.1ubuntu3.3_amd64",
+					"name": "libgnutls30t64",
+					"version": "3.8.3-1.1ubuntu3.3"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-3ubuntu0.24.04.1_amd64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-3ubuntu0.24.04.1"
+				},
+				{
+					"key": "libp11-kit0_0.25.3-4ubuntu2.1_amd64",
+					"name": "libp11-kit0",
+					"version": "0.25.3-4ubuntu2.1"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_amd64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libhogweed6t64_3.9.1-2.2build1.1_amd64",
+					"name": "libhogweed6t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libbrotli1_1.1.0-2build2_amd64",
+					"name": "libbrotli1",
+					"version": "1.1.0-2build2"
+				}
+			],
+			"key": "git_1-2.43.0-1ubuntu7.2_amd64",
+			"name": "git",
+			"sha256": "30866369cd8e5ad7f4078bf8e310198473c8680b544846e347a8df40c72fd7fb",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/git/git_2.43.0-1ubuntu7.2_amd64.deb"
+			],
+			"version": "1:2.43.0-1ubuntu7.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "git-man_1-2.43.0-1ubuntu7.2_amd64",
+			"name": "git-man",
+			"sha256": "bf6a37abf3839b2e2c108867bc58a1fd2cf27e20ec6a0a78c90c8cba9d7bccf9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/git/git-man_2.43.0-1ubuntu7.2_all.deb"
+			],
+			"version": "1:2.43.0-1ubuntu7.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liberror-perl_0.17029-2_amd64",
+			"name": "liberror-perl",
+			"sha256": "1907af6bf33dd8684447c09f216c675d2b8559fadd8ddace29fbf83c6fb2a636",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libe/liberror-perl/liberror-perl_0.17029-2_all.deb"
+			],
+			"version": "0.17029-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libexpat1_2.6.1-2ubuntu0.3_amd64",
+			"name": "libexpat1",
+			"sha256": "caf827507a506a45ab525d5dc1b94334a22fe32e9ee271aba1cb6df7c99c87c6",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/e/expat/libexpat1_2.6.1-2ubuntu0.3_amd64.deb"
+			],
+			"version": "2.6.1-2ubuntu0.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcurl3t64-gnutls_8.5.0-2ubuntu10.6_amd64",
+			"name": "libcurl3t64-gnutls",
+			"sha256": "38167d8ff4c180eceb0afb1a9bd3f343b07f87308894dd86866c5b1a3c14eebd",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/curl/libcurl3t64-gnutls_8.5.0-2ubuntu10.6_amd64.deb"
+			],
+			"version": "8.5.0-2ubuntu10.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssh-4_0.10.6-2build2_amd64",
+			"name": "libssh-4",
+			"sha256": "c0867b203887064777d677e18d4006f9b068a9ff98d361189cb941ab409326dd",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libs/libssh/libssh-4_0.10.6-2build2_amd64.deb"
+			],
+			"version": "0.10.6-2build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgssapi-krb5-2_1.20.1-6ubuntu2.5_amd64",
+			"name": "libgssapi-krb5-2",
+			"sha256": "6f71233188b5360e929d30454c98ea4afb553c06e1c93dfa08e9ec0bc9da033f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-6ubuntu2.5_amd64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5support0_1.20.1-6ubuntu2.5_amd64",
+			"name": "libkrb5support0",
+			"sha256": "4358e0c5a3f3ad0af21a6d2bcdd75e3c0237f6cd35989b25867db7eb32e7a3af",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libkrb5support0_1.20.1-6ubuntu2.5_amd64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libk5crypto3_1.20.1-6ubuntu2.5_amd64",
+			"name": "libk5crypto3",
+			"sha256": "11b8570829e1d49007e915e7d617e4f3f4dacc998769a6873839a9188a53a8a1",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libk5crypto3_1.20.1-6ubuntu2.5_amd64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcom-err2_1.47.0-2.4_exp1ubuntu4.1_amd64",
+			"name": "libcom-err2",
+			"sha256": "7ab24d3057dabf86db8f771ad6e43f073ed86b6b950d6e8ba22cb9fe6707bbc9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2.4~exp1ubuntu4.1_amd64.deb"
+			],
+			"version": "1.47.0-2.4~exp1ubuntu4.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5-3_1.20.1-6ubuntu2.5_amd64",
+			"name": "libkrb5-3",
+			"sha256": "9b5c6cc7aca50d4f6242977ab406ab41ea6cd314c4e572f6b3202e4d53bb9237",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libkrb5-3_1.20.1-6ubuntu2.5_amd64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkeyutils1_1.6.3-3build1_amd64",
+			"name": "libkeyutils1",
+			"sha256": "0679f198b0128179e46cdf956fb2022c23c758664c00bc8efa0382d509683a8a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/keyutils/libkeyutils1_1.6.3-3build1_amd64.deb"
+			],
+			"version": "1.6.3-3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2build7_amd64",
+			"name": "librtmp1",
+			"sha256": "967a39dbc14236d1580ede01d80fd78444668572e716734e1ac66c175052594e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2build7_amd64.deb"
+			],
+			"version": "2.4+20151223.gitfa8646d.1-2build7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpsl5t64_0.21.2-1.1build1_amd64",
+			"name": "libpsl5t64",
+			"sha256": "a6c85d1303ae90b6a3209d73c4f047f82c27cdc963c48adfd95dd7abca64f039",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libp/libpsl/libpsl5t64_0.21.2-1.1build1_amd64.deb"
+			],
+			"version": "0.21.2-1.1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnghttp2-14_1.59.0-1ubuntu0.2_amd64",
+			"name": "libnghttp2-14",
+			"sha256": "2f8a90953ba5c5671249fb3e414582ede4a7111872eaaa08119a560a29c65a1f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1ubuntu0.2_amd64.deb"
+			],
+			"version": "1.59.0-1ubuntu0.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libldap2_2.6.7-p-dfsg-1_exp1ubuntu8.2_amd64",
+			"name": "libldap2",
+			"sha256": "17000967a1fae30c8dbb92b2183ec6e245c6d802aacf2c2945a20ee89298b8e9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/o/openldap/libldap2_2.6.7+dfsg-1~exp1ubuntu8.2_amd64.deb"
+			],
+			"version": "2.6.7+dfsg-1~exp1ubuntu8.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsasl2-2_2.1.28-p-dfsg1-5ubuntu3.1_amd64",
+			"name": "libsasl2-2",
+			"sha256": "eda097f98dcb3a08b9ce157d6191d140e4885c1cba47b683c94b8ca45e88f458",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-5ubuntu3.1_amd64.deb"
+			],
+			"version": "2.1.28+dfsg1-5ubuntu3.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsasl2-modules-db_2.1.28-p-dfsg1-5ubuntu3.1_amd64",
+			"name": "libsasl2-modules-db",
+			"sha256": "1f13548b1774cd9c70c50b8c3267204a101334a4d2f979338896ba5a4c6f81b8",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-5ubuntu3.1_amd64.deb"
+			],
+			"version": "2.1.28+dfsg1-5ubuntu3.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbrotli1_1.1.0-2build2_amd64",
+			"name": "libbrotli1",
+			"sha256": "74492419b8fda803774b8c9acef6afc5d2f9ff31782635aae212906adae7b277",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/brotli/libbrotli1_1.1.0-2build2_amd64.deb"
+			],
+			"version": "1.1.0-2build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libpython3-stdlib_3.12.3-0ubuntu2_amd64",
+					"name": "libpython3-stdlib",
+					"version": "3.12.3-0ubuntu2"
+				},
+				{
+					"key": "libpython3.12-stdlib_3.12.3-1ubuntu0.5_amd64",
+					"name": "libpython3.12-stdlib",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libsqlite3-0_3.45.1-1ubuntu2.1_amd64",
+					"name": "libsqlite3-0",
+					"version": "3.45.1-1ubuntu2.1"
+				},
+				{
+					"key": "libreadline8t64_8.2-4build1_amd64",
+					"name": "libreadline8t64",
+					"version": "8.2-4build1"
+				},
+				{
+					"key": "readline-common_8.2-4build1_amd64",
+					"name": "readline-common",
+					"version": "8.2-4build1"
+				},
+				{
+					"key": "libncursesw6_6.4-p-20240113-1ubuntu2_amd64",
+					"name": "libncursesw6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_amd64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_amd64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "tzdata_2025b-0ubuntu0.24.04_amd64",
+					"name": "tzdata",
+					"version": "2025b-0ubuntu0.24.04"
+				},
+				{
+					"key": "debconf_1.5.86ubuntu1_amd64",
+					"name": "debconf",
+					"version": "1.5.86ubuntu1"
+				},
+				{
+					"key": "netbase_6.4_amd64",
+					"name": "netbase",
+					"version": "6.4"
+				},
+				{
+					"key": "media-types_10.1.0_amd64",
+					"name": "media-types",
+					"version": "10.1.0"
+				},
+				{
+					"key": "libpython3.12-minimal_3.12.3-1ubuntu0.5_amd64",
+					"name": "libpython3.12-minimal",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_amd64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "python3.12_3.12.3-1ubuntu0.5_amd64",
+					"name": "python3.12",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "python3.12-minimal_3.12.3-1ubuntu0.5_amd64",
+					"name": "python3.12-minimal",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libexpat1_2.6.1-2ubuntu0.3_amd64",
+					"name": "libexpat1",
+					"version": "2.6.1-2ubuntu0.3"
+				},
+				{
+					"key": "python3-minimal_3.12.3-0ubuntu2_amd64",
+					"name": "python3-minimal",
+					"version": "3.12.3-0ubuntu2"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_amd64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				}
+			],
+			"key": "python3_3.12.3-0ubuntu2_amd64",
+			"name": "python3",
+			"sha256": "987c52e9eeee5867c1af29fc2c35db104cf5d1157fdfc6afabcb95f854751344",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3-defaults/python3_3.12.3-0ubuntu2_amd64.deb"
+			],
+			"version": "3.12.3-0ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpython3-stdlib_3.12.3-0ubuntu2_amd64",
+			"name": "libpython3-stdlib",
+			"sha256": "faa97b0ccf7b89a725831d409d71dee32945b3079e1ed36c922b40ffdeaa7044",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3-defaults/libpython3-stdlib_3.12.3-0ubuntu2_amd64.deb"
+			],
+			"version": "3.12.3-0ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpython3.12-stdlib_3.12.3-1ubuntu0.5_amd64",
+			"name": "libpython3.12-stdlib",
+			"sha256": "01dea0dfa59189513cacbf066a36b9044c5e619fc47247e5392fa6ba2362d505",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/libpython3.12-stdlib_3.12.3-1ubuntu0.5_amd64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsqlite3-0_3.45.1-1ubuntu2.1_amd64",
+			"name": "libsqlite3-0",
+			"sha256": "5c4956e6adfe2e69cbe8130722ab20d1683aebaab3e93c838310b44d22fdc2df",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/sqlite3/libsqlite3-0_3.45.1-1ubuntu2.1_amd64.deb"
+			],
+			"version": "3.45.1-1ubuntu2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libreadline8t64_8.2-4build1_amd64",
+			"name": "libreadline8t64",
+			"sha256": "563977a16df03b611f5239cc1e9a0426e86479fcc616b5c9e200ea32063119e5",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/readline/libreadline8t64_8.2-4build1_amd64.deb"
+			],
+			"version": "8.2-4build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "readline-common_8.2-4build1_amd64",
+			"name": "readline-common",
+			"sha256": "879bfd7f8a9bc4c0f7cdc777cdd8bc6de5f8c4a2ac80c060322a1b22f13504bb",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/readline/readline-common_8.2-4build1_all.deb"
+			],
+			"version": "8.2-4build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libncursesw6_6.4-p-20240113-1ubuntu2_amd64",
+			"name": "libncursesw6",
+			"sha256": "96d1e64bb1a80f2005f41c4112d10e4756a222a6c245e9383fc8da924bd40bf9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/libncursesw6_6.4+20240113-1ubuntu2_amd64.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "netbase_6.4_amd64",
+			"name": "netbase",
+			"sha256": "8cdbc9c3dca01e660759bf9d840f72e45ac72faf5d19ca1faecacaf6a60c1a87",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/netbase/netbase_6.4_all.deb"
+			],
+			"version": "6.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "media-types_10.1.0_amd64",
+			"name": "media-types",
+			"sha256": "31bfb7eec55ab6d34a50ba995150e1498d4cb897714085d8025e330d3b529747",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/media-types/media-types_10.1.0_all.deb"
+			],
+			"version": "10.1.0"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpython3.12-minimal_3.12.3-1ubuntu0.5_amd64",
+			"name": "libpython3.12-minimal",
+			"sha256": "b6ade851d851df0fc3d00a943fa41bcaabd1a4955c77865ee16b5e6216762ebe",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/libpython3.12-minimal_3.12.3-1ubuntu0.5_amd64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3.12_3.12.3-1ubuntu0.5_amd64",
+			"name": "python3.12",
+			"sha256": "a4a31d969d499e215257c6bcfcb6245660e5dd10900539275a648a86ee351c9b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/python3.12_3.12.3-1ubuntu0.5_amd64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3.12-minimal_3.12.3-1ubuntu0.5_amd64",
+			"name": "python3.12-minimal",
+			"sha256": "fcad35f13e0532e8a2eefb7175a5711180c2da84a152e5c7268c6f88a2c6ccad",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/python3.12-minimal_3.12.3-1ubuntu0.5_amd64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "python3-minimal_3.12.3-0ubuntu2_amd64",
+			"name": "python3-minimal",
+			"sha256": "ad730fafa0b09eec55e3b3b1c7bf34fac4cb4065347e585dd44f3b19858f348e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3-defaults/python3-minimal_3.12.3-0ubuntu2_amd64.deb"
+			],
+			"version": "3.12.3-0ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "dpkg-dev_1.22.6ubuntu6.1_amd64",
+					"name": "dpkg-dev",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "lto-disabled-list_47_amd64",
+					"name": "lto-disabled-list",
+					"version": "47"
+				},
+				{
+					"key": "binutils_2.42-4ubuntu2.5_amd64",
+					"name": "binutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-x86-64-linux-gnu_2.42-4ubuntu2.5_amd64",
+					"name": "binutils-x86-64-linux-gnu",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libstdc++6",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libsframe1_2.42-4ubuntu2.5_amd64",
+					"name": "libsframe1",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libjansson4_2.14-2build2_amd64",
+					"name": "libjansson4",
+					"version": "2.14-2build2"
+				},
+				{
+					"key": "libgprofng0_2.42-4ubuntu2.5_amd64",
+					"name": "libgprofng0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libbinutils_2.42-4ubuntu2.5_amd64",
+					"name": "libbinutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-common_2.42-4ubuntu2.5_amd64",
+					"name": "binutils-common",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf0_2.42-4ubuntu2.5_amd64",
+					"name": "libctf0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf-nobfd0_2.42-4ubuntu2.5_amd64",
+					"name": "libctf-nobfd0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "make_4.3-4.1build2_amd64",
+					"name": "make",
+					"version": "4.3-4.1build2"
+				},
+				{
+					"key": "patch_2.7.6-7build3_amd64",
+					"name": "patch",
+					"version": "2.7.6-7build3"
+				},
+				{
+					"key": "xz-utils_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "xz-utils",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "bzip2_1.0.8-5.1build0.1_amd64",
+					"name": "bzip2",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "libdpkg-perl_1.22.6ubuntu6.1_amd64",
+					"name": "libdpkg-perl",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_amd64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "perl_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "libperl5.38t64",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-base_5.38.2-3.2ubuntu0.1_amd64",
+					"name": "perl-base",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libgdbm6t64_1.23-5.1build1_amd64",
+					"name": "libgdbm6t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libgdbm-compat4t64_1.23-5.1build1_amd64",
+					"name": "libgdbm-compat4t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_amd64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				},
+				{
+					"key": "g-p--p-_4-13.2.0-7ubuntu1_amd64",
+					"name": "g++",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "gcc-13_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "gcc-13",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "cpp-13_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "cpp-13",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "cpp-13-x86-64-linux-gnu_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "cpp-13-x86-64-linux-gnu",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libmpfr6_4.2.1-1build1.1_amd64",
+					"name": "libmpfr6",
+					"version": "4.2.1-1build1.1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "libmpc3_1.3.1-1build1.1_amd64",
+					"name": "libmpc3",
+					"version": "1.3.1-1build1.1"
+				},
+				{
+					"key": "libisl23_0.26-3build1.1_amd64",
+					"name": "libisl23",
+					"version": "0.26-3build1.1"
+				},
+				{
+					"key": "gcc-13-base_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "gcc-13-base",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-13-x86-64-linux-gnu_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "gcc-13-x86-64-linux-gnu",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "libgcc-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libquadmath0_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libquadmath0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libhwasan0_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libhwasan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libubsan1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libubsan1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libtsan2_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libtsan2",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "liblsan0_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "liblsan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libasan8_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libasan8",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libatomic1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libatomic1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libitm1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libitm1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libgomp1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgomp1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libcc1-0_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libcc1-0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "g-p--p--x86-64-linux-gnu_4-13.2.0-7ubuntu1_amd64",
+					"name": "g++-x86-64-linux-gnu",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "g-p--p--13-x86-64-linux-gnu_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "g++-13-x86-64-linux-gnu",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libstdc-p--p--13-dev_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "libstdc++-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libc6-dev_2.39-0ubuntu8.4_amd64",
+					"name": "libc6-dev",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "rpcsvc-proto_1.4.2-0ubuntu7_amd64",
+					"name": "rpcsvc-proto",
+					"version": "1.4.2-0ubuntu7"
+				},
+				{
+					"key": "libcrypt-dev_1-4.4.36-4build1_amd64",
+					"name": "libcrypt-dev",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "linux-libc-dev_6.8.0-58.60_amd64",
+					"name": "linux-libc-dev",
+					"version": "6.8.0-58.60"
+				},
+				{
+					"key": "libc-dev-bin_2.39-0ubuntu8.4_amd64",
+					"name": "libc-dev-bin",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "gcc-x86-64-linux-gnu_4-13.2.0-7ubuntu1_amd64",
+					"name": "gcc-x86-64-linux-gnu",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "cpp-x86-64-linux-gnu_4-13.2.0-7ubuntu1_amd64",
+					"name": "cpp-x86-64-linux-gnu",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "g-p--p--13_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "g++-13",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "gcc_4-13.2.0-7ubuntu1_amd64",
+					"name": "gcc",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "cpp_4-13.2.0-7ubuntu1_amd64",
+					"name": "cpp",
+					"version": "4:13.2.0-7ubuntu1"
+				}
+			],
+			"key": "build-essential_12.10ubuntu1_amd64",
+			"name": "build-essential",
+			"sha256": "9b2159b95a4c01937309783c7c8a6ec8dfbcb7ffd604951c9713ac52ee9c7268",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/build-essential/build-essential_12.10ubuntu1_amd64.deb"
+			],
+			"version": "12.10ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "dpkg-dev_1.22.6ubuntu6.1_amd64",
+			"name": "dpkg-dev",
+			"sha256": "c70989835ab42d3d7a4dc1f8bb8c5ed9a88fd8c6b024bb4c45e5901bb6cc2f19",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dpkg/dpkg-dev_1.22.6ubuntu6.1_all.deb"
+			],
+			"version": "1.22.6ubuntu6.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "lto-disabled-list_47_amd64",
+			"name": "lto-disabled-list",
+			"sha256": "cac0f63c88188f376bb4df10a2af2b49a607bbef97a57db50ed58f678c21eee9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/l/lto-disabled-list/lto-disabled-list_47_all.deb"
+			],
+			"version": "47"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "binutils_2.42-4ubuntu2.5_amd64",
+			"name": "binutils",
+			"sha256": "26de69964291e8cc6a9a29d34f71ab96c7c3ece56c3e2622c2dda3bfa76eb482",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/binutils_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "binutils-x86-64-linux-gnu_2.42-4ubuntu2.5_amd64",
+			"name": "binutils-x86-64-linux-gnu",
+			"sha256": "d09ca6f3e0906eeaf2ffbdde802b8cc4f7bd7a642e814598d96db7fa47e30637",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsframe1_2.42-4ubuntu2.5_amd64",
+			"name": "libsframe1",
+			"sha256": "55829d9356ce730a9df6ebeb0dca9c4bc4b439ca48936cb4b32c6bd4ed3f33e3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libsframe1_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libjansson4_2.14-2build2_amd64",
+			"name": "libjansson4",
+			"sha256": "0cf79113f5d193ce9af2be2ff4b2c3b30dd4e55a0b6c47f7d28f6c849ff3aa60",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/j/jansson/libjansson4_2.14-2build2_amd64.deb"
+			],
+			"version": "2.14-2build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgprofng0_2.42-4ubuntu2.5_amd64",
+			"name": "libgprofng0",
+			"sha256": "bad6f9da5312a5c0c13e678a2d7eadf110a6b364ce3275162750af491d26135f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libgprofng0_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbinutils_2.42-4ubuntu2.5_amd64",
+			"name": "libbinutils",
+			"sha256": "57a86e1dccdf831e70cceea279c31e0c09e64d8f8a6bc671e4eb6546dd367d8d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libbinutils_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "binutils-common_2.42-4ubuntu2.5_amd64",
+			"name": "binutils-common",
+			"sha256": "c069b6b9b885194344ba01b088a20b2dd151b2951fd30ee14902d91322a812d1",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/binutils-common_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libctf0_2.42-4ubuntu2.5_amd64",
+			"name": "libctf0",
+			"sha256": "101f802ee820545c60060bc93f5058e60989351c7e831da73946f5247cae24b1",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libctf0_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libctf-nobfd0_2.42-4ubuntu2.5_amd64",
+			"name": "libctf-nobfd0",
+			"sha256": "61bfedf28763b9b4b04cdae9b4207bfc12c0261aa34a8292e837db5856e0d7c0",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libctf-nobfd0_2.42-4ubuntu2.5_amd64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "make_4.3-4.1build2_amd64",
+			"name": "make",
+			"sha256": "1fe6a815b56c7b6e9ce4086a363f09444bbd0a0d30e230c453d0b78e44b57a99",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/make-dfsg/make_4.3-4.1build2_amd64.deb"
+			],
+			"version": "4.3-4.1build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "patch_2.7.6-7build3_amd64",
+			"name": "patch",
+			"sha256": "fb7d78ed25c2788a607802270f3c28ac5ed6857bfb6cce9f73ad2cafac9159b3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/patch/patch_2.7.6-7build3_amd64.deb"
+			],
+			"version": "2.7.6-7build3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "xz-utils_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+			"name": "xz-utils",
+			"sha256": "925187570891a3b0af6a1423bdc91492a33c231fa39974ed91efb3ae4ce530fc",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/x/xz-utils/xz-utils_5.6.1+really5.4.5-1ubuntu0.2_amd64.deb"
+			],
+			"version": "5.6.1+really5.4.5-1ubuntu0.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "bzip2_1.0.8-5.1build0.1_amd64",
+			"name": "bzip2",
+			"sha256": "71c02f8f7541a2a57f0f3545ee826ad9778e665c5c457f34aca9e71abdc1a22b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/bzip2/bzip2_1.0.8-5.1build0.1_amd64.deb"
+			],
+			"version": "1.0.8-5.1build0.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdpkg-perl_1.22.6ubuntu6.1_amd64",
+			"name": "libdpkg-perl",
+			"sha256": "efe6ca6a0fce8bf293d71d925c506f95eaf7ca37642ebe68b8b173bb1072ef2a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dpkg/libdpkg-perl_1.22.6ubuntu6.1_all.deb"
+			],
+			"version": "1.22.6ubuntu6.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "g-p--p-_4-13.2.0-7ubuntu1_amd64",
+			"name": "g++",
+			"sha256": "800a84b369c64b18d65f0fb5c1533de0446c880ee4f1cadad64e3363327f63f0",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/g++_13.2.0-7ubuntu1_amd64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-13_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "gcc-13",
+			"sha256": "4e68ececd898a13295b940ef63b123f2f385c8ab00c27f6a00bdfb1d2ecc08e2",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/gcc-13_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "cpp-13_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "cpp-13",
+			"sha256": "d23e5237678767cc0cb128973a2d64e58bf0e8adf466ce6b2bc70c73d89ce941",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/cpp-13_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "cpp-13-x86-64-linux-gnu_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "cpp-13-x86-64-linux-gnu",
+			"sha256": "595791da223beec7cbbe6b77906a7c3c1a3946ac5b406c50624d0ec272f25ce7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/cpp-13-x86-64-linux-gnu_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmpfr6_4.2.1-1build1.1_amd64",
+			"name": "libmpfr6",
+			"sha256": "aebc1c8b69a1f98bb43dfc268daecd181116dbf40b13ee4e822eb4bdd52b493a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/mpfr4/libmpfr6_4.2.1-1build1.1_amd64.deb"
+			],
+			"version": "4.2.1-1build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmpc3_1.3.1-1build1.1_amd64",
+			"name": "libmpc3",
+			"sha256": "cebe6098bb3d66fdacac9dc6fe406a651216d9c00f27c3f9c159d15d96cdf864",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/mpclib3/libmpc3_1.3.1-1build1.1_amd64.deb"
+			],
+			"version": "1.3.1-1build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libisl23_0.26-3build1.1_amd64",
+			"name": "libisl23",
+			"sha256": "4e040926e50fb961fae9bf95660189d468336a4a17bc321872c434fc8f777e7f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/i/isl/libisl23_0.26-3build1.1_amd64.deb"
+			],
+			"version": "0.26-3build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-13-base_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "gcc-13-base",
+			"sha256": "7bd0432f85232b900c0d5df1ef08bbd718297be181ab4a435067c6021a3a71f2",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/gcc-13-base_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-13-x86-64-linux-gnu_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "gcc-13-x86-64-linux-gnu",
+			"sha256": "7cd398670e8306eabc9e77202f356a3206c440bd9f3dc764680a19be01784776",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/gcc-13-x86-64-linux-gnu_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "libgcc-13-dev",
+			"sha256": "ea61cc40833b78517933725a7b9a1d6b9d2047785f68577ddadfd064cc193397",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/libgcc-13-dev_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libquadmath0_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libquadmath0",
+			"sha256": "d26d8229c1b99d53926f1ef7b8c0837a73ac0724d44c14b7936b53d03dab2c55",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libquadmath0_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libhwasan0_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libhwasan0",
+			"sha256": "d878915cf7f8edc1e2f30a638f3cfe12a5ec39454ec4839c3707202a6c629424",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libhwasan0_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libubsan1_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libubsan1",
+			"sha256": "d5937f6d1336838f12bff8933c23c22440247f59eba188a67195da1c6720f769",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libubsan1_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtsan2_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libtsan2",
+			"sha256": "608b8c970829c7659f2f06b49b769b2496a1017f974a96132c7972a81844150a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libtsan2_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblsan0_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "liblsan0",
+			"sha256": "ff629bedf97244f63ce4afe5970c58f1ce8071472e23dbfc772293e74497f3a3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/liblsan0_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libasan8_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libasan8",
+			"sha256": "14e0ef9ac377e0e640431463ddd4382e79e0870437cb67775dd2cf3d2539da9e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libasan8_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libatomic1_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libatomic1",
+			"sha256": "fc25326388168f6aaf2e4bf729cb87a3bc8b2e42bdc976b7528181e7ff136765",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libatomic1_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libitm1_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libitm1",
+			"sha256": "32a46e65b66640089e4e57020e8d87adecb173af7749aa731cf04f505ca9a7ff",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libitm1_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgomp1_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libgomp1",
+			"sha256": "c93b6dfa2d21844b0c9d7a77f4a9918f6a51ba2185c68803f03d34e2b34622fc",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libgomp1_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcc1-0_14.2.0-4ubuntu2_24.04_amd64",
+			"name": "libcc1-0",
+			"sha256": "05e71d32827ac910a11a64efe5a4fa37cf1742ba9a5e285f91a80e0385cf32bc",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libcc1-0_14.2.0-4ubuntu2~24.04_amd64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "g-p--p--x86-64-linux-gnu_4-13.2.0-7ubuntu1_amd64",
+			"name": "g++-x86-64-linux-gnu",
+			"sha256": "145b027a542db5b21f85d4f9e242f51c62c69914fc484adb3a4881ca8e2f3913",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/g++-x86-64-linux-gnu_13.2.0-7ubuntu1_amd64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "g-p--p--13-x86-64-linux-gnu_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "g++-13-x86-64-linux-gnu",
+			"sha256": "1bc039e8eddd918d0bc23887ee0b9f615b8fde89bbf99552817f4fba6e079707",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/g++-13-x86-64-linux-gnu_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p--13-dev_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "libstdc++-13-dev",
+			"sha256": "36823aa43f8ecf5e0d6848b4a4c174c83356178901c268b24647737b0c0e4fd7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/libstdc++-13-dev_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6-dev_2.39-0ubuntu8.4_amd64",
+			"name": "libc6-dev",
+			"sha256": "7d02e1c95e09ffd25ca6ee111d4dc22e1bf2caca9cacb9b7f3527608582da498",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/glibc/libc6-dev_2.39-0ubuntu8.4_amd64.deb"
+			],
+			"version": "2.39-0ubuntu8.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "rpcsvc-proto_1.4.2-0ubuntu7_amd64",
+			"name": "rpcsvc-proto",
+			"sha256": "7eb710fe148d224c159ddec1ceb0ba53ead52a80a6793dcdae1474acf20d8f71",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-0ubuntu7_amd64.deb"
+			],
+			"version": "1.4.2-0ubuntu7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt-dev_1-4.4.36-4build1_amd64",
+			"name": "libcrypt-dev",
+			"sha256": "2edff420ef80b4a3f3751e65c33423ef30e563122a58b759e4854ea8d84ba1b1",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-4build1_amd64.deb"
+			],
+			"version": "1:4.4.36-4build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "linux-libc-dev_6.8.0-58.60_amd64",
+			"name": "linux-libc-dev",
+			"sha256": "09ec1141dfa796eda4b2b8425d1473ca89bdf763793fb97514633f173979139b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/l/linux/linux-libc-dev_6.8.0-58.60_amd64.deb"
+			],
+			"version": "6.8.0-58.60"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc-dev-bin_2.39-0ubuntu8.4_amd64",
+			"name": "libc-dev-bin",
+			"sha256": "0953d09370fc96c2411e7dab8e12db9eb7762be137387055e62a0e7b8d8a2e48",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/glibc/libc-dev-bin_2.39-0ubuntu8.4_amd64.deb"
+			],
+			"version": "2.39-0ubuntu8.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-x86-64-linux-gnu_4-13.2.0-7ubuntu1_amd64",
+			"name": "gcc-x86-64-linux-gnu",
+			"sha256": "72e79089a10e381360bfc6f03c5e5d8c2ff177d6dbac2cd7ffb3cc1383f57591",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_13.2.0-7ubuntu1_amd64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "cpp-x86-64-linux-gnu_4-13.2.0-7ubuntu1_amd64",
+			"name": "cpp-x86-64-linux-gnu",
+			"sha256": "85059b30960de3582e8612740614da3dfe47241d0368a28dea686188cf7648dd",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/cpp-x86-64-linux-gnu_13.2.0-7ubuntu1_amd64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "g-p--p--13_13.3.0-6ubuntu2_24.04_amd64",
+			"name": "g++-13",
+			"sha256": "da109251ab0d6a88927c5416fd12498b08e7508b0221c22826263410ec7554af",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/g++-13_13.3.0-6ubuntu2~24.04_amd64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc_4-13.2.0-7ubuntu1_amd64",
+			"name": "gcc",
+			"sha256": "0e0bb8b25153ed1c44ab92bc219eed469fcb5820c5c0bc6454b2fd366a33d3ee",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/gcc_13.2.0-7ubuntu1_amd64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "cpp_4-13.2.0-7ubuntu1_amd64",
+			"name": "cpp",
+			"sha256": "b51f8094760f7b41afdcb1fe1b5a57fc64b75a090859918af17450a10f8c7d31",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/cpp_13.2.0-7ubuntu1_amd64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "ncurses-base_6.4-p-20240113-1ubuntu2_arm64",
+			"name": "ncurses-base",
+			"sha256": "56dbac135d58e580c2c9e33d5fd7c215b48091a54e1d9fa3d41f538f4acbac5f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/ncurses-base_6.4+20240113-1ubuntu2_all.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_arm64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				}
+			],
+			"key": "libncurses6_6.4-p-20240113-1ubuntu2_arm64",
+			"name": "libncurses6",
+			"sha256": "28bd1bd3d9a647d15da1a9c3d397eed873e0d03df2dc427c62bf6411d5049615",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/libncurses6_6.4+20240113-1ubuntu2_arm64.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6_2.39-0ubuntu8.4_arm64",
+			"name": "libc6",
+			"sha256": "4d5628bd7d15845f715b156d3f8b6f8260be04c30b43b861e283ba34f7e3173e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/glibc/libc6_2.39-0ubuntu8.4_arm64.deb"
+			],
+			"version": "2.39-0ubuntu8.4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libgcc-s1",
+			"sha256": "c9737e14642052d6eefb55bd52b2276e3b0eb3f41b8c97c6c370d0e5841fce9d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "gcc-14-base",
+			"sha256": "e3fc99593cd68e333e84c446cffde7e71ba62066cee665b061d231204bfd72e7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtinfo6_6.4-p-20240113-1ubuntu2_arm64",
+			"name": "libtinfo6",
+			"sha256": "e8d06277be81d0f6e7d49ce796a477a9fc88e755bf3048e0afe44fc14a310b72",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/libtinfo6_6.4+20240113-1ubuntu2_arm64.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.86ubuntu1_arm64",
+					"name": "debconf",
+					"version": "1.5.86ubuntu1"
+				}
+			],
+			"key": "tzdata_2025b-0ubuntu0.24.04_arm64",
+			"name": "tzdata",
+			"sha256": "1c58af2626cd9c6920cda7494d998ca1c32ab6c689a613c560d06acf8bac5e19",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/t/tzdata/tzdata_2025b-0ubuntu0.24.04_all.deb"
+			],
+			"version": "2025b-0ubuntu0.24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debconf_1.5.86ubuntu1_arm64",
+			"name": "debconf",
+			"sha256": "bb390da466a7461bfc87aa3e6b7cd145dae84af3e26bf437f2c0c218ba226294",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/debconf/debconf_1.5.86ubuntu1_all.deb"
+			],
+			"version": "1.5.86ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_arm64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "debianutils_5.17build1_arm64",
+					"name": "debianutils",
+					"version": "5.17build1"
+				}
+			],
+			"key": "dash_0.5.12-6ubuntu5_arm64",
+			"name": "dash",
+			"sha256": "ff6f0bbd178f02160f3b1de49650b2d9686aace1ac7bf14f85201f8502f1df20",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dash/dash_0.5.12-6ubuntu5_arm64.deb"
+			],
+			"version": "0.5.12-6ubuntu5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "tar_1.35-p-dfsg-3build1_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				}
+			],
+			"key": "dpkg_1.22.6ubuntu6.1_arm64",
+			"name": "dpkg",
+			"sha256": "14e422fde3ec43cc8c0b247bc1ee2ea391e899e7471a6ffc6668cbd428a67d4e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dpkg/dpkg_1.22.6ubuntu6.1_arm64.deb"
+			],
+			"version": "1.22.6ubuntu6.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "tar_1.35-p-dfsg-3build1_arm64",
+			"name": "tar",
+			"sha256": "2df76253d79fd27b8e10b4b1426e2a229c1f374406a80607878eb66bdc1edcf6",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/t/tar/tar_1.35+dfsg-3build1_arm64.deb"
+			],
+			"version": "1.35+dfsg-3build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+			"name": "libselinux1",
+			"sha256": "56630c4f009754e76808bf755072e634f8785a4dfbc8b1445213149e682f1502",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libs/libselinux/libselinux1_3.5-2ubuntu2.1_arm64.deb"
+			],
+			"version": "3.5-2ubuntu2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+			"name": "libpcre2-8-0",
+			"sha256": "7581764969752953aa1f991ce143bea594d2c5d0c36c2cc98c3c614c172aba93",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/pcre2/libpcre2-8-0_10.42-4ubuntu2.1_arm64.deb"
+			],
+			"version": "10.42-4ubuntu2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libacl1_2.3.2-1build1.1_arm64",
+			"name": "libacl1",
+			"sha256": "ebc53ded654fcf4449df250cb563ff05f10d851e904e638f698dc7e921ffa47b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/acl/libacl1_2.3.2-1build1.1_arm64.deb"
+			],
+			"version": "2.3.2-1build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+			"name": "zlib1g",
+			"sha256": "cbe3d39ec32d3cc27c021ae4af11e7c67bdf9d700d573207e0941d4038056278",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_arm64.deb"
+			],
+			"version": "1:1.3.dfsg-3.1ubuntu2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+			"name": "libzstd1",
+			"sha256": "ea7d6e9fde577ea14dbf07fdfb74d6287eb09c6cba4a9d63abdcb87b0ec54bcc",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2build1.1_arm64.deb"
+			],
+			"version": "1.5.5+dfsg2-2build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libmd0_1.1.0-2build1.1_arm64",
+			"name": "libmd0",
+			"sha256": "c28583825f7191cdc8b6b71c6150e2cbfc29616d6570680e5284fabc19765ea5",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libm/libmd/libmd0_1.1.0-2build1.1_arm64.deb"
+			],
+			"version": "1.1.0-2build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+			"name": "liblzma5",
+			"sha256": "ec5b9a72c1c59886bf5fbd3b1041b472e1fe7978ff37f14365d93cb437261d12",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/x/xz-utils/liblzma5_5.6.1+really5.4.5-1ubuntu0.2_arm64.deb"
+			],
+			"version": "5.6.1+really5.4.5-1ubuntu0.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+			"name": "libbz2-1.0",
+			"sha256": "889ffccfe565e1011f215581a81a2770a04b021313157e75066a3613b1569041",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5.1build0.1_arm64.deb"
+			],
+			"version": "1.0.8-5.1build0.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debianutils_5.17build1_arm64",
+			"name": "debianutils",
+			"sha256": "7419da04f9c467986b2176e799f3683b9403c643966084d0f6054f2a5b8919e9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/debianutils/debianutils_5.17build1_arm64.deb"
+			],
+			"version": "5.17build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "debianutils_5.17build1_arm64",
+					"name": "debianutils",
+					"version": "5.17build1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "base-files_13ubuntu10.2_arm64",
+					"name": "base-files",
+					"version": "13ubuntu10.2"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "mawk_1.3.4.20240123-1build1_arm64",
+					"name": "mawk",
+					"version": "1.3.4.20240123-1build1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_arm64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				}
+			],
+			"key": "bash_5.2.21-2ubuntu4_arm64",
+			"name": "bash",
+			"sha256": "1cb8aa182b8124a5304b5d5cf24300e295c9f6ff22a2565fcecae686c0492f09",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/bash/bash_5.2.21-2ubuntu4_arm64.deb"
+			],
+			"version": "5.2.21-2ubuntu4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "base-files_13ubuntu10.2_arm64",
+			"name": "base-files",
+			"sha256": "c8a665614653069e2114cefbf7e50d24dc99d71efcb4288b041e964c30c16b5e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/base-files/base-files_13ubuntu10.2_arm64.deb"
+			],
+			"version": "13ubuntu10.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.36-4build1_arm64",
+			"name": "libcrypt1",
+			"sha256": "5cd73ba112507dabd8e43b528ca9f530719a370e014b8e3e797770e6e940cccf",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libx/libxcrypt/libcrypt1_4.4.36-4build1_arm64.deb"
+			],
+			"version": "1:4.4.36-4build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "mawk_1.3.4.20240123-1build1_arm64",
+			"name": "mawk",
+			"sha256": "a6fa75e49de6327ccdbf664e905cde229df77116a966c310e81c778eba756dca",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/mawk/mawk_1.3.4.20240123-1build1_arm64.deb"
+			],
+			"version": "1.3.4.20240123-1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_arm64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "libattr1_1-2.5.2-1build1.1_arm64",
+					"name": "libattr1",
+					"version": "1:2.5.2-1build1.1"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				}
+			],
+			"key": "coreutils_9.4-3ubuntu6_arm64",
+			"name": "coreutils",
+			"sha256": "6a49cb31be2c0d5403da0c675a5b3af9e7b2461b2d4c6a0e243f1627bed9cc81",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/coreutils/coreutils_9.4-3ubuntu6_arm64.deb"
+			],
+			"version": "9.4-3ubuntu6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssl3t64_3.0.13-0ubuntu3.5_arm64",
+			"name": "libssl3t64",
+			"sha256": "8d6324dc06affd7d80afbc4ab521ee554875c0f753660098737a89988bc4bfca",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/o/openssl/libssl3t64_3.0.13-0ubuntu3.5_arm64.deb"
+			],
+			"version": "3.0.13-0ubuntu3.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_arm64",
+			"name": "libgmp10",
+			"sha256": "5a783429ec1a29fb74a9a59c1699579dd9742bd35722280b9ce10e1f3916b003",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2ubuntu6.1_arm64.deb"
+			],
+			"version": "2:6.3.0+dfsg-2ubuntu6.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libattr1_1-2.5.2-1build1.1_arm64",
+			"name": "libattr1",
+			"sha256": "d441ec6f5df6ffa76d37fe5c7eecbd42ae1876121baf3e511de57afe79538f1d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/attr/libattr1_2.5.2-1build1.1_arm64.deb"
+			],
+			"version": "1:2.5.2-1build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "grep_3.11-4build1_arm64",
+			"name": "grep",
+			"sha256": "275938cc6b1e4ab16f803bcc62961ee88312298d9d36b5b1e7a3590d795e3921",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/grep/grep_3.11-4build1_arm64.deb"
+			],
+			"version": "3.11-4build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				}
+			],
+			"key": "sed_4.9-2build1_arm64",
+			"name": "sed",
+			"sha256": "fdcaa3eaaaa511ec87d7847622aa4036d56f17f251c48b4113b515f589a0b121",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/sed/sed_4.9-2build1_arm64.deb"
+			],
+			"version": "4.9-2build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "findutils_4.9.0-5build1_arm64",
+			"name": "findutils",
+			"sha256": "260f15b1da771ce33c9179970aab3fbc0104620628d1826b8b9de19ea4483fe4",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/f/findutils/findutils_4.9.0-5build1_arm64.deb"
+			],
+			"version": "4.9.0-5build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libsystemd0_255.4-1ubuntu8.6_arm64",
+					"name": "libsystemd0",
+					"version": "255.4-1ubuntu8.6"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "liblz4-1_1.9.4-1build1.1_arm64",
+					"name": "liblz4-1",
+					"version": "1.9.4-1build1.1"
+				},
+				{
+					"key": "libgcrypt20_1.10.3-2build1_arm64",
+					"name": "libgcrypt20",
+					"version": "1.10.3-2build1"
+				},
+				{
+					"key": "libgpg-error0_1.47-3build2.1_arm64",
+					"name": "libgpg-error0",
+					"version": "1.47-3build2.1"
+				},
+				{
+					"key": "libcap2_1-2.66-5ubuntu2.2_arm64",
+					"name": "libcap2",
+					"version": "1:2.66-5ubuntu2.2"
+				},
+				{
+					"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libstdc++6",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libseccomp2_2.5.5-1ubuntu3.1_arm64",
+					"name": "libseccomp2",
+					"version": "2.5.5-1ubuntu3.1"
+				},
+				{
+					"key": "libgnutls30t64_3.8.3-1.1ubuntu3.3_arm64",
+					"name": "libgnutls30t64",
+					"version": "3.8.3-1.1ubuntu3.3"
+				},
+				{
+					"key": "libunistring5_1.1-2build1.1_arm64",
+					"name": "libunistring5",
+					"version": "1.1-2build1.1"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-3ubuntu0.24.04.1_arm64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-3ubuntu0.24.04.1"
+				},
+				{
+					"key": "libp11-kit0_0.25.3-4ubuntu2.1_arm64",
+					"name": "libp11-kit0",
+					"version": "0.25.3-4ubuntu2.1"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_arm64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libnettle8t64_3.9.1-2.2build1.1_arm64",
+					"name": "libnettle8t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libidn2-0_2.3.7-2build1.1_arm64",
+					"name": "libidn2-0",
+					"version": "2.3.7-2build1.1"
+				},
+				{
+					"key": "libhogweed6t64_3.9.1-2.2build1.1_arm64",
+					"name": "libhogweed6t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "ubuntu-keyring_2023.11.28.1_arm64",
+					"name": "ubuntu-keyring",
+					"version": "2023.11.28.1"
+				},
+				{
+					"key": "libapt-pkg6.0t64_2.7.14build2_arm64",
+					"name": "libapt-pkg6.0t64",
+					"version": "2.7.14build2"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libxxhash0_0.8.2-2build1_arm64",
+					"name": "libxxhash0",
+					"version": "0.8.2-2build1"
+				},
+				{
+					"key": "libudev1_255.4-1ubuntu8.6_arm64",
+					"name": "libudev1",
+					"version": "255.4-1ubuntu8.6"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "gpgv_2.4.4-2ubuntu17.2_arm64",
+					"name": "gpgv",
+					"version": "2.4.4-2ubuntu17.2"
+				},
+				{
+					"key": "libnpth0t64_1.6-3.1build1_arm64",
+					"name": "libnpth0t64",
+					"version": "1.6-3.1build1"
+				},
+				{
+					"key": "libassuan0_2.5.6-1build1_arm64",
+					"name": "libassuan0",
+					"version": "2.5.6-1build1"
+				},
+				{
+					"key": "base-passwd_3.6.3build1_arm64",
+					"name": "base-passwd",
+					"version": "3.6.3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libdebconfclient0_0.271ubuntu3_arm64",
+					"name": "libdebconfclient0",
+					"version": "0.271ubuntu3"
+				}
+			],
+			"key": "apt_2.7.14build2_arm64",
+			"name": "apt",
+			"sha256": "75815ee5f4a7c5098705dc31538ab7732fdee08ea71219c136bfa27cc7388685",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/apt/apt_2.7.14build2_arm64.deb"
+			],
+			"version": "2.7.14build2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsystemd0_255.4-1ubuntu8.6_arm64",
+			"name": "libsystemd0",
+			"sha256": "22e18a9310347e066657a4515462d5dd4d1b79bfa86b72d0cab5581281408e2a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/systemd/libsystemd0_255.4-1ubuntu8.6_arm64.deb"
+			],
+			"version": "255.4-1ubuntu8.6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.4-1build1.1_arm64",
+			"name": "liblz4-1",
+			"sha256": "65ab8cfe4aeb8205ef4f980500d2c8cb397cb49901ef12efad59f4ed7685cbe0",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/l/lz4/liblz4-1_1.9.4-1build1.1_arm64.deb"
+			],
+			"version": "1.9.4-1build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.10.3-2build1_arm64",
+			"name": "libgcrypt20",
+			"sha256": "ef72eafe2393bdc23d37750a2c8ee025b0d61f8158397bd8bca21b5319b5e2c6",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2build1_arm64.deb"
+			],
+			"version": "1.10.3-2build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.47-3build2.1_arm64",
+			"name": "libgpg-error0",
+			"sha256": "cb14ae76d098421ee58c0b6796ce836a9fd386fa4824894a029089062b485b09",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libg/libgpg-error/libgpg-error0_1.47-3build2.1_arm64.deb"
+			],
+			"version": "1.47-3build2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcap2_1-2.66-5ubuntu2.2_arm64",
+			"name": "libcap2",
+			"sha256": "852946ceb96d94f3a9057a0c9be6fea5a41cc79ffe26adde61bc2915aa6ed4a3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu2.2_arm64.deb"
+			],
+			"version": "1:2.66-5ubuntu2.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libstdc++6",
+			"sha256": "0a4b6988232f58b3f96f4ba1464c653d0448b4e6932a30f539434c9be3100b9d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libstdc++6_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libseccomp2_2.5.5-1ubuntu3.1_arm64",
+			"name": "libseccomp2",
+			"sha256": "2feac77a129e336960734586ccdb16eefb040adfe7b662369549e41b82ba0a1b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-1ubuntu3.1_arm64.deb"
+			],
+			"version": "2.5.5-1ubuntu3.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgnutls30t64_3.8.3-1.1ubuntu3.3_arm64",
+			"name": "libgnutls30t64",
+			"sha256": "900906e51930c35418d898061b25dc901aaa577c76d20077675ebabb3b83fa54",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gnutls28/libgnutls30t64_3.8.3-1.1ubuntu3.3_arm64.deb"
+			],
+			"version": "3.8.3-1.1ubuntu3.3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libunistring5_1.1-2build1.1_arm64",
+			"name": "libunistring5",
+			"sha256": "faa0cea6bf19c57cace839f7184c070f2f0f4efc41258b39625b0ed988f68100",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libu/libunistring/libunistring5_1.1-2build1.1_arm64.deb"
+			],
+			"version": "1.1-2build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.19.0-3ubuntu0.24.04.1_arm64",
+			"name": "libtasn1-6",
+			"sha256": "11a9722db63989eb4c282970bcd00a4e135f14bcc36a73d41e767dabf857dce5",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3ubuntu0.24.04.1_arm64.deb"
+			],
+			"version": "4.19.0-3ubuntu0.24.04.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.25.3-4ubuntu2.1_arm64",
+			"name": "libp11-kit0",
+			"sha256": "0c609690ae1d4c4deccd6fbd50601d6ffc55e1f6f2a53b1b9469203db848674d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/p11-kit/libp11-kit0_0.25.3-4ubuntu2.1_arm64.deb"
+			],
+			"version": "0.25.3-4ubuntu2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libffi8_3.4.6-1build1_arm64",
+			"name": "libffi8",
+			"sha256": "a4d4607144bc599328a913d7312761fd8f4a650d67c7d5058f1f3667d771d37c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libf/libffi/libffi8_3.4.6-1build1_arm64.deb"
+			],
+			"version": "3.4.6-1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnettle8t64_3.9.1-2.2build1.1_arm64",
+			"name": "libnettle8t64",
+			"sha256": "c2943b87811fe1f35b7e67869810226652caf43a31bd32c8d3ce1b331700b008",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/nettle/libnettle8t64_3.9.1-2.2build1.1_arm64.deb"
+			],
+			"version": "3.9.1-2.2build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.7-2build1.1_arm64",
+			"name": "libidn2-0",
+			"sha256": "5d21e1ff26d44b762efc8f94df2e1e1944c1d288a29059b3cf5e76e3bfdf2968",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2build1.1_arm64.deb"
+			],
+			"version": "2.3.7-2build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libhogweed6t64_3.9.1-2.2build1.1_arm64",
+			"name": "libhogweed6t64",
+			"sha256": "1c252dfe2c1e458c47c6e674285c043e7940555581574a96c49defae26126883",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/nettle/libhogweed6t64_3.9.1-2.2build1.1_arm64.deb"
+			],
+			"version": "3.9.1-2.2build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "ubuntu-keyring_2023.11.28.1_arm64",
+			"name": "ubuntu-keyring",
+			"sha256": "36de43b15853ccae0028e9a767613770c704833f82586f28eb262f0311adb8a8",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2023.11.28.1_all.deb"
+			],
+			"version": "2023.11.28.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0t64_2.7.14build2_arm64",
+			"name": "libapt-pkg6.0t64",
+			"sha256": "b73ba8b07a22d5a1b182c4141998a7bac800f6113ef41f6a74ec9ea93cf92194",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/a/apt/libapt-pkg6.0t64_2.7.14build2_arm64.deb"
+			],
+			"version": "2.7.14build2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxxhash0_0.8.2-2build1_arm64",
+			"name": "libxxhash0",
+			"sha256": "a69cf89fe33b386e63c26f6992be1e20bfa2ea2dd30c3619af8b1174612c4525",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/x/xxhash/libxxhash0_0.8.2-2build1_arm64.deb"
+			],
+			"version": "0.8.2-2build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libudev1_255.4-1ubuntu8.6_arm64",
+			"name": "libudev1",
+			"sha256": "7b04cf001d31de5c049f3c6bb0b8688203501c321df33ae0f4dd5cbbd534495e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/systemd/libudev1_255.4-1ubuntu8.6_arm64.deb"
+			],
+			"version": "255.4-1ubuntu8.6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gpgv_2.4.4-2ubuntu17.2_arm64",
+			"name": "gpgv",
+			"sha256": "66e540649596b3aad2e4cb4b7d6df22c06d302903e50756314fa9b29f56062b2",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gnupg2/gpgv_2.4.4-2ubuntu17.2_arm64.deb"
+			],
+			"version": "2.4.4-2ubuntu17.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnpth0t64_1.6-3.1build1_arm64",
+			"name": "libnpth0t64",
+			"sha256": "a3d40edb1295a8c7a6074a1f4a4fa23f52a8f682014da965cd7d7a020729428d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/npth/libnpth0t64_1.6-3.1build1_arm64.deb"
+			],
+			"version": "1.6-3.1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libassuan0_2.5.6-1build1_arm64",
+			"name": "libassuan0",
+			"sha256": "7d6c7b49d63422d3cb813406d0b5f698439b4619d6491ef6a73c09bbf30ba625",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/liba/libassuan/libassuan0_2.5.6-1build1_arm64.deb"
+			],
+			"version": "2.5.6-1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "base-passwd_3.6.3build1_arm64",
+			"name": "base-passwd",
+			"sha256": "d9bbc2cfb535ee6f177df8ef685be8932a24c3ec46269183dc78319770e78caf",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/base-passwd/base-passwd_3.6.3build1_arm64.deb"
+			],
+			"version": "3.6.3build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdebconfclient0_0.271ubuntu3_arm64",
+			"name": "libdebconfclient0",
+			"sha256": "643c8461a9a1ff3a14bccfabe68ec6dac03645d393cc39f3c06c9bba423d7d60",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/cdebconf/libdebconfclient0_0.271ubuntu3_arm64.deb"
+			],
+			"version": "0.271ubuntu3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "libperl5.38t64",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-base_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl-base",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_arm64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libgdbm6t64_1.23-5.1build1_arm64",
+					"name": "libgdbm6t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libgdbm-compat4t64_1.23-5.1build1_arm64",
+					"name": "libgdbm-compat4t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_arm64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				}
+			],
+			"key": "perl_5.38.2-3.2ubuntu0.1_arm64",
+			"name": "perl",
+			"sha256": "66cd568ef5f05442717a7aa74b07a5ea0bb67695eec6340847771374f1e254ca",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/perl_5.38.2-3.2ubuntu0.1_arm64.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_arm64",
+			"name": "libperl5.38t64",
+			"sha256": "6badd97ca01690cd3a36e198e5a665c444a594217ddf5d4e43f96a68ddfbf1da",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/libperl5.38t64_5.38.2-3.2ubuntu0.1_arm64.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_arm64",
+			"name": "perl-modules-5.38",
+			"sha256": "7856700df3a65bcc4cf8506c61138b069d2512f3b4576ba6b54db59fde93950f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/perl-modules-5.38_5.38.2-3.2ubuntu0.1_all.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "perl-base_5.38.2-3.2ubuntu0.1_arm64",
+			"name": "perl-base",
+			"sha256": "d707d5019ae7256062e20343ccff1bbb8248d2b73828f9caa9c45c696ae25a5c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/perl/perl-base_5.38.2-3.2ubuntu0.1_arm64.deb"
+			],
+			"version": "5.38.2-3.2ubuntu0.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgdbm6t64_1.23-5.1build1_arm64",
+			"name": "libgdbm6t64",
+			"sha256": "acc12af7e644ac336024c5d24028b20814fadd272588be30fb792982217e2dd4",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gdbm/libgdbm6t64_1.23-5.1build1_arm64.deb"
+			],
+			"version": "1.23-5.1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgdbm-compat4t64_1.23-5.1build1_arm64",
+			"name": "libgdbm-compat4t64",
+			"sha256": "e5788a4d0477e0b5bf5cad8950cbd591698828836818c180c20da6f86d68bd37",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gdbm/libgdbm-compat4t64_1.23-5.1build1_arm64.deb"
+			],
+			"version": "1.23-5.1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdb5.3t64_5.3.28-p-dfsg2-7_arm64",
+			"name": "libdb5.3t64",
+			"sha256": "b04d246b871e2e745538fa71ce2d1a127dfd65e7b1438bc6b8e2bb86538f519e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/db5.3/libdb5.3t64_5.3.28+dfsg2-7_arm64.deb"
+			],
+			"version": "5.3.28+dfsg2-7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "debconf_1.5.86ubuntu1_arm64",
+					"name": "debconf",
+					"version": "1.5.86ubuntu1"
+				},
+				{
+					"key": "openssl_3.0.13-0ubuntu3.5_arm64",
+					"name": "openssl",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_arm64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "ca-certificates_20240203_arm64",
+			"name": "ca-certificates",
+			"sha256": "641de77d8f142cfd62a1a6f964ba67b20754d3337c480efb529d086075a06c9a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/ca-certificates/ca-certificates_20240203_all.deb"
+			],
+			"version": "20240203"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "openssl_3.0.13-0ubuntu3.5_arm64",
+			"name": "openssl",
+			"sha256": "bac742269555a52c12df5706a69c374fc87cbe3379e60de22e7a0984522f34c7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/o/openssl/openssl_3.0.13-0ubuntu3.5_arm64.deb"
+			],
+			"version": "3.0.13-0ubuntu3.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "git-man_1-2.43.0-1ubuntu7.2_arm64",
+					"name": "git-man",
+					"version": "1:2.43.0-1ubuntu7.2"
+				},
+				{
+					"key": "liberror-perl_0.17029-2_arm64",
+					"name": "liberror-perl",
+					"version": "0.17029-2"
+				},
+				{
+					"key": "perl_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "libperl5.38t64",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-base_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl-base",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_arm64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libgdbm6t64_1.23-5.1build1_arm64",
+					"name": "libgdbm6t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libgdbm-compat4t64_1.23-5.1build1_arm64",
+					"name": "libgdbm-compat4t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_arm64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				},
+				{
+					"key": "libexpat1_2.6.1-2ubuntu0.3_arm64",
+					"name": "libexpat1",
+					"version": "2.6.1-2ubuntu0.3"
+				},
+				{
+					"key": "libcurl3t64-gnutls_8.5.0-2ubuntu10.6_arm64",
+					"name": "libcurl3t64-gnutls",
+					"version": "8.5.0-2ubuntu10.6"
+				},
+				{
+					"key": "libssh-4_0.10.6-2build2_arm64",
+					"name": "libssh-4",
+					"version": "0.10.6-2build2"
+				},
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_arm64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.20.1-6ubuntu2.5_arm64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libkrb5support0_1.20.1-6ubuntu2.5_arm64",
+					"name": "libkrb5support0",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libk5crypto3_1.20.1-6ubuntu2.5_arm64",
+					"name": "libk5crypto3",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libcom-err2_1.47.0-2.4_exp1ubuntu4.1_arm64",
+					"name": "libcom-err2",
+					"version": "1.47.0-2.4~exp1ubuntu4.1"
+				},
+				{
+					"key": "libkrb5-3_1.20.1-6ubuntu2.5_arm64",
+					"name": "libkrb5-3",
+					"version": "1.20.1-6ubuntu2.5"
+				},
+				{
+					"key": "libkeyutils1_1.6.3-3build1_arm64",
+					"name": "libkeyutils1",
+					"version": "1.6.3-3build1"
+				},
+				{
+					"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2build7_arm64",
+					"name": "librtmp1",
+					"version": "2.4+20151223.gitfa8646d.1-2build7"
+				},
+				{
+					"key": "libnettle8t64_3.9.1-2.2build1.1_arm64",
+					"name": "libnettle8t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libhogweed6t64_3.9.1-2.2build1.1_arm64",
+					"name": "libhogweed6t64",
+					"version": "3.9.1-2.2build1.1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "libgnutls30t64_3.8.3-1.1ubuntu3.3_arm64",
+					"name": "libgnutls30t64",
+					"version": "3.8.3-1.1ubuntu3.3"
+				},
+				{
+					"key": "libunistring5_1.1-2build1.1_arm64",
+					"name": "libunistring5",
+					"version": "1.1-2build1.1"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-3ubuntu0.24.04.1_arm64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-3ubuntu0.24.04.1"
+				},
+				{
+					"key": "libp11-kit0_0.25.3-4ubuntu2.1_arm64",
+					"name": "libp11-kit0",
+					"version": "0.25.3-4ubuntu2.1"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_arm64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libidn2-0_2.3.7-2build1.1_arm64",
+					"name": "libidn2-0",
+					"version": "2.3.7-2build1.1"
+				},
+				{
+					"key": "libpsl5t64_0.21.2-1.1build1_arm64",
+					"name": "libpsl5t64",
+					"version": "0.21.2-1.1build1"
+				},
+				{
+					"key": "libnghttp2-14_1.59.0-1ubuntu0.2_arm64",
+					"name": "libnghttp2-14",
+					"version": "1.59.0-1ubuntu0.2"
+				},
+				{
+					"key": "libldap2_2.6.7-p-dfsg-1_exp1ubuntu8.2_arm64",
+					"name": "libldap2",
+					"version": "2.6.7+dfsg-1~exp1ubuntu8.2"
+				},
+				{
+					"key": "libsasl2-2_2.1.28-p-dfsg1-5ubuntu3.1_arm64",
+					"name": "libsasl2-2",
+					"version": "2.1.28+dfsg1-5ubuntu3.1"
+				},
+				{
+					"key": "libsasl2-modules-db_2.1.28-p-dfsg1-5ubuntu3.1_arm64",
+					"name": "libsasl2-modules-db",
+					"version": "2.1.28+dfsg1-5ubuntu3.1"
+				},
+				{
+					"key": "libbrotli1_1.1.0-2build2_arm64",
+					"name": "libbrotli1",
+					"version": "1.1.0-2build2"
+				}
+			],
+			"key": "git_1-2.43.0-1ubuntu7.2_arm64",
+			"name": "git",
+			"sha256": "7a38b6c67b2e90f75d879f4830fb02eef82efec9e3d01640bbf4a502fe985e02",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/git/git_2.43.0-1ubuntu7.2_arm64.deb"
+			],
+			"version": "1:2.43.0-1ubuntu7.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "git-man_1-2.43.0-1ubuntu7.2_arm64",
+			"name": "git-man",
+			"sha256": "bf6a37abf3839b2e2c108867bc58a1fd2cf27e20ec6a0a78c90c8cba9d7bccf9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/git/git-man_2.43.0-1ubuntu7.2_all.deb"
+			],
+			"version": "1:2.43.0-1ubuntu7.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liberror-perl_0.17029-2_arm64",
+			"name": "liberror-perl",
+			"sha256": "1907af6bf33dd8684447c09f216c675d2b8559fadd8ddace29fbf83c6fb2a636",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libe/liberror-perl/liberror-perl_0.17029-2_all.deb"
+			],
+			"version": "0.17029-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libexpat1_2.6.1-2ubuntu0.3_arm64",
+			"name": "libexpat1",
+			"sha256": "0c3147ebba308444634c507e88538686948aba0448e92c7f1ff36a7f6e67b1d7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/e/expat/libexpat1_2.6.1-2ubuntu0.3_arm64.deb"
+			],
+			"version": "2.6.1-2ubuntu0.3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcurl3t64-gnutls_8.5.0-2ubuntu10.6_arm64",
+			"name": "libcurl3t64-gnutls",
+			"sha256": "6239266767363831020c92c127089804d97cae276bc8fd509c23e3c47d356345",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/curl/libcurl3t64-gnutls_8.5.0-2ubuntu10.6_arm64.deb"
+			],
+			"version": "8.5.0-2ubuntu10.6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssh-4_0.10.6-2build2_arm64",
+			"name": "libssh-4",
+			"sha256": "633cbff0912d85db99f50ec7fa2a61bea7a1b3252f5d4ef2a1bb53145f15611c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libs/libssh/libssh-4_0.10.6-2build2_arm64.deb"
+			],
+			"version": "0.10.6-2build2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgssapi-krb5-2_1.20.1-6ubuntu2.5_arm64",
+			"name": "libgssapi-krb5-2",
+			"sha256": "f4f6846529575fe60cc661fee753f659cc12e12d6550365270274280c0ebc447",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-6ubuntu2.5_arm64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkrb5support0_1.20.1-6ubuntu2.5_arm64",
+			"name": "libkrb5support0",
+			"sha256": "32f537ef02c6965e13097b21cd6af8d7e5c66d1607b96a47a792325322f65baf",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libkrb5support0_1.20.1-6ubuntu2.5_arm64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libk5crypto3_1.20.1-6ubuntu2.5_arm64",
+			"name": "libk5crypto3",
+			"sha256": "e69d29fcaed8330a890bf8ab6ebf0676cb548fb89a8c141136c287488acfcf3b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libk5crypto3_1.20.1-6ubuntu2.5_arm64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcom-err2_1.47.0-2.4_exp1ubuntu4.1_arm64",
+			"name": "libcom-err2",
+			"sha256": "7bc569801d708551dd1eb8bf41feaadbc6191344e65d17f26ecf73a6f5b701dd",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2.4~exp1ubuntu4.1_arm64.deb"
+			],
+			"version": "1.47.0-2.4~exp1ubuntu4.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkrb5-3_1.20.1-6ubuntu2.5_arm64",
+			"name": "libkrb5-3",
+			"sha256": "d392ed21cd61d8d9d6b38bf118cfc120f048e3f3f7bac50a447e660f022a6f24",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/krb5/libkrb5-3_1.20.1-6ubuntu2.5_arm64.deb"
+			],
+			"version": "1.20.1-6ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkeyutils1_1.6.3-3build1_arm64",
+			"name": "libkeyutils1",
+			"sha256": "d141e94ed3b32ea6540f2e927a83b3d42cd4378256a1aad60cda583ffdbd78af",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/k/keyutils/libkeyutils1_1.6.3-3build1_arm64.deb"
+			],
+			"version": "1.6.3-3build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2build7_arm64",
+			"name": "librtmp1",
+			"sha256": "fb771b2743120d9d44ee9989fd485205680976f7bf89f2f1ac5df50238ea1db7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2build7_arm64.deb"
+			],
+			"version": "2.4+20151223.gitfa8646d.1-2build7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpsl5t64_0.21.2-1.1build1_arm64",
+			"name": "libpsl5t64",
+			"sha256": "886d485c74567b855bcd19b6f353a769a08b58c111b2d8275a908a469c15d4bf",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libp/libpsl/libpsl5t64_0.21.2-1.1build1_arm64.deb"
+			],
+			"version": "0.21.2-1.1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnghttp2-14_1.59.0-1ubuntu0.2_arm64",
+			"name": "libnghttp2-14",
+			"sha256": "bee053e74416ddc6f30c573ac7c3d475d97820fe5ee4a39fbf053ad94fb72826",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1ubuntu0.2_arm64.deb"
+			],
+			"version": "1.59.0-1ubuntu0.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libldap2_2.6.7-p-dfsg-1_exp1ubuntu8.2_arm64",
+			"name": "libldap2",
+			"sha256": "e4e5640d8d2052eb4a6b467f09c54df3669add4f86b0103800ee373531601f3e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/o/openldap/libldap2_2.6.7+dfsg-1~exp1ubuntu8.2_arm64.deb"
+			],
+			"version": "2.6.7+dfsg-1~exp1ubuntu8.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsasl2-2_2.1.28-p-dfsg1-5ubuntu3.1_arm64",
+			"name": "libsasl2-2",
+			"sha256": "05da24adf2b95285ce7eaf9a2ea902fbf4f756a796c8adbfd221d746035df44b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-5ubuntu3.1_arm64.deb"
+			],
+			"version": "2.1.28+dfsg1-5ubuntu3.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsasl2-modules-db_2.1.28-p-dfsg1-5ubuntu3.1_arm64",
+			"name": "libsasl2-modules-db",
+			"sha256": "ee8237dfd0d26df4d5fbfd3a9b132ae9f34f05b4508176b8bd1839f12739d94c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-5ubuntu3.1_arm64.deb"
+			],
+			"version": "2.1.28+dfsg1-5ubuntu3.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbrotli1_1.1.0-2build2_arm64",
+			"name": "libbrotli1",
+			"sha256": "cabf3462d908e72f2e594f19ae87c581c4614f099947e38fbd865bf8eae27014",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/brotli/libbrotli1_1.1.0-2build2_arm64.deb"
+			],
+			"version": "1.1.0-2build2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libpython3-stdlib_3.12.3-0ubuntu2_arm64",
+					"name": "libpython3-stdlib",
+					"version": "3.12.3-0ubuntu2"
+				},
+				{
+					"key": "libpython3.12-stdlib_3.12.3-1ubuntu0.5_arm64",
+					"name": "libpython3.12-stdlib",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_arm64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libsqlite3-0_3.45.1-1ubuntu2.1_arm64",
+					"name": "libsqlite3-0",
+					"version": "3.45.1-1ubuntu2.1"
+				},
+				{
+					"key": "libreadline8t64_8.2-4build1_arm64",
+					"name": "libreadline8t64",
+					"version": "8.2-4build1"
+				},
+				{
+					"key": "readline-common_8.2-4build1_arm64",
+					"name": "readline-common",
+					"version": "8.2-4build1"
+				},
+				{
+					"key": "libncursesw6_6.4-p-20240113-1ubuntu2_arm64",
+					"name": "libncursesw6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_arm64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_arm64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "tzdata_2025b-0ubuntu0.24.04_arm64",
+					"name": "tzdata",
+					"version": "2025b-0ubuntu0.24.04"
+				},
+				{
+					"key": "debconf_1.5.86ubuntu1_arm64",
+					"name": "debconf",
+					"version": "1.5.86ubuntu1"
+				},
+				{
+					"key": "netbase_6.4_arm64",
+					"name": "netbase",
+					"version": "6.4"
+				},
+				{
+					"key": "media-types_10.1.0_arm64",
+					"name": "media-types",
+					"version": "10.1.0"
+				},
+				{
+					"key": "libpython3.12-minimal_3.12.3-1ubuntu0.5_arm64",
+					"name": "libpython3.12-minimal",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "libssl3t64_3.0.13-0ubuntu3.5_arm64",
+					"name": "libssl3t64",
+					"version": "3.0.13-0ubuntu3.5"
+				},
+				{
+					"key": "python3.12_3.12.3-1ubuntu0.5_arm64",
+					"name": "python3.12",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "python3.12-minimal_3.12.3-1ubuntu0.5_arm64",
+					"name": "python3.12-minimal",
+					"version": "3.12.3-1ubuntu0.5"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libexpat1_2.6.1-2ubuntu0.3_arm64",
+					"name": "libexpat1",
+					"version": "2.6.1-2ubuntu0.3"
+				},
+				{
+					"key": "python3-minimal_3.12.3-0ubuntu2_arm64",
+					"name": "python3-minimal",
+					"version": "3.12.3-0ubuntu2"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_arm64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				}
+			],
+			"key": "python3_3.12.3-0ubuntu2_arm64",
+			"name": "python3",
+			"sha256": "e6e6247777af403cc68a60196f283e6125f798703eb16e2dbc6d2c91fa1586f9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3-defaults/python3_3.12.3-0ubuntu2_arm64.deb"
+			],
+			"version": "3.12.3-0ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpython3-stdlib_3.12.3-0ubuntu2_arm64",
+			"name": "libpython3-stdlib",
+			"sha256": "17612e887f09b3b8a978c436bf4b5826aa5c78b27f4d22a411a97f33096dc815",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3-defaults/libpython3-stdlib_3.12.3-0ubuntu2_arm64.deb"
+			],
+			"version": "3.12.3-0ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpython3.12-stdlib_3.12.3-1ubuntu0.5_arm64",
+			"name": "libpython3.12-stdlib",
+			"sha256": "697d62a0e2f378a473dc3cdc13869d4823def6c13b098e179c4b7db09bb3e711",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/libpython3.12-stdlib_3.12.3-1ubuntu0.5_arm64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsqlite3-0_3.45.1-1ubuntu2.1_arm64",
+			"name": "libsqlite3-0",
+			"sha256": "6be9718469d3af32ad3735dae3337f2778fd432559537248783dfeedd3c0af3d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/s/sqlite3/libsqlite3-0_3.45.1-1ubuntu2.1_arm64.deb"
+			],
+			"version": "3.45.1-1ubuntu2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libreadline8t64_8.2-4build1_arm64",
+			"name": "libreadline8t64",
+			"sha256": "7f46b2f3ca588cd2f05d2cfb6844017309760b4201105cdfda4b339f9e6c69da",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/readline/libreadline8t64_8.2-4build1_arm64.deb"
+			],
+			"version": "8.2-4build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "readline-common_8.2-4build1_arm64",
+			"name": "readline-common",
+			"sha256": "879bfd7f8a9bc4c0f7cdc777cdd8bc6de5f8c4a2ac80c060322a1b22f13504bb",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/readline/readline-common_8.2-4build1_all.deb"
+			],
+			"version": "8.2-4build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libncursesw6_6.4-p-20240113-1ubuntu2_arm64",
+			"name": "libncursesw6",
+			"sha256": "b301f776112fadae74852adb953e9b3f8ce5f896a4b927a916b402e51d8b08a9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/ncurses/libncursesw6_6.4+20240113-1ubuntu2_arm64.deb"
+			],
+			"version": "6.4+20240113-1ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "netbase_6.4_arm64",
+			"name": "netbase",
+			"sha256": "8cdbc9c3dca01e660759bf9d840f72e45ac72faf5d19ca1faecacaf6a60c1a87",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/n/netbase/netbase_6.4_all.deb"
+			],
+			"version": "6.4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "media-types_10.1.0_arm64",
+			"name": "media-types",
+			"sha256": "31bfb7eec55ab6d34a50ba995150e1498d4cb897714085d8025e330d3b529747",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/media-types/media-types_10.1.0_all.deb"
+			],
+			"version": "10.1.0"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpython3.12-minimal_3.12.3-1ubuntu0.5_arm64",
+			"name": "libpython3.12-minimal",
+			"sha256": "05690cc9a2b3047da2b6cea9783b972b04f40dc6418352be22ef364345db46da",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/libpython3.12-minimal_3.12.3-1ubuntu0.5_arm64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "python3.12_3.12.3-1ubuntu0.5_arm64",
+			"name": "python3.12",
+			"sha256": "c564ac97d8ee2e7b3851ce53fa4973ed3e9d279c3e2fd7d7da44875ed26851f4",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/python3.12_3.12.3-1ubuntu0.5_arm64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "python3.12-minimal_3.12.3-1ubuntu0.5_arm64",
+			"name": "python3.12-minimal",
+			"sha256": "eb4fc955d633625515173dc8becb9761f20efe56bc80f9a5b0eb3ecc8a601b57",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3.12/python3.12-minimal_3.12.3-1ubuntu0.5_arm64.deb"
+			],
+			"version": "3.12.3-1ubuntu0.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "python3-minimal_3.12.3-0ubuntu2_arm64",
+			"name": "python3-minimal",
+			"sha256": "045801bf04ca2699d7e29b7ae1a2ef1552474c216685220d147949391beba30c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/python3-defaults/python3-minimal_3.12.3-0ubuntu2_arm64.deb"
+			],
+			"version": "3.12.3-0ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "dpkg-dev_1.22.6ubuntu6.1_arm64",
+					"name": "dpkg-dev",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "lto-disabled-list_47_arm64",
+					"name": "lto-disabled-list",
+					"version": "47"
+				},
+				{
+					"key": "binutils_2.42-4ubuntu2.5_arm64",
+					"name": "binutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-aarch64-linux-gnu_2.42-4ubuntu2.5_arm64",
+					"name": "binutils-aarch64-linux-gnu",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libstdc++6",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libsframe1_2.42-4ubuntu2.5_arm64",
+					"name": "libsframe1",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libjansson4_2.14-2build2_arm64",
+					"name": "libjansson4",
+					"version": "2.14-2build2"
+				},
+				{
+					"key": "libgprofng0_2.42-4ubuntu2.5_arm64",
+					"name": "libgprofng0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libbinutils_2.42-4ubuntu2.5_arm64",
+					"name": "libbinutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-common_2.42-4ubuntu2.5_arm64",
+					"name": "binutils-common",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf0_2.42-4ubuntu2.5_arm64",
+					"name": "libctf0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf-nobfd0_2.42-4ubuntu2.5_arm64",
+					"name": "libctf-nobfd0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "make_4.3-4.1build2_arm64",
+					"name": "make",
+					"version": "4.3-4.1build2"
+				},
+				{
+					"key": "patch_2.7.6-7build3_arm64",
+					"name": "patch",
+					"version": "2.7.6-7build3"
+				},
+				{
+					"key": "xz-utils_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "xz-utils",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "bzip2_1.0.8-5.1build0.1_arm64",
+					"name": "bzip2",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5.1build0.1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5.1build0.1"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3build1_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3build1"
+				},
+				{
+					"key": "libselinux1_3.5-2ubuntu2.1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2ubuntu2.1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu2.1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu2.1"
+				},
+				{
+					"key": "libacl1_2.3.2-1build1.1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1build1.1"
+				},
+				{
+					"key": "libdpkg-perl_1.22.6ubuntu6.1_arm64",
+					"name": "libdpkg-perl",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "dpkg_1.22.6ubuntu6.1_arm64",
+					"name": "dpkg",
+					"version": "1.22.6ubuntu6.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "perl_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "libperl5.38t64_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "libperl5.38t64",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "perl-base_5.38.2-3.2ubuntu0.1_arm64",
+					"name": "perl-base",
+					"version": "5.38.2-3.2ubuntu0.1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libgdbm6t64_1.23-5.1build1_arm64",
+					"name": "libgdbm6t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libgdbm-compat4t64_1.23-5.1build1_arm64",
+					"name": "libgdbm-compat4t64",
+					"version": "1.23-5.1build1"
+				},
+				{
+					"key": "libdb5.3t64_5.3.28-p-dfsg2-7_arm64",
+					"name": "libdb5.3t64",
+					"version": "5.3.28+dfsg2-7"
+				},
+				{
+					"key": "g-p--p-_4-13.2.0-7ubuntu1_arm64",
+					"name": "g++",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "gcc-13_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "gcc-13",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "cpp-13_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "cpp-13",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "cpp-13-aarch64-linux-gnu_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "cpp-13-aarch64-linux-gnu",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libmpfr6_4.2.1-1build1.1_arm64",
+					"name": "libmpfr6",
+					"version": "4.2.1-1build1.1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu6.1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu6.1"
+				},
+				{
+					"key": "libmpc3_1.3.1-1build1.1_arm64",
+					"name": "libmpc3",
+					"version": "1.3.1-1build1.1"
+				},
+				{
+					"key": "libisl23_0.26-3build1.1_arm64",
+					"name": "libisl23",
+					"version": "0.26-3build1.1"
+				},
+				{
+					"key": "gcc-13-base_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "gcc-13-base",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-13-aarch64-linux-gnu_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "gcc-13-aarch64-linux-gnu",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "libgcc-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libhwasan0_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libhwasan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libubsan1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libubsan1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libtsan2_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libtsan2",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "liblsan0_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "liblsan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libasan8_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libasan8",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libatomic1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libatomic1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libitm1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libitm1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libgomp1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgomp1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libcc1-0_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libcc1-0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "g-p--p--aarch64-linux-gnu_4-13.2.0-7ubuntu1_arm64",
+					"name": "g++-aarch64-linux-gnu",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "g-p--p--13-aarch64-linux-gnu_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "g++-13-aarch64-linux-gnu",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libstdc-p--p--13-dev_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "libstdc++-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libc6-dev_2.39-0ubuntu8.4_arm64",
+					"name": "libc6-dev",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "rpcsvc-proto_1.4.2-0ubuntu7_arm64",
+					"name": "rpcsvc-proto",
+					"version": "1.4.2-0ubuntu7"
+				},
+				{
+					"key": "libcrypt-dev_1-4.4.36-4build1_arm64",
+					"name": "libcrypt-dev",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "linux-libc-dev_6.8.0-58.60_arm64",
+					"name": "linux-libc-dev",
+					"version": "6.8.0-58.60"
+				},
+				{
+					"key": "libc-dev-bin_2.39-0ubuntu8.4_arm64",
+					"name": "libc-dev-bin",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "gcc-aarch64-linux-gnu_4-13.2.0-7ubuntu1_arm64",
+					"name": "gcc-aarch64-linux-gnu",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "cpp-aarch64-linux-gnu_4-13.2.0-7ubuntu1_arm64",
+					"name": "cpp-aarch64-linux-gnu",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "g-p--p--13_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "g++-13",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "gcc_4-13.2.0-7ubuntu1_arm64",
+					"name": "gcc",
+					"version": "4:13.2.0-7ubuntu1"
+				},
+				{
+					"key": "cpp_4-13.2.0-7ubuntu1_arm64",
+					"name": "cpp",
+					"version": "4:13.2.0-7ubuntu1"
+				}
+			],
+			"key": "build-essential_12.10ubuntu1_arm64",
+			"name": "build-essential",
+			"sha256": "6242b151676903160a5eeaffcddaba3d1c77b1d94d60dfad28c2d8c505cd9dee",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/build-essential/build-essential_12.10ubuntu1_arm64.deb"
+			],
+			"version": "12.10ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "dpkg-dev_1.22.6ubuntu6.1_arm64",
+			"name": "dpkg-dev",
+			"sha256": "c70989835ab42d3d7a4dc1f8bb8c5ed9a88fd8c6b024bb4c45e5901bb6cc2f19",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dpkg/dpkg-dev_1.22.6ubuntu6.1_all.deb"
+			],
+			"version": "1.22.6ubuntu6.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "lto-disabled-list_47_arm64",
+			"name": "lto-disabled-list",
+			"sha256": "cac0f63c88188f376bb4df10a2af2b49a607bbef97a57db50ed58f678c21eee9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/l/lto-disabled-list/lto-disabled-list_47_all.deb"
+			],
+			"version": "47"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "binutils_2.42-4ubuntu2.5_arm64",
+			"name": "binutils",
+			"sha256": "267ac3e38eed0c9ba20e36f4bd6a190076c37cc4908b0aa7a8d4864ba080f1c6",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/binutils_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "binutils-aarch64-linux-gnu_2.42-4ubuntu2.5_arm64",
+			"name": "binutils-aarch64-linux-gnu",
+			"sha256": "d091a2246dfca39eff5f1e3fc51050f709ba049ca569675569045077c7e275a8",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsframe1_2.42-4ubuntu2.5_arm64",
+			"name": "libsframe1",
+			"sha256": "25fd350e61b148a2ae170b274a70fb632661983f9afd77a26e408bd367757add",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libsframe1_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libjansson4_2.14-2build2_arm64",
+			"name": "libjansson4",
+			"sha256": "a9d513eae76f4efb1c7370413bd21634fcfc0955e103d26af95f298af6c90abd",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/j/jansson/libjansson4_2.14-2build2_arm64.deb"
+			],
+			"version": "2.14-2build2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgprofng0_2.42-4ubuntu2.5_arm64",
+			"name": "libgprofng0",
+			"sha256": "cd56f9225cf02c5566c23d94d25ad6133817e4cb21cb916d50e10fb30a328eae",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libgprofng0_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbinutils_2.42-4ubuntu2.5_arm64",
+			"name": "libbinutils",
+			"sha256": "5a624fbb64fc4ea9b9044178fb748bbe0fb20e16b8cc6e6144495aa3f7802e9c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libbinutils_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "binutils-common_2.42-4ubuntu2.5_arm64",
+			"name": "binutils-common",
+			"sha256": "a38640d61118d7c1d3fb9c97c83754378ebc893360e0a71e3f25979568c11d36",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/binutils-common_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libctf0_2.42-4ubuntu2.5_arm64",
+			"name": "libctf0",
+			"sha256": "bd92b7a844ba727b3030ce0c292acf0de6048b23e4d46c4ef4c578990a51edeb",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libctf0_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libctf-nobfd0_2.42-4ubuntu2.5_arm64",
+			"name": "libctf-nobfd0",
+			"sha256": "71b47c57f97f47321377ff1697d6281d56aace183b136a8ddce93c6d32612753",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/binutils/libctf-nobfd0_2.42-4ubuntu2.5_arm64.deb"
+			],
+			"version": "2.42-4ubuntu2.5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "make_4.3-4.1build2_arm64",
+			"name": "make",
+			"sha256": "3bbbf5d426bc68fc232fc4e20f135aaf3eb76a514839acf82eeffa0dce9c81d4",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/make-dfsg/make_4.3-4.1build2_arm64.deb"
+			],
+			"version": "4.3-4.1build2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "patch_2.7.6-7build3_arm64",
+			"name": "patch",
+			"sha256": "29c96f8e8cd1f6470c7a13cfd76d4127a977d849f83d616648369fd87c0a6907",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/p/patch/patch_2.7.6-7build3_arm64.deb"
+			],
+			"version": "2.7.6-7build3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "xz-utils_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+			"name": "xz-utils",
+			"sha256": "0917c83f4c7e826c5bdb9fac5bfc3aff7cd2247140d6dd89843928b4ef58a6ec",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/x/xz-utils/xz-utils_5.6.1+really5.4.5-1ubuntu0.2_arm64.deb"
+			],
+			"version": "5.6.1+really5.4.5-1ubuntu0.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "bzip2_1.0.8-5.1build0.1_arm64",
+			"name": "bzip2",
+			"sha256": "37ab1c20b5624dd80efff3cec2aea60a5d30109231d69caaa47ba17d0fbe8efe",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/b/bzip2/bzip2_1.0.8-5.1build0.1_arm64.deb"
+			],
+			"version": "1.0.8-5.1build0.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdpkg-perl_1.22.6ubuntu6.1_arm64",
+			"name": "libdpkg-perl",
+			"sha256": "efe6ca6a0fce8bf293d71d925c506f95eaf7ca37642ebe68b8b173bb1072ef2a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/d/dpkg/libdpkg-perl_1.22.6ubuntu6.1_all.deb"
+			],
+			"version": "1.22.6ubuntu6.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "g-p--p-_4-13.2.0-7ubuntu1_arm64",
+			"name": "g++",
+			"sha256": "1c0786b509b97ebce60d6c98de64c7f8a9ed0e68ccdbc908a3feb6045123b89c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/g++_13.2.0-7ubuntu1_arm64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-13_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "gcc-13",
+			"sha256": "36058ba86bae0edab31269163b4c7b0a530b927babfebc9e7c3684e833fcff35",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/gcc-13_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "cpp-13_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "cpp-13",
+			"sha256": "4e45c98b35eefe9796dd2851ed8b66e7c25dc5e19d3b8a4299c3a1ca15f210a9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/cpp-13_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "cpp-13-aarch64-linux-gnu_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "cpp-13-aarch64-linux-gnu",
+			"sha256": "a2693f46fe831037741075209479f579b679ec5415f17113aae9afd835eccbec",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/cpp-13-aarch64-linux-gnu_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libmpfr6_4.2.1-1build1.1_arm64",
+			"name": "libmpfr6",
+			"sha256": "83517e4377082a35dcce66ec5310881a848486279f64d737919d1819b7884201",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/mpfr4/libmpfr6_4.2.1-1build1.1_arm64.deb"
+			],
+			"version": "4.2.1-1build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libmpc3_1.3.1-1build1.1_arm64",
+			"name": "libmpc3",
+			"sha256": "efc4a44fb7382db33bf3adbfd0058201fd73d0e56fd48662d653e9a93f6139da",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/m/mpclib3/libmpc3_1.3.1-1build1.1_arm64.deb"
+			],
+			"version": "1.3.1-1build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libisl23_0.26-3build1.1_arm64",
+			"name": "libisl23",
+			"sha256": "250bff60f1405c2fa7cd8cdd839f83105c7fec9b42ed6cb5f62e1bcda709bbc2",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/i/isl/libisl23_0.26-3build1.1_arm64.deb"
+			],
+			"version": "0.26-3build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-13-base_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "gcc-13-base",
+			"sha256": "11f51962932841ead9a446d4f812e2b3d4736550561dc6923d2140f9bcf51e67",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/gcc-13-base_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-13-aarch64-linux-gnu_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "gcc-13-aarch64-linux-gnu",
+			"sha256": "b03c39507acffb558f0a76658f1397fbc9419fe98c96e2c5860238a437476e6b",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/gcc-13-aarch64-linux-gnu_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "libgcc-13-dev",
+			"sha256": "176ce9cf6ef8b3dce7237f82fe0b268bf4c9c91d21a27d5d1acd911590d0d8ab",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/libgcc-13-dev_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libhwasan0_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libhwasan0",
+			"sha256": "4c853ff4eca50878f0f7b7b7d3a56c0fad6efdeafa7c655ee7f3ad52bff95ea8",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libhwasan0_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libubsan1_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libubsan1",
+			"sha256": "7858335bbb9e5c012f6989c6d46a0d4a5cd9f1461ca018f948a4525ac21f043a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libubsan1_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtsan2_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libtsan2",
+			"sha256": "12ae63a7b05a1387e1fe666cef2242283593264fa3bc02bd6d3a89be2e9ec5ad",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libtsan2_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblsan0_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "liblsan0",
+			"sha256": "76574563e56670a8748a5e32ce315bbdb68b294fbd74668431dbae46bf95754f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/liblsan0_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libasan8_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libasan8",
+			"sha256": "9f3497ec8053ee003ca71be21b0750f50ed67db91def414388e84ece6dd837bd",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libasan8_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libatomic1_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libatomic1",
+			"sha256": "b98a1246be116164f66dd0e9e032c50221cf465963bb2eabf254a593cbf803a4",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libatomic1_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libitm1_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libitm1",
+			"sha256": "075079caee7ae8c7bfdad596f0117c89366149aa067869b503de383d43e03c30",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libitm1_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgomp1_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libgomp1",
+			"sha256": "34d68752ee60a416827bcdcbc4d9f5a845017d53c4cf5a8e5c3867d03acc0e1a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libgomp1_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcc1-0_14.2.0-4ubuntu2_24.04_arm64",
+			"name": "libcc1-0",
+			"sha256": "88a6600ed664c18be4829c212a5f2092ee821bca26606a4cfe3e03a8d5bc74e2",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-14/libcc1-0_14.2.0-4ubuntu2~24.04_arm64.deb"
+			],
+			"version": "14.2.0-4ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "g-p--p--aarch64-linux-gnu_4-13.2.0-7ubuntu1_arm64",
+			"name": "g++-aarch64-linux-gnu",
+			"sha256": "5920bf2675f86e65338fdc9f7753f7891e07a74616c01c437ba2a7c086c7e42a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/g++-aarch64-linux-gnu_13.2.0-7ubuntu1_arm64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "g-p--p--13-aarch64-linux-gnu_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "g++-13-aarch64-linux-gnu",
+			"sha256": "91c20ba9b8a0d04dc98d3de9dbf3d0cf5b3e0352443c60c5ff40af90c82c6a7e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/g++-13-aarch64-linux-gnu_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libstdc-p--p--13-dev_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "libstdc++-13-dev",
+			"sha256": "cd63d0a4763aa9cfeac01ec317edb92ef235bb1675f9c33dcc2831bef6c79c43",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/libstdc++-13-dev_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6-dev_2.39-0ubuntu8.4_arm64",
+			"name": "libc6-dev",
+			"sha256": "2982a75c82265eeb6022759505009deb8b9dc4cbe54d9c51d669b66955aae135",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/glibc/libc6-dev_2.39-0ubuntu8.4_arm64.deb"
+			],
+			"version": "2.39-0ubuntu8.4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "rpcsvc-proto_1.4.2-0ubuntu7_arm64",
+			"name": "rpcsvc-proto",
+			"sha256": "ae527152fc2bf9c1a645c2620d802b0849db32c8aa48328b4ae94c59cc57bcc9",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-0ubuntu7_arm64.deb"
+			],
+			"version": "1.4.2-0ubuntu7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcrypt-dev_1-4.4.36-4build1_arm64",
+			"name": "libcrypt-dev",
+			"sha256": "cadcc00021aa1082a8cb5cd1c2686b25b7a4d396f2029eaa1b12159ca46f1766",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-4build1_arm64.deb"
+			],
+			"version": "1:4.4.36-4build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "linux-libc-dev_6.8.0-58.60_arm64",
+			"name": "linux-libc-dev",
+			"sha256": "6209dae287c2f4026e2e9eb1a943d4526e77c5093aba5e529a217dbdf27ce21c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/l/linux/linux-libc-dev_6.8.0-58.60_arm64.deb"
+			],
+			"version": "6.8.0-58.60"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc-dev-bin_2.39-0ubuntu8.4_arm64",
+			"name": "libc-dev-bin",
+			"sha256": "a8393ce8381627962f43d76f7e71318b25117f42b496c6c67249677da3394102",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/glibc/libc-dev-bin_2.39-0ubuntu8.4_arm64.deb"
+			],
+			"version": "2.39-0ubuntu8.4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-aarch64-linux-gnu_4-13.2.0-7ubuntu1_arm64",
+			"name": "gcc-aarch64-linux-gnu",
+			"sha256": "14bd5f429f7e91c23fcae70ddc1acf1438adfe246fa3078273f5a0629f64e2dc",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/gcc-aarch64-linux-gnu_13.2.0-7ubuntu1_arm64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "cpp-aarch64-linux-gnu_4-13.2.0-7ubuntu1_arm64",
+			"name": "cpp-aarch64-linux-gnu",
+			"sha256": "52822e3b33c0ccf29b86c6366683ebf61549973b02eda0643437a1fe8a099b9a",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/cpp-aarch64-linux-gnu_13.2.0-7ubuntu1_arm64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "g-p--p--13_13.3.0-6ubuntu2_24.04_arm64",
+			"name": "g++-13",
+			"sha256": "b9b67dcbe08e9098790cc8ad91d234eadf3f5c49b95df289f5881794cc3aa2ea",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-13/g++-13_13.3.0-6ubuntu2~24.04_arm64.deb"
+			],
+			"version": "13.3.0-6ubuntu2~24.04"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc_4-13.2.0-7ubuntu1_arm64",
+			"name": "gcc",
+			"sha256": "11dec7614bba0bd5b7cfad6a9890a4680dac5de6908ae625dd07105679bad67c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/gcc_13.2.0-7ubuntu1_arm64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "cpp_4-13.2.0-7ubuntu1_arm64",
+			"name": "cpp",
+			"sha256": "133d40380f18509cf137347f7c470d87ccaf75fd1fa488c3b42b7d6ca3c09d30",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/cpp_13.2.0-7ubuntu1_arm64.deb"
+			],
+			"version": "4:13.2.0-7ubuntu1"
+		}
+	],
+	"version": 1
+}

--- a/images/ubuntu_24_04_packages.lock.json
+++ b/images/ubuntu_24_04_packages.lock.json
@@ -3018,6 +3018,347 @@
 			"version": "4:13.2.0-7ubuntu1"
 		},
 		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "binutils_2.42-4ubuntu2.5_amd64",
+					"name": "binutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-x86-64-linux-gnu_2.42-4ubuntu2.5_amd64",
+					"name": "binutils-x86-64-linux-gnu",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libstdc++6",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libsframe1_2.42-4ubuntu2.5_amd64",
+					"name": "libsframe1",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libjansson4_2.14-2build2_amd64",
+					"name": "libjansson4",
+					"version": "2.14-2build2"
+				},
+				{
+					"key": "libgprofng0_2.42-4ubuntu2.5_amd64",
+					"name": "libgprofng0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libbinutils_2.42-4ubuntu2.5_amd64",
+					"name": "libbinutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-common_2.42-4ubuntu2.5_amd64",
+					"name": "binutils-common",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf0_2.42-4ubuntu2.5_amd64",
+					"name": "libctf0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf-nobfd0_2.42-4ubuntu2.5_amd64",
+					"name": "libctf-nobfd0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libc6-dev_2.39-0ubuntu8.4_amd64",
+					"name": "libc6-dev",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "rpcsvc-proto_1.4.2-0ubuntu7_amd64",
+					"name": "rpcsvc-proto",
+					"version": "1.4.2-0ubuntu7"
+				},
+				{
+					"key": "libcrypt-dev_1-4.4.36-4build1_amd64",
+					"name": "libcrypt-dev",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "linux-libc-dev_6.8.0-58.60_amd64",
+					"name": "linux-libc-dev",
+					"version": "6.8.0-58.60"
+				},
+				{
+					"key": "libc-dev-bin_2.39-0ubuntu8.4_amd64",
+					"name": "libc-dev-bin",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libclang1-18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+					"name": "libclang1-18",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libllvm18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+					"name": "libllvm18",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3.2_amd64",
+					"name": "libxml2",
+					"version": "2.9.14+dfsg-1.3ubuntu3.2"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_amd64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libicu74_74.2-1ubuntu3.1_amd64",
+					"name": "libicu74",
+					"version": "74.2-1ubuntu3.1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_amd64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libedit2_3.1-20230828-1build1_amd64",
+					"name": "libedit2",
+					"version": "3.1-20230828-1build1"
+				},
+				{
+					"key": "libbsd0_0.12.1-1build1.1_amd64",
+					"name": "libbsd0",
+					"version": "0.12.1-1build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "llvm-18-linker-tools_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+					"name": "llvm-18-linker-tools",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libclang-common-18-dev_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+					"name": "libclang-common-18-dev",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "libgcc-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libquadmath0_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libquadmath0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libhwasan0_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libhwasan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libubsan1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libubsan1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libtsan2_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libtsan2",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "liblsan0_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "liblsan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libasan8_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libasan8",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libatomic1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libatomic1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libitm1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libitm1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libgomp1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgomp1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-13-base_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "gcc-13-base",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libstdc-p--p--13-dev_13.3.0-6ubuntu2_24.04_amd64",
+					"name": "libstdc++-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libclang-cpp18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+					"name": "libclang-cpp18",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				}
+			],
+			"key": "clang-18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+			"name": "clang-18",
+			"sha256": "6b23c30bd68a86e9485cafd0806d3aa46a812089fba74d8283befa611825b42b",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/clang-18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_amd64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libclang1-18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+			"name": "libclang1-18",
+			"sha256": "208abb2defadc4bf204ffc4cd74da0419aa66ae00763ba6e4a7aae48a5bbfb46",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libclang1-18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_amd64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libllvm18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+			"name": "libllvm18",
+			"sha256": "4c2ccb3bdca15e5741f57bb025a05d79cdd57becfd5e23633ce82f120007cece",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libllvm18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_amd64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3.2_amd64",
+			"name": "libxml2",
+			"sha256": "8ab0a98cf88c847e2314bdd7dd1673db4d27d3c48787fc652c143207843e325c",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3ubuntu3.2_amd64.deb"
+			],
+			"version": "2.9.14+dfsg-1.3ubuntu3.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libicu74_74.2-1ubuntu3.1_amd64",
+			"name": "libicu74",
+			"sha256": "c9a70989678660eed9a1e904c74fa043da8bec8e2036856fc16e31ced79b04f8",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/i/icu/libicu74_74.2-1ubuntu3.1_amd64.deb"
+			],
+			"version": "74.2-1ubuntu3.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libedit2_3.1-20230828-1build1_amd64",
+			"name": "libedit2",
+			"sha256": "3afbc8ddf835049dd4d88275b9d13680e4c4cdd59e191cbd63424152cc08e00e",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libe/libedit/libedit2_3.1-20230828-1build1_amd64.deb"
+			],
+			"version": "3.1-20230828-1build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbsd0_0.12.1-1build1.1_amd64",
+			"name": "libbsd0",
+			"sha256": "f3857b0863ac5cfd4263e9bf6cfb1d4be88d5321e4070d5bc2b62b0949e6c86f",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libb/libbsd/libbsd0_0.12.1-1build1.1_amd64.deb"
+			],
+			"version": "0.12.1-1build1.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "llvm-18-linker-tools_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+			"name": "llvm-18-linker-tools",
+			"sha256": "cdef719cb8d8c37c1e85b8e230e022016c9b5a5df2e62b45b8a5f5a6f7c6c92b",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/llvm-18-linker-tools_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_amd64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libclang-common-18-dev_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+			"name": "libclang-common-18-dev",
+			"sha256": "c8775e56339bcbf050994ed97ab4cc442350d3583a86cb29de4a06aec7576dde",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libclang-common-18-dev_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_amd64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libclang-cpp18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_amd64",
+			"name": "libclang-cpp18",
+			"sha256": "6abcc0f657b09434acfa561afb73791323f326782a0ea513f9747ef49440941d",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libclang-cpp18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_amd64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
 			"arch": "arm64",
 			"dependencies": [],
 			"key": "ncurses-base_6.4-p-20240113-1ubuntu2_arm64",
@@ -6017,6 +6358,342 @@
 				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/g/gcc-defaults/cpp_13.2.0-7ubuntu1_arm64.deb"
 			],
 			"version": "4:13.2.0-7ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "binutils_2.42-4ubuntu2.5_arm64",
+					"name": "binutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-aarch64-linux-gnu_2.42-4ubuntu2.5_arm64",
+					"name": "binutils-aarch64-linux-gnu",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3.1ubuntu2.1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3.1ubuntu2.1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2build1.1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2build1.1"
+				},
+				{
+					"key": "libstdc-p--p-6_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libstdc++6",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libsframe1_2.42-4ubuntu2.5_arm64",
+					"name": "libsframe1",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libjansson4_2.14-2build2_arm64",
+					"name": "libjansson4",
+					"version": "2.14-2build2"
+				},
+				{
+					"key": "libgprofng0_2.42-4ubuntu2.5_arm64",
+					"name": "libgprofng0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libbinutils_2.42-4ubuntu2.5_arm64",
+					"name": "libbinutils",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "binutils-common_2.42-4ubuntu2.5_arm64",
+					"name": "binutils-common",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf0_2.42-4ubuntu2.5_arm64",
+					"name": "libctf0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libctf-nobfd0_2.42-4ubuntu2.5_arm64",
+					"name": "libctf-nobfd0",
+					"version": "2.42-4ubuntu2.5"
+				},
+				{
+					"key": "libc6-dev_2.39-0ubuntu8.4_arm64",
+					"name": "libc6-dev",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "rpcsvc-proto_1.4.2-0ubuntu7_arm64",
+					"name": "rpcsvc-proto",
+					"version": "1.4.2-0ubuntu7"
+				},
+				{
+					"key": "libcrypt-dev_1-4.4.36-4build1_arm64",
+					"name": "libcrypt-dev",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4build1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4build1"
+				},
+				{
+					"key": "linux-libc-dev_6.8.0-58.60_arm64",
+					"name": "linux-libc-dev",
+					"version": "6.8.0-58.60"
+				},
+				{
+					"key": "libc-dev-bin_2.39-0ubuntu8.4_arm64",
+					"name": "libc-dev-bin",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libclang1-18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+					"name": "libclang1-18",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libllvm18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+					"name": "libllvm18",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3.2_arm64",
+					"name": "libxml2",
+					"version": "2.9.14+dfsg-1.3ubuntu3.2"
+				},
+				{
+					"key": "liblzma5_5.6.1-p-really5.4.5-1ubuntu0.2_arm64",
+					"name": "liblzma5",
+					"version": "5.6.1+really5.4.5-1ubuntu0.2"
+				},
+				{
+					"key": "libicu74_74.2-1ubuntu3.1_arm64",
+					"name": "libicu74",
+					"version": "74.2-1ubuntu3.1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu2_arm64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu2"
+				},
+				{
+					"key": "libffi8_3.4.6-1build1_arm64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libedit2_3.1-20230828-1build1_arm64",
+					"name": "libedit2",
+					"version": "3.1-20230828-1build1"
+				},
+				{
+					"key": "libbsd0_0.12.1-1build1.1_arm64",
+					"name": "libbsd0",
+					"version": "0.12.1-1build1.1"
+				},
+				{
+					"key": "libmd0_1.1.0-2build1.1_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2build1.1"
+				},
+				{
+					"key": "llvm-18-linker-tools_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+					"name": "llvm-18-linker-tools",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libclang-common-18-dev_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+					"name": "libclang-common-18-dev",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				},
+				{
+					"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "libgcc-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libhwasan0_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libhwasan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libubsan1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libubsan1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libtsan2_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libtsan2",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "liblsan0_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "liblsan0",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libasan8_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libasan8",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libatomic1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libatomic1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libitm1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libitm1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "libgomp1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgomp1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-13-base_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "gcc-13-base",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libstdc-p--p--13-dev_13.3.0-6ubuntu2_24.04_arm64",
+					"name": "libstdc++-13-dev",
+					"version": "13.3.0-6ubuntu2~24.04"
+				},
+				{
+					"key": "libclang-cpp18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+					"name": "libclang-cpp18",
+					"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+				}
+			],
+			"key": "clang-18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+			"name": "clang-18",
+			"sha256": "3e1f265aecb03881ebb61357fdd98ada5ef6089aceab3190c74636d717db00e2",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/clang-18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_arm64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libclang1-18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+			"name": "libclang1-18",
+			"sha256": "c040a1aab55e41bb6bd36ce328c5b43ff869144d69ec28aaf25432962681f0c0",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libclang1-18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_arm64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libllvm18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+			"name": "libllvm18",
+			"sha256": "9f8f783f5591cb4e7e1b85cc20506c4cc30149a1a3031354f48d79a2dd7b2e08",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libllvm18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_arm64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3.2_arm64",
+			"name": "libxml2",
+			"sha256": "2c6a75b968f3ede9b403fc4adfe74100dace20c030abed7d78a8dbb50a8b39d4",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3ubuntu3.2_arm64.deb"
+			],
+			"version": "2.9.14+dfsg-1.3ubuntu3.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libicu74_74.2-1ubuntu3.1_arm64",
+			"name": "libicu74",
+			"sha256": "48f93acf50dcf237a8d58ce366730a28438ce52d3f06d7a2a88b51261dd791f7",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/i/icu/libicu74_74.2-1ubuntu3.1_arm64.deb"
+			],
+			"version": "74.2-1ubuntu3.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libedit2_3.1-20230828-1build1_arm64",
+			"name": "libedit2",
+			"sha256": "cf642fec16d86517e0e715520c3a7cdaee650e7ae8a4993f82d0e1e7a5883efb",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libe/libedit/libedit2_3.1-20230828-1build1_arm64.deb"
+			],
+			"version": "3.1-20230828-1build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbsd0_0.12.1-1build1.1_arm64",
+			"name": "libbsd0",
+			"sha256": "cdf9ff601244e64482584d9d9b98aa54a573c081ab5956227c737307196c1ce3",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libb/libbsd/libbsd0_0.12.1-1build1.1_arm64.deb"
+			],
+			"version": "0.12.1-1build1.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "llvm-18-linker-tools_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+			"name": "llvm-18-linker-tools",
+			"sha256": "b15846d3b12b0daccd3db11abf3b85d8b8f810cb9a6e374a464f985d379ef270",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/llvm-18-linker-tools_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_arm64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libclang-common-18-dev_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+			"name": "libclang-common-18-dev",
+			"sha256": "303b8e2be66a41df391b377a2fa27ad959dd1a3b6992bc2874a194f5bcfa1b1b",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libclang-common-18-dev_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_arm64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libclang-cpp18_1-18.1.8_-p--p-20240731025043-p-3b5b5c1ec4a3-1_exp1_20240731145144.92_arm64",
+			"name": "libclang-cpp18",
+			"sha256": "f815b62ad52c06d7e965ad5c12b7aa56c7614731404d22926cab29af16afe848",
+			"urls": [
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-18/libclang-cpp18_18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92_arm64.deb"
+			],
+			"version": "1:18.1.8~++20240731025043+3b5b5c1ec4a3-1~exp1~20240731145144.92"
 		}
 	],
 	"version": 1

--- a/images/ubuntu_24_04_packages.yaml
+++ b/images/ubuntu_24_04_packages.yaml
@@ -41,3 +41,4 @@ packages:
   - "git" # release controller and commit annotator
   - "python3" # release controller and commit annotator
   - "build-essential" # commit annotator (Bazel / Bazelisk)
+  - "clang" # partial IC build process run by target-determinator in commit annotator

--- a/images/ubuntu_24_04_packages.yaml
+++ b/images/ubuntu_24_04_packages.yaml
@@ -16,6 +16,8 @@ sources:
     url: https://snapshot.ubuntu.com/ubuntu/20250424T000000Z
   - channel: noble-updates main
     url: https://snapshot.ubuntu.com/ubuntu/20250424T000000Z
+  - channel: llvm-toolchain-noble-18 main
+    url: https://apt.llvm.org/noble/
 
 archs:
   - "amd64"
@@ -41,4 +43,4 @@ packages:
   - "git" # release controller and commit annotator
   - "python3" # release controller and commit annotator
   - "build-essential" # commit annotator (Bazel / Bazelisk)
-  - "clang" # partial IC build process run by target-determinator in commit annotator
+  - "clang-18" # partial IC build process run by target-determinator in commit annotator

--- a/images/ubuntu_24_04_packages.yaml
+++ b/images/ubuntu_24_04_packages.yaml
@@ -1,0 +1,43 @@
+# Packages for ubuntu_24_04_minimal.
+#
+#  Anytime this file is changed, the lockfile needs to be regenerated.
+#
+#  To generate the ubuntu_24_04_packages.lock.json run the following command
+#
+#     bazel run @ubuntu_24_04_packages//:lock
+#
+# See the section about ubuntu_24_04_minimal in /MODULE.bazel for info.
+version: 1
+
+sources:
+  - channel: noble main
+    url: https://snapshot.ubuntu.com/ubuntu/20250424T000000Z
+  - channel: noble-security main
+    url: https://snapshot.ubuntu.com/ubuntu/20250424T000000Z
+  - channel: noble-updates main
+    url: https://snapshot.ubuntu.com/ubuntu/20250424T000000Z
+
+archs:
+  - "amd64"
+  - "arm64"
+
+packages:
+  - "ncurses-base"
+  - "libncurses6"
+  - "tzdata"
+  - "dash"
+  - "bash"
+  - "coreutils" # for commands like `ls`
+  - "grep"
+  - "sed"
+  - "findutils"
+  # for apt list --installed
+  - "dpkg"
+  - "apt"
+  - "perl"
+  # Things needed for the container to work correctly.
+  - "ca-certificates"
+  # Things needed by our containers.
+  - "git" # release controller and commit annotator
+  - "python3" # release controller and commit annotator
+  - "build-essential" # commit annotator (Bazel / Bazelisk)

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -301,11 +301,33 @@ py_oci_image(
 # bazel run ...:oci_image_commit_annotator_load to load the
 # commit annotator container into Podman as an image, then
 # podman run -it --entrypoint=/bin/sh <sha256 printed>
+# Note that `podman run`
+# will require `--user $UID` or else Bazel will fail.
 py_oci_image(
     name = "oci_image_commit_annotator",
     base = "//images:ubuntu_24_04",
     binary = ":commit-annotator",
     tars = []
+)
+
+# bazel run ...:oci_image_release_notes_load loads a container
+# image with just the release notes code.  Like the targets above,
+# it is runnable via podman after loading.  This target does
+# not get published to the OCI repository.
+#
+# This target is useful to run the release notes process
+# from the container, to diagnose issues with specific commits
+# not being annotated properly (in conjunction with flag
+# `--commit-annotator-url=recreate`).  Note that `podman run`
+# will require `--user $UID` or else Bazel will fail.
+# See heading Generate release notes locally in file README.txt
+# on this folder for more details on local release notes generation.
+py_oci_image(
+    name = "oci_image_release_notes",
+    base = "//images:ubuntu_24_04",
+    binary = ":release-notes",
+    tars = [],
+    publish = False,
 )
 
 exports_files(["README.md"])

--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -293,7 +293,7 @@ small_tests_deps = ["forum", "publish_notes", "release_index_loader", "dryrun"] 
 # podman run -it --entrypoint=/bin/sh <sha256 printed>
 py_oci_image(
     name = "oci_image",
-    base = "@bazel_image_7_4_1",
+    base = "//images:ubuntu_24_04",
     binary = ":release-controller",
     tars = [],
 )
@@ -303,7 +303,7 @@ py_oci_image(
 # podman run -it --entrypoint=/bin/sh <sha256 printed>
 py_oci_image(
     name = "oci_image_commit_annotator",
-    base = "@bazel_image_7_4_1",
+    base = "//images:ubuntu_24_04",
     binary = ":commit-annotator",
     tars = []
 )

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -219,7 +219,17 @@ built and imported into your containerization system.  Run it as follows:
 
 ```sh
 SHASUM=...
-podman run -it --entrypoint=/release-controller/release-controller $SHASUM
+podman run --rm -it --entrypoint=/release-controller/release-controller $SHASUM
+```
+
+Or, in short:
+
+```sh
+mkdir -p -m 0777 /tmp/git
+podman run --rm -it \
+  -v /tmp/git:/root/.cache \
+  --entrypoint /release-controller/release-controller \
+  $(bazel run --verbose_failures //release-controller:oci_image_load | tail -1 | cut -d : -f 3)
 ```
 
 ### Running the annotator locally in "dry-run mode"
@@ -290,3 +300,10 @@ Building it all tests MyPy types:
 ```sh
 bazel build //release-controller/...
 ```
+
+### Maintenance
+
+The container image currently used by release controller components
+is an Ubuntu 24.04 image built by Bazel.  Refer to [BUILD.bazel](./BUILD.bazel)
+and [../images/BUILD.bazel](../images/BUILD.bazel) for instructions
+on how to maintain and update the images.

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -246,6 +246,10 @@ bazel run //release-controller:commit-annotator \
   --verbose
 ```
 
+The annotator can also be run as a podman container, with a similar
+technique as above.  However, the annotator requires `--user $UID`
+because Bazel will not run as root (UID 0).
+
 Please consult `--help` for additional options.
 
 ### Generate release notes locally

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -272,7 +272,7 @@ testing the effects of changes made to the commit annotator code or Bazel
 query formulas the annotator uses.
 
 A great tip / trick to diagnose exactly what the release notes and
-commit annotation processes are doing is to pick a commit from the IC
+commit annotation processes would do is to pick a commit from the IC
 repo, figure out which its parent commit is, then run:
 
 ```sh
@@ -282,10 +282,12 @@ CURR_RC=curr
 CURR_COMMIT=f8131bfbc2d339716a9cff06e04de49a68e5a80b # commit
 bazel run //release-controller:release-notes -- \
    $PREV_RC $PREV_COMMIT $CURR_RC $CURR_COMMIT \
+   --commit-annotator-url recreate \
   --os-kind=GuestOS \
   --verbose
 bazel run //release-controller:release-notes -- \
    $PREV_RC $PREV_COMMIT $CURR_RC $CURR_COMMIT \
+   --commit-annotator-url recreate \
   --os-kind=HostOS \
   --verbose
 ```

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -271,6 +271,28 @@ commit annotations instead of using cached ones, you can use option
 testing the effects of changes made to the commit annotator code or Bazel
 query formulas the annotator uses.
 
+A great tip / trick to diagnose exactly what the release notes and
+commit annotation processes are doing is to pick a commit from the IC
+repo, figure out which its parent commit is, then run:
+
+```sh
+PREV_RC=prev
+PREV_COMMIT=1354f31c9cd4fb6b4a65ab64eb9ac4a0a4d16839 # parent commit
+CURR_RC=curr
+CURR_COMMIT=f8131bfbc2d339716a9cff06e04de49a68e5a80b # commit
+bazel run //release-controller:release-notes -- \
+   $PREV_RC $PREV_COMMIT $CURR_RC $CURR_COMMIT \
+  --os-kind=GuestOS \
+  --verbose
+bazel run //release-controller:release-notes -- \
+   $PREV_RC $PREV_COMMIT $CURR_RC $CURR_COMMIT \
+  --os-kind=HostOS \
+  --verbose
+```
+
+That run tells you what the annotation process would do for that single
+commit in question.
+
 Please consult `--help` for additional options.
 
 ### Tests

--- a/release-controller/commit_annotation.py
+++ b/release-controller/commit_annotation.py
@@ -23,11 +23,8 @@ CHANGED_NOTES_NAMESPACES: dict[OsKind, str] = {
 }
 COMMIT_BELONGS: typing.Literal["True"] = "True"
 COMMIT_DOES_NOT_BELONG: typing.Literal["False"] = "False"
-COMMIT_COULD_NOT_BE_ANNOTATED: typing.Literal["Failed"] = "Failed"
 
-CommitInclusionState = (
-    typing.Literal["True"] | typing.Literal["False"] | typing.Literal["Failed"]
-)
+CommitInclusionState = typing.Literal["True"] | typing.Literal["False"]
 
 
 class NotReady(Exception):
@@ -193,7 +190,6 @@ class LocalCommitChangeDeterminator(object):
         assert changed in [
             COMMIT_BELONGS,
             COMMIT_DOES_NOT_BELONG,
-            COMMIT_COULD_NOT_BE_ANNOTATED,
         ], "Expected a specific CommitInclusionState, not %r" % changed
         return typing.cast(CommitInclusionState, changed)
 
@@ -228,6 +224,5 @@ class CommitAnnotatorClientCommitChangeDeterminator(object):
         assert changed in [
             COMMIT_BELONGS,
             COMMIT_DOES_NOT_BELONG,
-            COMMIT_COULD_NOT_BE_ANNOTATED,
         ], "Expected a specific CommitInclusionState, not %r" % changed
         return typing.cast(CommitInclusionState, changed)

--- a/release-controller/commit_annotation.py
+++ b/release-controller/commit_annotation.py
@@ -187,6 +187,14 @@ class LocalCommitChangeDeterminator(object):
             raise NotReady(
                 f"Could not find {os_kind} label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."
             )
+        if changed == "Failed":
+            # An artifact of prior commit annotators that recorded failure.
+            _LOGGER.warning(
+                "Change determinator received %s which is an invalid value."
+                "  Proceeding by assuming this commit changes the artifact.",
+                changed,
+            )
+            return COMMIT_BELONGS
         assert changed in [
             COMMIT_BELONGS,
             COMMIT_DOES_NOT_BELONG,
@@ -221,6 +229,14 @@ class CommitAnnotatorClientCommitChangeDeterminator(object):
                     f"Could not find {os_kind} label for commit {commit}. Check out commit annotator logs and runbook: https://dfinity.github.io/dre/release.html#missing-guestos-label."
                 ) from he
             raise
+        if changed == "Failed":
+            # An artifact of prior commit annotators that recorded failure.
+            _LOGGER.warning(
+                "Change determinator received %s which is an invalid value."
+                "  Proceeding by assuming this commit changes the artifact.",
+                changed,
+            )
+            return COMMIT_BELONGS
         assert changed in [
             COMMIT_BELONGS,
             COMMIT_DOES_NOT_BELONG,

--- a/release-controller/commit_annotation_recreator.py
+++ b/release-controller/commit_annotation_recreator.py
@@ -5,8 +5,6 @@ from commit_annotation import (
     GitRepoAnnotator,
     CHANGED_NOTES_NAMESPACES,
     CommitInclusionState,
-    COMMIT_BELONGS,
-    COMMIT_DOES_NOT_BELONG,
 )
 from const import OsKind
 from commit_annotator import compute_annotations_for_object

--- a/release-controller/commit_annotation_recreator.py
+++ b/release-controller/commit_annotation_recreator.py
@@ -1,3 +1,5 @@
+import logging
+
 from git_repo import GitRepo
 from commit_annotation import (
     GitRepoAnnotator,
@@ -8,6 +10,9 @@ from commit_annotation import (
 )
 from const import OsKind
 from commit_annotator import compute_annotations_for_object
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class RecreatingCommitChangeDeterminator(object):
@@ -38,8 +43,4 @@ class RecreatingCommitChangeDeterminator(object):
         """
 
         _, _, belongs = compute_annotations_for_object(self.annotator, commit, os_kind)
-        assert belongs in [
-            COMMIT_BELONGS,
-            COMMIT_DOES_NOT_BELONG,
-        ], "Expected a specific CommitInclusionState, not %r" % belongs
         return belongs

--- a/release-controller/commit_annotation_recreator.py
+++ b/release-controller/commit_annotation_recreator.py
@@ -5,7 +5,6 @@ from commit_annotation import (
     CommitInclusionState,
     COMMIT_BELONGS,
     COMMIT_DOES_NOT_BELONG,
-    COMMIT_COULD_NOT_BE_ANNOTATED,
 )
 from const import OsKind
 from commit_annotator import compute_annotations_for_object
@@ -42,6 +41,5 @@ class RecreatingCommitChangeDeterminator(object):
         assert belongs in [
             COMMIT_BELONGS,
             COMMIT_DOES_NOT_BELONG,
-            COMMIT_COULD_NOT_BE_ANNOTATED,
         ], "Expected a specific CommitInclusionState, not %r" % belongs
         return belongs

--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -17,7 +17,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__)))
 
 from commit_annotation import (
     CHANGED_NOTES_NAMESPACES,
-    COMMIT_COULD_NOT_BE_ANNOTATED,
     COMMIT_BELONGS,
     COMMIT_DOES_NOT_BELONG,
     CommitInclusionState,
@@ -209,12 +208,8 @@ def annotate_object(annotator: GitRepoAnnotator, object: str, os_kind: OsKind) -
             content=belongs,
         )
     except Exception:
-        logger.exception("Annotation failed.  Saving a record of the failure.")
-        annotator.add(
-            object=object,
-            namespace=CHANGED_NOTES_NAMESPACES[os_kind],
-            content=COMMIT_COULD_NOT_BE_ANNOTATED,
-        )
+        logger.exception("Annotation failed.  Aborting.")
+        raise
 
 
 def plan_to_annotate_branch(

--- a/release-controller/release_notes_composer.py
+++ b/release-controller/release_notes_composer.py
@@ -22,7 +22,6 @@ from const import (  # noqa: E402
 from commit_annotation import (  # noqa: E402
     ChangeDeterminatorProtocol,
     COMMIT_BELONGS,
-    COMMIT_COULD_NOT_BE_ANNOTATED,
 )
 from git_repo import GitRepo, FileChange  # noqa: E402
 from util import auto_progressbar_with_item_descriptions  # noqa: E402
@@ -287,7 +286,7 @@ def release_changes(
             commit_hash=commits[i],
             ic_repo=ic_repo,
             belongs=belongs_determinator.commit_changes_artifact(commits[i], os_kind)
-            in [COMMIT_BELONGS, COMMIT_COULD_NOT_BE_ANNOTATED],
+            in [COMMIT_BELONGS],
         )
         if change is None:
             continue

--- a/rs/cli/BUILD.bazel
+++ b/rs/cli/BUILD.bazel
@@ -57,6 +57,7 @@ rust_binary(
         "//:cordoned_features.yaml",
     ],
     compile_data = [ "src/assets/subnet_topic_map.json" ],
+    crate_features = ["no-default-features"],
 )
 
 rust_library(

--- a/rs/cli/Cargo.toml
+++ b/rs/cli/Cargo.toml
@@ -10,6 +10,9 @@ license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["keyring"]
+
 [dependencies]
 ahash = { workspace = true }
 anyhow = { workspace = true }
@@ -57,7 +60,7 @@ ic-types = { workspace = true }
 icp-ledger = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-keyring = { workspace = true }
+keyring = { workspace = true, optional = true }
 log = { workspace = true }
 mockall.workspace = true
 pretty_env_logger = { workspace = true }

--- a/rs/cli/src/lib.rs
+++ b/rs/cli/src/lib.rs
@@ -10,6 +10,7 @@ mod forum;
 mod governance;
 mod ic_admin;
 mod operations;
+mod pin;
 mod proposal_executors;
 mod qualification;
 mod runner;

--- a/rs/cli/src/pin/ask.rs
+++ b/rs/cli/src/pin/ask.rs
@@ -1,0 +1,26 @@
+use dialoguer::Password;
+use ic_canisters::parallel_hardware_identity::{HsmPinHandler, PinHandlerError};
+
+/// `keyring`-based memory for PIN that uses console prompting for the PIN
+/// when a PIN is necessary and has not been supplied by the user.
+/// This implementation lives in this crate to avoid having to add a
+/// `keyring` dependency to the parallel_hardware_identity module.
+#[derive(Default)]
+pub struct AskEveryTimePinHandler {}
+
+impl HsmPinHandler for AskEveryTimePinHandler {
+    fn retrieve(&self, _key: &str, _from_memory: bool) -> Result<String, PinHandlerError> {
+        match Password::new().with_prompt("Please enter the hardware security module PIN: ").interact() {
+            Ok(pin) => Ok(pin),
+            Err(e) => Err(PinHandlerError(format!("Prompt for PIN failed: {}", e))),
+        }
+    }
+
+    fn store(&self, _key: &str, _pin: &str) -> Result<(), PinHandlerError> {
+        Ok(())
+    }
+
+    fn forget(&self, _key: &str) -> Result<(), PinHandlerError> {
+        Ok(())
+    }
+}

--- a/rs/cli/src/pin/keyring.rs
+++ b/rs/cli/src/pin/keyring.rs
@@ -1,0 +1,63 @@
+use dialoguer::Password;
+use ic_canisters::parallel_hardware_identity::{HsmPinHandler, PinHandlerError};
+use keyring::{Entry, Error};
+use log::error;
+
+/// `keyring`-based memory for PIN that uses console prompting for the PIN
+/// when a PIN is necessary and has not been supplied by the user.
+/// This implementation lives in this crate to avoid having to add a
+/// `keyring` dependency to the parallel_hardware_identity module.
+#[derive(Default)]
+pub struct PlatformKeyringPinHandler {}
+
+impl HsmPinHandler for PlatformKeyringPinHandler {
+    fn retrieve(&self, key: &str, from_memory: bool) -> Result<String, PinHandlerError> {
+        if !from_memory {
+            match Password::new().with_prompt("Please enter the hardware security module PIN: ").interact() {
+                Ok(pin) => Ok(pin),
+                Err(e) => Err(PinHandlerError(format!("Prompt for PIN failed: {}", e))),
+            }
+        } else {
+            let entry = match Entry::new("dre-tool-hsm-pin", key) {
+                Ok(entry) => Ok(entry),
+                Err(e) => Err(PinHandlerError(format!("Keyring initialization failed: {}", e))),
+            }?;
+            match entry.get_password() {
+                Ok(pin) => Ok(pin),
+                Err(e) => {
+                    if let Error::NoEntry = e {
+                    } else {
+                        error!("Cannot retrieve password from keyring; switching to unconditional prompt.  Error: {}", e);
+                    };
+                    match Password::new().with_prompt("Please enter the hardware security module PIN: ").interact() {
+                        Ok(pin) => Ok(pin),
+                        Err(e) => Err(PinHandlerError(format!("Prompt for PIN failed: {}", e))),
+                    }
+                }
+            }
+        }
+    }
+
+    fn store(&self, key: &str, pin: &str) -> Result<(), PinHandlerError> {
+        let entry = match Entry::new("dre-tool-hsm-pin", key) {
+            Ok(entry) => Ok(entry),
+            Err(e) => Err(PinHandlerError(format!("Keyring initialization failed: {}", e))),
+        }?;
+        match entry.set_password(pin) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(PinHandlerError(format!("{}", e))),
+        }
+    }
+
+    fn forget(&self, key: &str) -> Result<(), PinHandlerError> {
+        let entry = match Entry::new("dre-tool-hsm-pin", key) {
+            Ok(entry) => Ok(entry),
+            Err(e) => Err(PinHandlerError(format!("Keyring initialization failed: {}", e))),
+        }?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(PinHandlerError(format!("{}", e))),
+        }
+    }
+}

--- a/rs/cli/src/pin/mod.rs
+++ b/rs/cli/src/pin/mod.rs
@@ -1,0 +1,3 @@
+pub mod ask;
+#[cfg(feature = "keyring")]
+pub mod keyring;

--- a/tools/python/py_oci_image.bzl
+++ b/tools/python/py_oci_image.bzl
@@ -68,7 +68,7 @@ def py_layers(name, binary):
 
     return result
 
-def py_oci_image(name, binary, tars = [], **kwargs):
+def py_oci_image(name, binary, tars = [], publish = True, **kwargs):
     "Wrapper around oci_image that splits the py_binary into layers."
     oci_image(
         name = name,
@@ -83,9 +83,10 @@ def py_oci_image(name, binary, tars = [], **kwargs):
         tags = ["manual"],
     )
 
-    binary_label = native.package_relative_label(binary)
-    oci_push(
-        name = "{}_push".format(name),
-        image = name,
-        repository = "ghcr.io/dfinity/dre/{}".format(binary_label.name),
-    )
+    if publish:
+        binary_label = native.package_relative_label(binary)
+        oci_push(
+            name = "{}_push".format(name),
+            image = name,
+            repository = "ghcr.io/dfinity/dre/{}".format(binary_label.name),
+        )


### PR DESCRIPTION
The commit annotator and the reconciler switch in this release to be shipped in a minimal Ubuntu 24.04 container, with the requisite dependencies added for them to work properly.  Image size has gone down accordingly (first image is the old one, second is the locally built one):

```
REPOSITORY                              TAG                                       IMAGE ID      CREATED       SIZE
ghcr.io/dfinity/dre/release-controller  ab1d8ef1aec27b53a94fcd9bb720be12e8680f60  256020b26a92  5 months ago  1.71 GB
<none>                                  <none>                                    56e16585497e  55 years ago  1 GB
```

To debug the execution of these containers, it is now possible to load them via `podman` and then run them locally.  They operate correctly as far as I could tell.  Additionally, the `release-notes` standalone command has now been tested to work correctly in a container (but we do not ship this container to the repository).

**Optimization:** As part of the footprint reduction, the `dre-embedded` target that ships with the reconciler gained an optional feature (default on) to use the keyring, which ordinarily pulls in the D-BUS desktop IPC library, which is not available in the container.  Rather than deploy the D-BUS library (which enlarges the container), we simply make compilation optional (of course, by default on, to preserve the behavior expected by users).  This behavior change does not affect the uses that the `dre-embedded` tool sees in production within the reconciler container.

**Fix:** As part of a change that took place two weeks ago, annotation failures were being recorded as `Failed` in the annotation git note.  While this was a good-intentioned change, and it did not result in any notes being missed during the last two release notes cycle, we now revert to actually asserting that annotation result either `Include` or `Exclude` (true/false), or else we raise an exception.  This will help us detect annotation failures early and deal with them.  E.g. today almost by accident (logs window visible in the background) we discovered an annotation failure due to the lack of `clang` in the old container (which has now been corrected by this PR).  An alert will now alert us when the annotator is behind (due to failures) for more than five minutes.

Other applications' containers have not been switched yet because they require more testing, time for which is not currently available.