### PR TITLE
fix(ci): concurrency group for required checks

### DIFF
--- a/.github/workflows/required-checks.yaml
+++ b/.github/workflows/required-checks.yaml
@@ -9,7 +9,7 @@ on:
       - in_progress
 
 concurrency:
-  group: ${{ github.workflow }}-required-checks-${{ github.event.pull_request.number || || github.event.push.after || github.ref }}
+  group: ${{ github.workflow }}-required-checks-${{ github.event.pull_request.number || github.event.push.after || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/required-checks.yaml
+++ b/.github/workflows/required-checks.yaml
@@ -9,7 +9,7 @@ on:
       - in_progress
 
 concurrency:
-  group: ${{ github.workflow }}-required-checks-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-required-checks-${{ github.event.pull_request.number || || github.event.push.after || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Updated concurrency group to include push events in addition to pull requests and branch creation. This ensures that required checks workflows do not get cancelled when a merge is done into `main`. This will also clear up the ocean of red crosses in the commit history for `main`.

EDIT: we won't actually know if this did work until we merge to `main`.  Guh.