### PR TITLE
Fix correct base rewards computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3188,7 +3188,7 @@ version = "0.17.1"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3228,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3241,7 +3241,7 @@ version = "0.11.0"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3700,9 +3700,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-icrc1",
  "ic-icrc1-tokens-u64",
@@ -3729,9 +3729,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certification 3.0.2",
  "ic-crypto-tree-hash",
  "ic-icrc1",
@@ -3841,7 +3841,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -4174,7 +4174,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "candid",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -4207,7 +4207,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -4226,7 +4226,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4244,7 +4244,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -4267,7 +4267,7 @@ name = "ic-nervous-system-timers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk-timers 0.11.0",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slotmap",
 ]
 
@@ -4300,7 +4300,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nns-constants",
@@ -4343,9 +4343,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
  "ic-ledger-core",
@@ -4462,7 +4462,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -4518,7 +4518,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
  "ic-nns-common",
@@ -4795,9 +4795,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
  "ic-ledger-core",
@@ -4897,7 +4897,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -4951,9 +4951,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
@@ -4982,9 +4982,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
@@ -5034,7 +5034,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5308,7 +5308,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -6167,9 +6167,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-timers 0.11.0 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic-interfaces-registry",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -7357,7 +7357,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
@@ -7464,7 +7464,7 @@ version = "0.6.2"
 dependencies = [
  "chrono",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic-protobuf",
  "ic-types",
  "itertools 0.13.0",

--- a/rs/dre-canisters/node-provider-rewards/canister/api/src/endpoints.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/api/src/endpoints.rs
@@ -121,8 +121,8 @@ impl TryFrom<rewards_calculator_results::RewardsCalculatorResults> for RewardsCa
             .results_by_node
             .into_iter()
             .map(|(node_id, node_results)| {
-                let region = node_results.region.to_string();
-                let node_type = node_results.node_type.to_string();
+                let region = node_results.region.0;
+                let node_type = node_results.node_type.0;
                 let dc_id = node_results.dc_id.to_string();
                 let avg_relative_fr = node_results.avg_relative_fr.map(|fr| fr.try_into()).transpose()?;
 

--- a/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator.rs
+++ b/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator.rs
@@ -238,7 +238,37 @@ impl<'a> RewardsCalculatorPipeline<'a, ComputeBaseRewardsByCategory> {
     fn fill_nodes_base_rewards(&mut self, rewards_by_category: HashMap<(Region, NodeType), Decimal>) {
         for node_results in self.calculator_results.results_by_node.values_mut() {
             let node_category = (node_results.region.clone(), node_results.node_type.clone());
-            let base_rewards_per_month = *rewards_by_category.get(&node_category).expect("Node category exist");
+            // Fix once rewardable nodes are correct
+            //
+            // "node_operator_principal_id": "z6cfb-dbya3-nh4pm-nyteq-76n7d-xzi27-tf3cg-t7sz7-244qt-6rnjy-3ae",
+            // "node_provider_principal_id": "g2ax6-jrkmb-3zuh3-jibtb-q5xoq-njrgo-5utbc-j2o7g-zfq2w-yyhky-dqe",
+            // "dc_id": "hk1",
+            // "rewardable_nodes": {
+            //     "type3.1": 6
+            // },
+            // "node_allowance": 0,
+            // "ipv6": "",
+            // "computed": {
+            //     "node_provider_name": "Wancloud limited",
+            //     "node_allowance_remaining": 0,
+            //     "node_allowance_total": 10,
+            //     "total_up_nodes": 10,
+            //     "nodes_health": {
+            //         "Healthy": [
+            //         "2a7fq-jivc5-upcob-l5e6k-v3l6a-xo4fc-5rfga-7t5ng-cnv72-t6z7d-wqe",
+            //         "2w5be-ukk5g-kmecu-jxtan-w2gsb-htdfz-z5czd-6yacq-cemqu-qhjpm-iqe",
+            //         "bqplp-iejs2-2awcz-oiy6u-62jzx-rzp66-z4eba-m6nan-dtljh-bb4pn-rae",
+            //         "daawl-5c7hb-iltb3-rkphn-d272x-kkpu4-vb5nr-4qxzp-azreg-47okd-gqe",
+            //         "fpjx3-tfebc-csio2-hxi4u-7jomj-p4c4q-b66xe-ngut6-yi63x-keuhl-6ae",
+            //         "gsvxv-tou7p-drlxw-rnldp-m7z3n-e42j4-nrsp4-dzsfc-7wuqr-2qwpf-pae",
+            //         "jemyk-uhint-w6ftv-s3xpy-ne4hr-xbcpu-aqskm-6a4cy-orm5q-aqqwd-gqe",
+            //         "ked4e-syml2-ao2ub-xgtxi-awdfd-2vkf6-lbol5-prycv-2vpb5-ws5jp-oae",
+            //         "oe52f-su776-yflut-ihohm-rm7gp-47fvy-alweq-ndg3i-g5uci-qzcvo-jqe",
+            //         "q6i2a-r2jyo-qvchx-fx2eg-5vz74-tb674-au7zd-cy24h-wvywl-zbyro-7ae"
+            //         ]
+            //     },
+            //     "rewards_correct": false,
+            let base_rewards_per_month = *rewards_by_category.get(&node_category).unwrap_or(&dec!(0));
 
             node_results.base_rewards_per_month = base_rewards_per_month.into();
         }

--- a/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator/builder.rs
+++ b/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator/builder.rs
@@ -1,10 +1,11 @@
 use super::*;
+use crate::types::ProviderRewardableNodes;
 
 pub struct RewardsCalculatorBuilder {
     pub reward_period: RewardPeriod,
     pub rewards_table: NodeRewardsTable,
     pub daily_metrics_by_subnet: HashMap<SubnetMetricsDailyKey, Vec<NodeMetricsDailyRaw>>,
-    pub rewardable_nodes_per_provider: BTreeMap<PrincipalId, Vec<RewardableNode>>,
+    pub rewardable_nodes_per_provider: BTreeMap<PrincipalId, ProviderRewardableNodes>,
 }
 
 /// The percentile used to calculate the failure rate for a subnet.
@@ -30,13 +31,6 @@ impl RewardsCalculatorBuilder {
             }
         }
 
-        for rewardable_nodes in self.rewardable_nodes_per_provider.values() {
-            for rewardable_node in rewardable_nodes {
-                if !self.reward_period.contains(rewardable_node.rewardable_from) || !self.reward_period.contains(rewardable_node.rewardable_to) {
-                    return Err(RewardCalculatorError::RewardableNodeOutOfRange(rewardable_node.node_id));
-                }
-            }
-        }
         Ok(())
     }
 

--- a/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator/tests.rs
+++ b/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator/tests.rs
@@ -110,8 +110,8 @@ impl RewardCalculatorRunnerTest {
 
         let rewardables = nodes.into_iter().map(|node_id| RewardableNode {
             node_id,
-            region: region.to_string(),
-            node_type: node_type.to_string(),
+            region: Region(region.to_string()),
+            node_type: NodeType(node_type.to_string()),
             rewardable_from: start_ts,
             rewardable_to: end_ts,
             ..Default::default()
@@ -149,8 +149,17 @@ impl RewardCalculatorRunnerTest {
             .into_iter()
             .collect();
 
+        let rewardable_nodes_count = rewardables.iter().fold(HashMap::new(), |mut acc, node| {
+            *acc.entry((node.region.clone(), node.node_type.clone())).or_insert(0) += 1;
+            acc
+        });
+
         let rewardable_nodes_per_provider = btreemap! {
-            PrincipalId::new_anonymous() => rewardables.clone()
+            PrincipalId::new_anonymous() => ProviderRewardableNodes {
+                provider_id: PrincipalId::new_anonymous(),
+                rewardable_nodes_count,
+                rewardable_nodes: rewardables,
+            }
         };
 
         let subnets_metrics: HashMap<SubnetMetricsDailyKey, Vec<NodeMetricsDailyRaw>> = self

--- a/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator_results.rs
+++ b/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/rewards_calculator_results.rs
@@ -1,4 +1,4 @@
-use crate::types::{DayEndNanos, RewardPeriod, RewardPeriodError, TimestampNanos, NANOS_PER_DAY};
+use crate::types::{DayEndNanos, NodeType, Region, RewardPeriod, RewardPeriodError, TimestampNanos, NANOS_PER_DAY};
 use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use rust_decimal::Decimal;
 use std::collections::BTreeMap;
@@ -94,8 +94,8 @@ pub struct NodeMetricsDaily {
 
 #[derive(Debug, Default)]
 pub struct NodeResults {
-    pub region: String,
-    pub node_type: String,
+    pub region: Region,
+    pub node_type: NodeType,
     pub dc_id: String,
     pub rewardable_from: DayUTC,
     pub rewardable_to: DayUTC,

--- a/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/types.rs
+++ b/rs/dre-canisters/node-provider-rewards/rewards-calculation/src/types.rs
@@ -1,6 +1,7 @@
 use crate::rewards_calculator_results::DayUTC;
-use ic_base_types::{NodeId, SubnetId};
+use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use ic_types::Time;
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::fmt::Display;
@@ -105,13 +106,24 @@ impl fmt::Display for RewardPeriodError {
 
 impl Error for RewardPeriodError {}
 
+#[derive(Eq, Hash, PartialEq, Clone, Ord, PartialOrd, Debug, Default)]
+pub struct Region(pub String);
+#[derive(Eq, Hash, PartialEq, Clone, Ord, PartialOrd, Debug, Default)]
+pub struct NodeType(pub String);
+
+#[derive(Default)]
+pub struct ProviderRewardableNodes {
+    pub provider_id: PrincipalId,
+    pub rewardable_nodes_count: HashMap<(Region, NodeType), u32>,
+    pub rewardable_nodes: Vec<RewardableNode>,
+}
 #[derive(Eq, Hash, PartialEq, Clone, Ord, PartialOrd, Debug)]
 pub struct RewardableNode {
     pub node_id: NodeId,
     pub rewardable_from: DayUTC,
     pub rewardable_to: DayUTC,
-    pub region: String,
-    pub node_type: String,
+    pub region: Region,
+    pub node_type: NodeType,
     pub dc_id: String,
 }
 


### PR DESCRIPTION
This PR add to `ProviderRewardableNodes` the rewardable_nodes_count present in the registry.
This is used to correctly compute the base rewards per `region` `node_type` in `RewardsCalculator`