### PR TITLE
Remove push event trigger from required checks workflow

### DIFF
--- a/.github/workflows/required-checks.yaml
+++ b/.github/workflows/required-checks.yaml
@@ -1,6 +1,5 @@
 name: Required checks
 on:
-  push: {}
   workflow_run:
     workflows:
       - Release controller


### PR DESCRIPTION
The `push` event trigger has been removed from the `required-checks.yaml` workflow file, because it causes duplicate required checks to run.