### PR TITLE
fix(reconciler): correct issue with reconciler and Slack messages.

### DIFF
--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -106,6 +106,18 @@ cacerts(
     }),
 )
 
+# The following thing is necessary because Bazel-wrapped Python programs
+# insist on ignoring the default /usr/lib/ssl/cert.pem and /etc/ssl/certificates/...
+# root and intermediate certificate store, making `urllib.request.urlopen()` fail
+# for any Bazel-wrapped py_binary in the container.  This does not happen when
+# regular Python is invoked inside of the container.
+tar(
+    name = "cacerts-symlink",
+    mtree = [
+        "./etc/ssl/cert.pem type=link link=/etc/ssl/certs/ca-certificates.crt",
+    ],
+)
+
 oci_image(
     name = "ubuntu_24_04",
     architecture = select({
@@ -122,6 +134,7 @@ oci_image(
         ":group",
         ":home",
         ":cacerts",
+        ":cacerts-symlink",
         # Packages listed in this manifest (see YAML files in this folder)
         # get installed in the container by this rule.
         "@ubuntu_24_04_packages//:ubuntu_24_04_packages",

--- a/images/ubuntu_24_04_packages.lock.json
+++ b/images/ubuntu_24_04_packages.lock.json
@@ -3126,14 +3126,14 @@
 					"version": "2.39-0ubuntu8.4"
 				},
 				{
-					"key": "libclang1-20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+					"key": "libclang1-20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 					"name": "libclang1-20",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
-					"key": "libllvm20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+					"key": "libllvm20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 					"name": "libllvm20",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
 					"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3.2_amd64",
@@ -3176,14 +3176,14 @@
 					"version": "1.1.0-2build1.1"
 				},
 				{
-					"key": "llvm-20-linker-tools_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+					"key": "llvm-20-linker-tools_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 					"name": "llvm-20-linker-tools",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
-					"key": "libclang-common-20-dev_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+					"key": "libclang-common-20-dev_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 					"name": "libclang-common-20-dev",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
 					"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_amd64",
@@ -3246,40 +3246,40 @@
 					"version": "13.3.0-6ubuntu2~24.04"
 				},
 				{
-					"key": "libclang-cpp20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+					"key": "libclang-cpp20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 					"name": "libclang-cpp20",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				}
 			],
-			"key": "clang-20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+			"key": "clang-20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 			"name": "clang-20",
-			"sha256": "642ac27d153a593eb17b636992cf9f26be2764f45a80c87390d0ef3f029cc1ff",
+			"sha256": "9e877b2dc7d6591ea113dc3223e7a6b456b726c393147389aa215abc5f16f65d",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/clang-20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_amd64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/clang-20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_amd64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "libclang1-20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+			"key": "libclang1-20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 			"name": "libclang1-20",
-			"sha256": "bc1a0fa0dff42e4c631c517696f7b6d37836d2d0e64ea96b3cff485958092ecc",
+			"sha256": "3f04bee1c4310f2d7accff76a84e915b0f4f5de0bf8ad7d7c3ec32673345baf7",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang1-20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_amd64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang1-20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_amd64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "libllvm20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+			"key": "libllvm20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 			"name": "libllvm20",
-			"sha256": "3a2a8c0e8b864eaa1bbdf7d721e5003d7c408b2ff38c1a1553157b19d824a2ef",
+			"sha256": "739e162b143a81076f3d10e492a4c1dd6512e5c6edd9107c73718da8ccd3a315",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libllvm20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_amd64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libllvm20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_amd64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "amd64",
@@ -3328,35 +3328,35 @@
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "llvm-20-linker-tools_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+			"key": "llvm-20-linker-tools_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 			"name": "llvm-20-linker-tools",
-			"sha256": "3e5d8ae0c0c40373e2d63c43a6d00459f643b8ece8f92ba971d1ea765674d2e4",
+			"sha256": "e28cb5663ba6ce9375a96a399dd040243e315522d6961097a275f92ed96c63cc",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_amd64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_amd64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "libclang-common-20-dev_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+			"key": "libclang-common-20-dev_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 			"name": "libclang-common-20-dev",
-			"sha256": "cb1f2e9de3562bdc0365451b8925bd968f4993a4a55bf91a16dd0fa8d8a0b63b",
+			"sha256": "37d91634729580012289b11f1de633bda956b79ae06259c1ef55cea7019f6f97",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-common-20-dev_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_amd64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-common-20-dev_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_amd64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "libclang-cpp20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_amd64",
+			"key": "libclang-cpp20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_amd64",
 			"name": "libclang-cpp20",
-			"sha256": "f5cc07419aeaa99c615415b4def1a3618774794016bc5a24489a4cc0f7527825",
+			"sha256": "bb21b9dc3b5006249332ae173ac986dff412cfb1b879f989e02b5a8c81a90e55",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-cpp20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_amd64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-cpp20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_amd64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "amd64",
@@ -6500,14 +6500,14 @@
 					"version": "2.39-0ubuntu8.4"
 				},
 				{
-					"key": "libclang1-20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+					"key": "libclang1-20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 					"name": "libclang1-20",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
-					"key": "libllvm20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+					"key": "libllvm20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 					"name": "libllvm20",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
 					"key": "libxml2_2.9.14-p-dfsg-1.3ubuntu3.2_arm64",
@@ -6550,14 +6550,14 @@
 					"version": "1.1.0-2build1.1"
 				},
 				{
-					"key": "llvm-20-linker-tools_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+					"key": "llvm-20-linker-tools_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 					"name": "llvm-20-linker-tools",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
-					"key": "libclang-common-20-dev_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+					"key": "libclang-common-20-dev_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 					"name": "libclang-common-20-dev",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				},
 				{
 					"key": "libgcc-13-dev_13.3.0-6ubuntu2_24.04_arm64",
@@ -6615,40 +6615,40 @@
 					"version": "13.3.0-6ubuntu2~24.04"
 				},
 				{
-					"key": "libclang-cpp20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+					"key": "libclang-cpp20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 					"name": "libclang-cpp20",
-					"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+					"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 				}
 			],
