### PR TITLE
feat(node-provider-rewards): Add query call measurement and telemetry

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d4c18e77271938e77f2fa083396236804a282d10ffe5a1b83ddc298d3a54d820",
+  "checksum": "76a4da2b094a047087a50c20e9adbba41ea01b976e629561f61afd0c7e0a2d04",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -35856,6 +35856,10 @@
             {
               "id": "candid 0.10.13",
               "target": "candid"
+            },
+            {
+              "id": "chrono 0.4.40",
+              "target": "chrono"
             },
             {
               "id": "futures 0.3.31",

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "76a4da2b094a047087a50c20e9adbba41ea01b976e629561f61afd0c7e0a2d04",
+  "checksum": "77a9de4fb87d78318100584f1e14bcb2dc9a3d147fac3c1d51c9b1315e1c4a1e",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -6721,14 +6721,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "chrono 0.4.40": {
+    "chrono 0.4.41": {
       "name": "chrono",
-      "version": "0.4.40",
+      "version": "0.4.41",
       "package_url": "https://github.com/chronotope/chrono",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/chrono/0.4.40/download",
-          "sha256": "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+          "url": "https://static.crates.io/crates/chrono/0.4.41/download",
+          "sha256": "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
         }
       },
       "targets": [
@@ -6972,7 +6972,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.4.40"
+        "version": "0.4.41"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -12196,7 +12196,7 @@
               "target": "candid"
             },
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -15389,7 +15389,7 @@
               "target": "axum_otel_metrics"
             },
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -23110,7 +23110,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -23202,7 +23202,7 @@
               "target": "candid"
             },
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -23547,7 +23547,7 @@
               "target": "candid"
             },
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -27027,7 +27027,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -29540,7 +29540,7 @@
           "selects": {
             "cfg(not(all(target_arch = \"wasm32\", target_os = \"unknown\")))": [
               {
-                "id": "chrono 0.4.40",
+                "id": "chrono 0.4.41",
                 "target": "chrono"
               }
             ]
@@ -35787,7 +35787,7 @@
               "target": "candid"
             },
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -35858,7 +35858,7 @@
               "target": "candid"
             },
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -37081,7 +37081,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -40971,7 +40971,7 @@
         "deps": {
           "common": [
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -45006,7 +45006,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "chrono 0.4.40",
+              "id": "chrono 0.4.41",
               "target": "chrono"
             },
             {
@@ -62552,7 +62552,7 @@
     "base64 0.22.1",
     "byteorder 1.5.0",
     "candid 0.10.13",
-    "chrono 0.4.40",
+    "chrono 0.4.41",
     "clap 4.5.32",
     "clap-num 1.2.0",
     "clap_complete 4.5.47",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3188,7 +3188,7 @@ version = "0.17.1"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-macros 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3228,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3241,7 +3241,7 @@ version = "0.11.0"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3700,9 +3700,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1",
  "ic-icrc1-tokens-u64",
@@ -3729,9 +3729,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-certification 3.0.2",
  "ic-crypto-tree-hash",
  "ic-icrc1",
@@ -3841,7 +3841,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -4174,7 +4174,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "candid",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -4207,7 +4207,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -4226,7 +4226,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
 ]
 
 [[package]]
@@ -4244,7 +4244,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -4267,7 +4267,7 @@ name = "ic-nervous-system-timers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0",
  "slotmap",
 ]
 
@@ -4300,7 +4300,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nns-constants",
@@ -4343,9 +4343,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
  "ic-ledger-core",
@@ -4462,7 +4462,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -4518,7 +4518,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
  "ic-nns-common",
@@ -4795,9 +4795,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
  "ic-ledger-core",
