### PR TITLE
Add libffi-dev package for building the IC.

### DIFF
--- a/images/ubuntu_24_04_packages.lock.json
+++ b/images/ubuntu_24_04_packages.lock.json
@@ -3359,6 +3359,38 @@
 			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
 		},
 		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libffi8_3.4.6-1build1_amd64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "libffi-dev_3.4.6-1build1_amd64",
+			"name": "libffi-dev",
+			"sha256": "7009959b8a3b77206325026917fb45150ac81bf6139468abc0841d5a29c8619d",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libf/libffi/libffi-dev_3.4.6-1build1_amd64.deb"
+			],
+			"version": "3.4.6-1build1"
+		},
+		{
 			"arch": "arm64",
 			"dependencies": [],
 			"key": "ncurses-base_6.4-p-20240113-1ubuntu2_arm64",
@@ -6694,6 +6726,38 @@
 				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-cpp20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_arm64.deb"
 			],
 			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libffi8_3.4.6-1build1_arm64",
+					"name": "libffi8",
+					"version": "3.4.6-1build1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu8.4_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu8.4"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-4ubuntu2~24.04"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-4ubuntu2_24.04_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-4ubuntu2~24.04"
+				}
+			],
+			"key": "libffi-dev_3.4.6-1build1_arm64",
+			"name": "libffi-dev",
+			"sha256": "887755d6aa91c12ee0eb3404b61f6dc138c4c59234aa2add0264baf270337708",
+			"urls": [
+				"https://snapshot.ubuntu.com/ubuntu/20250424T000000Z/pool/main/libf/libffi/libffi-dev_3.4.6-1build1_arm64.deb"
+			],
+			"version": "3.4.6-1build1"
 		}
 	],
 	"version": 1

--- a/images/ubuntu_24_04_packages.yaml
+++ b/images/ubuntu_24_04_packages.yaml
@@ -44,3 +44,4 @@ packages:
   - "python3" # release controller and commit annotator
   - "build-essential" # commit annotator (Bazel / Bazelisk)
   - "clang-20" # partial IC build process run by target-determinator in commit annotator
+  - "libffi-dev" # necessary to build the IC just like clang


### PR DESCRIPTION
Without this package, HostOS commit annotation fails.