-			"key": "clang-20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+			"key": "clang-20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 			"name": "clang-20",
-			"sha256": "124ee290c37ed25c2d8b21ebf02043576e771c2a3f89459896655d86d123ae1f",
+			"sha256": "bc75337414a5f3c886d22d358a397c7688ac88a8777d53b396bdae57918a2024",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/clang-20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_arm64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/clang-20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_arm64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "arm64",
 			"dependencies": [],
-			"key": "libclang1-20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+			"key": "libclang1-20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 			"name": "libclang1-20",
-			"sha256": "4a5832e815f4ab952733adb98291d22048728a668d418595c0c758ee23d96a83",
+			"sha256": "c1200e2b1cc8818746572d1be0de3daf3724e615faa400255ae42a9773d29e06",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang1-20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_arm64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang1-20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_arm64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "arm64",
 			"dependencies": [],
-			"key": "libllvm20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+			"key": "libllvm20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 			"name": "libllvm20",
-			"sha256": "59290576ba4f4702e4230f29a97f16d82a38e4e3872ee9218a8de5f95a14e3b3",
+			"sha256": "b9bb7a61d2bbb6c8c6ea9f28cd2ed3c4e14a8f61d010fa99656957fdc35e2fe6",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libllvm20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_arm64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libllvm20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_arm64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "arm64",
@@ -6697,35 +6697,35 @@
 		{
 			"arch": "arm64",
 			"dependencies": [],
-			"key": "llvm-20-linker-tools_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+			"key": "llvm-20-linker-tools_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 			"name": "llvm-20-linker-tools",
-			"sha256": "80618a6601a65522008de8c82b57ea022f561458ae503f0b15666e0b94f435ee",
+			"sha256": "812b8f09f351b46192d377e801eb6894e2333895521da199ca99aea4a5595a9d",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_arm64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_arm64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "arm64",
 			"dependencies": [],
-			"key": "libclang-common-20-dev_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+			"key": "libclang-common-20-dev_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 			"name": "libclang-common-20-dev",
-			"sha256": "e7b8b89e78c6561492917ca5d16f9c10af3fc73bda1be4666c6e159f7ef70381",
+			"sha256": "33a0ff50a3fdca61e395c14102c67982af97f0ad37a2db03467ceb3c81cbbbc5",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-common-20-dev_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_arm64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-common-20-dev_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_arm64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "arm64",
 			"dependencies": [],
-			"key": "libclang-cpp20_1-20.1.3_-p--p-20250415115034-p-9420327ad768-1_exp1_20250415235124.105_arm64",
+			"key": "libclang-cpp20_1-20.1.5_-p--p-20250430014901-p-ebfae55af454-1_exp1_20250430014920.111_arm64",
 			"name": "libclang-cpp20",
-			"sha256": "72945ec812ee91390e94477af3919188ca390b130d2b4f71ccad047bb973118b",
+			"sha256": "10d65afa860a513f461e84bbad36fbfbc1209a8695537239c703b0fb57f03652",
 			"urls": [
-				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-cpp20_20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105_arm64.deb"
+				"https://apt.llvm.org/noble/pool/main/l/llvm-toolchain-20/libclang-cpp20_20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111_arm64.deb"
 			],
-			"version": "1:20.1.3~++20250415115034+9420327ad768-1~exp1~20250415235124.105"
+			"version": "1:20.1.5~++20250430014901+ebfae55af454-1~exp1~20250430014920.111"
 		},
 		{
 			"arch": "arm64",

--- a/release-controller/dryrun.py
+++ b/release-controller/dryrun.py
@@ -179,14 +179,19 @@ class ReleaseNotesClient(object):
         release_commit: str,
         os_kind: OsKind,
         content: PreparedReleaseNotes,
-    ) -> DocInfo:
+    ) -> tuple[DocInfo, bool]:
+        """
+        Ensures the relase notes are stored in Google Docs (fake).
+
+        Returns a DocInfo object, along with whether the doc changed.
+        """
         t = self.release_notes_folder / (release_commit + os_kind)
         if t.exists():