@@ -4897,7 +4897,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -4951,9 +4951,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
@@ -4982,9 +4982,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
@@ -5034,7 +5034,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5308,7 +5308,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -6164,12 +6164,13 @@ version = "0.6.2"
 dependencies = [
  "async-trait",
  "candid",
+ "chrono",
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
- "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
- "ic-cdk-timers 0.11.0 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
+ "ic-cdk-timers 0.11.0",
  "ic-interfaces-registry",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -7357,7 +7358,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
@@ -7464,7 +7465,7 @@ version = "0.6.2"
 dependencies = [
  "chrono",
  "ic-base-types",
- "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk 0.17.1",
  "ic-protobuf",
  "ic-types",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,9 +1101,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3188,7 +3188,7 @@ version = "0.17.1"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3228,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3241,7 +3241,7 @@ version = "0.11.0"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3700,9 +3700,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-icrc1",
  "ic-icrc1-tokens-u64",
@@ -3729,9 +3729,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certification 3.0.2",
  "ic-crypto-tree-hash",
  "ic-icrc1",
@@ -3841,7 +3841,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -4174,7 +4174,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "candid",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -4207,7 +4207,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -4226,7 +4226,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4244,7 +4244,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -4267,7 +4267,7 @@ name = "ic-nervous-system-timers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk-timers 0.11.0",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slotmap",
 ]
 
@@ -4300,7 +4300,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nns-constants",
@@ -4343,9 +4343,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
  "ic-ledger-core",
@@ -4462,7 +4462,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -4518,7 +4518,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
  "ic-nns-common",
@@ -4795,9 +4795,9 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
  "ic-ledger-core",
@@ -4897,7 +4897,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -4951,9 +4951,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
@@ -4982,9 +4982,9 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-timers 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
@@ -5034,7 +5034,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5308,7 +5308,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -6168,9 +6168,9 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-timers 0.11.0 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic-interfaces-registry",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -7358,7 +7358,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
@@ -7465,7 +7465,7 @@ version = "0.6.2"
 dependencies = [
  "chrono",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic-protobuf",
  "ic-types",
  "itertools 0.13.0",

--- a/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
+++ b/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 async-trait = { workspace = true }
+chrono = { workspace = true }
 ic-canisters-http-types = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }

--- a/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
+++ b/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 async-trait = { workspace = true }
-chrono = { workspace = true }
+chrono = { version = "0.4.41", default-features = false, features = [] }
 ic-canisters-http-types = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }

--- a/rs/dre-canisters/node-provider-rewards/canister/api/src/endpoints.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/api/src/endpoints.rs
@@ -5,7 +5,8 @@ use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use std::collections::BTreeMap;
 
-#[derive(candid::CandidType, candid::Deserialize)]
+// FIXME: these fields need to be documented!  Are they inclusive or exclusive ranges?  How does this work?
+#[derive(candid::CandidType, candid::Deserialize, Clone)]
 pub struct RewardPeriodArgs {
     pub start_ts: u64,
     pub end_ts: u64,

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -178,18 +178,11 @@ fn setup_timers() {
         ic_cdk::spawn(sync_all());
 
         // Hourly timers after first sync.
-        ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(HOUR_IN_SECONDS), || {
-            ic_cdk::spawn(async {
-                // Measure measure_get_node_providers_rewards_query calls every hour.
-                ic_cdk::spawn(async { measure_get_node_providers_rewards_query() });
-            });
-        });
-        ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(HOUR_IN_SECONDS), || {
-            ic_cdk::spawn(async {
-                // Measure measure_get_node_provider_rewards_calculation_query calls every hour.
-                ic_cdk::spawn(async { measure_get_node_provider_rewards_calculation_query() });
-            });
-        });
+        ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(HOUR_IN_SECONDS), measure_get_node_providers_rewards_query);
+        ic_cdk_timers::set_timer_interval(
+            std::time::Duration::from_secs(HOUR_IN_SECONDS),
+            measure_get_node_provider_rewards_calculation_query,
+        );
     });
 
     // Hourly timers.

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -12,7 +12,6 @@ use rewards_calculation::rewards_calculator::RewardsCalculator;
 use rewards_calculation::types::RewardPeriod;
 use std::collections::BTreeMap;
 use std::ops::Add;
-use std::ops::Sub;
 use std::str::FromStr;
 
 mod metrics;

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -88,34 +88,23 @@ fn today_at_midnight(now: Option<DateTime<Utc>>) -> DateTime<Utc> {
     start_of_this_hour(now).with_hour(0).expect("Midnight always exists in UTC time.")
 }
 