-            return {"alternateLink": str(t)}
+            return {"alternateLink": str(t)}, False
         with open(t, "w") as f:
             f.write(f"{content}")
         self._logger.warning("Stored release notes in %s", t)
-        return {"alternateLink": str(t)}
+        return {"alternateLink": str(t)}, True
 
     def markdown_file(
         self, version: str, os_kind: OsKind

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -570,18 +570,17 @@ class Reconciler:
                         os_kind=v.os_kind,
                     )
 
-            if needs_announce:
+            if "SLACK_WEBHOOK_URL" in os.environ and needs_announce:
                 with phase("release notes announcement"):
-                    if "SLACK_WEBHOOK_URL" in os.environ:
-                        # This should have never been in the Google Docs code.
-                        revlogger.info("Announcing release notes")
-                        self.slack_announcer.announce_release(
-                            webhook=os.environ["SLACK_WEBHOOK_URL"],
-                            version_name=release_tag,
-                            google_doc_url=gdoc["alternateLink"],
-                            tag_all_teams=v.is_base,
-                            os_kind=v.os_kind,
-                        )
+                    # This should have never been in the Google Docs code.
+                    revlogger.info("Announcing release notes")
+                    self.slack_announcer.announce_release(
+                        webhook=os.environ["SLACK_WEBHOOK_URL"],
+                        version_name=release_tag,
+                        google_doc_url=gdoc["alternateLink"],
+                        tag_all_teams=v.is_base,
+                        os_kind=v.os_kind,
+                    )
 
             with phase("release notes pull request") as p:
                 self.publish_client.publish_if_ready(


### PR DESCRIPTION
When we moved to Ubuntu 24.04 for the container package of the reconciler, something changed in the way that the container was built, such that Bazel-wrapped Python binaries (such as the reconciler) silently failed to load the system certificate store, leading to Python `urllib.request.urlopen` failing to load HTTPS resources.  Since `urllib` is how the Slack SDK posts announcements about GuestOS and HostOS, that begun failing (fortunately not in a way that prevented making progress with the release process).

This failure does not affect usage of the `requests` because `requests` uses the `certifi` certificate store by default (although if we were using a private certificate authority for some of our requested resources, this would not work and it would require the use of the environment variable `REQUESTS_CA_BUNDLE` to override that).

This failure, strangely, also does not affect plain `urllib.request.urlopen` from the container's Python.  When that is invoked manually within the container, it works OK. It only seems to affect any script wrapped by Bazel and packaged up in the container.

The fix here is to pay attention to which files the `urllib` (and `ssl`) module attempt to read when creating an SSL context, and symlinking one of those files to the system certificate store in `/etc/ssl/certs`.  Which is exactly what this fix does.

In addition to the fix above, we make the announcement into its own phase, such that we can get failure telemetry for that phase.  We do not currently keep track of whether the announcement has been made (for retry purposes) but we can now easily add that in the future.