-/// Get an interval that ends at the beginning of the day and starts two months before that.
+/// Get an interval that ends at the beginning of the day and starts N months before that.
 /// The first value in the return tuple is the start of the interval.  The second is the end.
 /// The supplied value is used the reference date/time (if None, uses current date/time).
 ///
 /// If the supplied or current date/time falls in an end of the month day, and the target
-/// month (two months ago) has fewer days than the supplied date/time, this code does the
+/// month (N months before) has fewer days than the supplied date/time, this code does the
 /// right thing and computes the end of that month.  The wrong thing would be to blindly
 /// subtract 62 days or something equally arbitrary.  Example of the right thing:
 ///
 /// * supplied date/time: 2025-04-30T03:01:00
 /// * returned interval: (2025-02-28T00:00:00 -- 2025-04-30T00:00:00)
-fn get_two_months_rewards_period(now: Option<DateTime<Utc>>) -> RewardPeriodArgs {
+fn get_n_months_rewards_period(now: Option<DateTime<Utc>>, months: u32) -> RewardPeriodArgs {
     let midnite = today_at_midnight(now);
-    let twomoago = midnite.checked_sub_months(Months::new(2)).expect("UTC dates cannot have a nonexistent or unambiguous date after we subtract months, because UTC dates do not have daylight savings time, and there is no way this could be out of range.  See checked_sub_months() documentation.");
+    let twomoago = midnite.checked_sub_months(Months::new(months)).expect("UTC dates cannot have a nonexistent or unambiguous date after we subtract months, because UTC dates do not have daylight savings time, and there is no way this could be out of range.  See checked_sub_months() documentation.");
     RewardPeriodArgs {
         start_ts: midnite.timestamp().try_into().unwrap(),
         end_ts: twomoago.timestamp().try_into().unwrap(),
-    }
-}
-
-/// Get an interval that ends at the beginning of the day and starts one month before that.
-/// See get_two_months_rewards_period() for more information on how this function works.
-fn get_one_month_rewards_period(now: Option<DateTime<Utc>>) -> RewardPeriodArgs {
-    let midnite = today_at_midnight(now);
-    let onemoago = midnite.checked_sub_months(Months::new(1)).expect("UTC dates cannot have a nonexistent or unambiguous date after we subtract months, because UTC dates do not have daylight savings time, and there is no way this could be out of range.  See checked_sub_months() documentation.");
-    RewardPeriodArgs {
-        start_ts: midnite.timestamp().try_into().unwrap(),
-        end_ts: onemoago.timestamp().try_into().unwrap(),
     }
 }
 
@@ -133,7 +122,7 @@ fn time_left_for_next_1am(now: Option<DateTime<Utc>>) -> std::time::Duration {
 }
 
 fn measure_get_node_providers_rewards_query() {
-    let reward_period = get_two_months_rewards_period(None);
+    let reward_period = get_n_months_rewards_period(None, 2);
     let instruction_counter = telemetry::InstructionCounter::default();
     let success = get_node_providers_rewards(reward_period).is_ok();
     let instructions = instruction_counter.sum();
@@ -143,7 +132,7 @@ fn measure_get_node_providers_rewards_query() {
 }
 
 fn measure_get_node_provider_rewards_calculation_query() {
-    let reward_period = get_one_month_rewards_period(None);
+    let reward_period = get_n_months_rewards_period(None, 1);
     let instruction_counter = telemetry::InstructionCounter::default();
     let failures: Vec<()> = NODE_PROVIDERS_USED_DURING_CALCULATION_MEASUREMENT
         .iter()


### PR DESCRIPTION
Introduce functionality to exercise, hourly, the query calls `get_node_providers_rewards` and `get_node_provider_rewards_calculation` based on current time, and measure execution cost (instruction count) for them.

Adds `chrono` dependency for date/time handling.  The method to determine the next 1 AM has been changed.

Addresses https://dfinity.atlassian.net/browse/DRE-390 .