### PR TITLE
feat(node-provider-rewards): Perform inter-canister calls using non-blocking calls

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "39a8e598cb1896264eac70558b3e6a60bc5df73916e991af446ca2aae987e738",
+  "checksum": "93eb173474b738829386a93aa1c4fe928fa11cc79c0e225995cf6a3c621f2f5c",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -45305,7 +45305,7 @@
               "target": "ic_base_types"
             },
             {
-              "id": "ic-cdk 0.17.1",
+              "id": "ic-cdk 0.18.0",
               "target": "ic_cdk"
             },
             {
@@ -62907,7 +62907,6 @@
     "ic-canister-client 0.9.0",
     "ic-canister-client-sender 0.9.0",
     "ic-canisters-http-types 0.9.0",
-    "ic-cdk 0.17.1",
     "ic-cdk 0.18.0",
     "ic-cdk-macros 0.18.0",
     "ic-cdk-timers 0.12.0",

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d261444e8b4f5afb859fa01196302b8dbf3598a8f257220c597ec3ae29f7de92",
+  "checksum": "39a8e598cb1896264eac70558b3e6a60bc5df73916e991af446ca2aae987e738",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",
@@ -19590,6 +19590,90 @@
       ],
       "license_file": "LICENSE"
     },
+    "ic-cdk 0.18.0": {
+      "name": "ic-cdk",
+      "version": "0.18.0",
+      "package_url": "https://github.com/dfinity/cdk-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ic-cdk/0.18.0/download",
+          "sha256": "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ic_cdk",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ic_cdk",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "candid 0.10.13",
+              "target": "candid"
+            },
+            {
+              "id": "ic-error-types 0.1.0",
+              "target": "ic_error_types"
+            },
+            {
+              "id": "ic-management-canister-types 0.3.0",
+              "target": "ic_management_canister_types"
+            },
+            {
+              "id": "ic0 0.24.0",
+              "target": "ic0"
+            },
+            {
+              "id": "serde 1.0.219",
+              "target": "serde"
+            },
+            {
+              "id": "serde_bytes 0.11.15",
+              "target": "serde_bytes"
+            },
+            {
+              "id": "slotmap 1.0.7",
+              "target": "slotmap"
+            },
+            {
+              "id": "thiserror 2.0.12",
+              "target": "thiserror"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "ic-cdk-macros 0.18.0",
+              "target": "ic_cdk_macros"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.18.0"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
+    },
     "ic-cdk-macros 0.17.1": {
       "name": "ic-cdk-macros",
       "version": "0.17.1",
@@ -19657,6 +19741,73 @@
       ],
       "license_file": "LICENSE"
     },
+    "ic-cdk-macros 0.18.0": {
+      "name": "ic-cdk-macros",
+      "version": "0.18.0",
+      "package_url": "https://github.com/dfinity/cdk-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ic-cdk-macros/0.18.0/download",
+          "sha256": "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "ic_cdk_macros",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ic_cdk_macros",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "candid 0.10.13",
+              "target": "candid"
+            },
+            {
+              "id": "proc-macro2 1.0.94",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.39",
+              "target": "quote"
+            },
+            {
+              "id": "serde 1.0.219",
+              "target": "serde"
+            },
+            {
+              "id": "serde_tokenstream 0.2.2",
+              "target": "serde_tokenstream"
+            },
+            {
+              "id": "syn 2.0.100",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.18.0"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
+    },
     "ic-cdk-timers 0.11.0": {
       "name": "ic-cdk-timers",
       "version": "0.11.0",
@@ -19717,6 +19868,77 @@
         },
         "edition": "2021",
         "version": "0.11.0"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
+    },
+    "ic-cdk-timers 0.12.0": {
+      "name": "ic-cdk-timers",
+      "version": "0.12.0",
+      "package_url": "https://github.com/dfinity/cdk-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ic-cdk-timers/0.12.0/download",
+          "sha256": "647de2a321d15442c2a73597fd81f031af80624022f069844bf789a317889299"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ic_cdk_timers",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ic_cdk_timers",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "candid 0.10.13",
+              "target": "candid"
+            },
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "ic-cdk 0.18.0",
+              "target": "ic_cdk"
+            },
+            {
+              "id": "ic0 0.24.0",
+              "target": "ic0"
+            },
+            {
+              "id": "serde 1.0.219",
+              "target": "serde"
+            },
+            {
+              "id": "serde_bytes 0.11.15",
+              "target": "serde_bytes"
+            },
+            {
+              "id": "slotmap 1.0.7",
+              "target": "slotmap"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.12.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -21718,12 +21940,9 @@
       "version": "0.1.0",
       "package_url": "https://github.com/dfinity/ic",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/dfinity/ic.git",
-          "commitish": {
-            "Rev": "2fe8aefafcb2fbee6fdb2785374d5de715560269"
-          },
-          "strip_prefix": "packages/ic-error-types"
+        "Http": {
+          "url": "https://static.crates.io/crates/ic-error-types/0.1.0/download",
+          "sha256": "be844216781d6f4a0853b5a8d63dee8d1b6ee0b9aef310d8c0cb82a6796d7072"
         }
       },
       "targets": [
@@ -23402,6 +23621,61 @@
         "Apache-2.0"
       ],
       "license_file": null
+    },
+    "ic-management-canister-types 0.3.0": {
+      "name": "ic-management-canister-types",
+      "version": "0.3.0",
+      "package_url": "https://github.com/dfinity/cdk-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ic-management-canister-types/0.3.0/download",
+          "sha256": "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ic_management_canister_types",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ic_management_canister_types",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "candid 0.10.13",
+              "target": "candid"
+            },
+            {
+              "id": "serde 1.0.219",
+              "target": "serde"
+            },
+            {
+              "id": "serde_bytes 0.11.15",
+              "target": "serde_bytes"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.3.0"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
     },
     "ic-management-canister-types-private 0.9.0": {
       "name": "ic-management-canister-types-private",
@@ -30251,6 +30525,44 @@
       ],
       "license_file": "LICENSE"
     },
+    "ic0 0.24.0": {
+      "name": "ic0",
+      "version": "0.24.0",
+      "package_url": "https://github.com/dfinity/cdk-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ic0/0.24.0/download",
+          "sha256": "673a6b846467547f3fc61f95d246aadff03e368b53c931655300b9d1bd05a55a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ic0",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ic0",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.24.0"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
+    },
     "ic_bls12_381 0.10.0": {
       "name": "ic_bls12_381",
       "version": "0.10.0",
@@ -35878,11 +36190,11 @@
               "target": "ic_canisters_http_types"
             },
             {
-              "id": "ic-cdk 0.17.1",
+              "id": "ic-cdk 0.18.0",
               "target": "ic_cdk"
             },
             {
-              "id": "ic-cdk-timers 0.11.0",
+              "id": "ic-cdk-timers 0.12.0",
               "target": "ic_cdk_timers"
             },
             {
@@ -35906,6 +36218,10 @@
               "target": "ic_nervous_system_common"
             },
             {
+              "id": "ic-nns-constants 0.9.0",
+              "target": "ic_nns_constants"
+            },
+            {
               "id": "ic-protobuf 0.9.0",
               "target": "ic_protobuf"
             },
@@ -35916,6 +36232,10 @@
             {
               "id": "ic-registry-keys 0.9.0",
               "target": "ic_registry_keys"
+            },
+            {
+              "id": "ic-registry-transport 0.9.0",
+              "target": "ic_registry_transport"
             },
             {
               "id": "ic-stable-structures 0.6.8",
@@ -35965,7 +36285,7 @@
               "target": "async_trait"
             },
             {
-              "id": "ic-cdk-macros 0.17.1",
+              "id": "ic-cdk-macros 0.18.0",
               "target": "ic_cdk_macros"
             }
           ],
@@ -62588,8 +62908,9 @@
     "ic-canister-client-sender 0.9.0",
     "ic-canisters-http-types 0.9.0",
     "ic-cdk 0.17.1",
-    "ic-cdk-macros 0.17.1",
-    "ic-cdk-timers 0.11.0",
+    "ic-cdk 0.18.0",
+    "ic-cdk-macros 0.18.0",
+    "ic-cdk-timers 0.12.0",
     "ic-config 0.9.0",
     "ic-crypto-utils-threshold-sig-der 0.9.0",
     "ic-http-endpoints-metrics 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "ic-btc-interface",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "ic-protobuf",
  "serde",
  "serde_bytes",
@@ -3142,7 +3142,7 @@ dependencies = [
  "ic-canonical-state-tree-hash",
  "ic-certification-version",
  "ic-crypto-tree-hash",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "ic-protobuf",
  "ic-registry-routing-table",
  "ic-registry-subnet-type",
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3188,10 +3188,27 @@ version = "0.17.1"
 source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
+]
+
+[[package]]
+name = "ic-cdk"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+dependencies = [
+ "candid",
+ "ic-cdk-macros 0.18.0",
+ "ic-error-types 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-management-canister-types",
+ "ic0 0.24.0",
+ "serde",
+ "serde_bytes",
+ "slotmap",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3222,13 +3239,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk-macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+dependencies = [
+ "candid",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "ic-cdk-timers"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3237,12 +3268,14 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-timers"
-version = "0.11.0"
-source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647de2a321d15442c2a73597fd81f031af80624022f069844bf789a317889299"
 dependencies = [
+ "candid",
  "futures",
- "ic-cdk 0.17.1",
- "ic0 0.23.0",
+ "ic-cdk 0.18.0",
+ "ic0 0.24.0",
  "serde",
  "serde_bytes",
  "slotmap",
@@ -3626,6 +3659,17 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be844216781d6f4a0853b5a8d63dee8d1b6ee0b9aef310d8c0cb82a6796d7072"
+dependencies = [
+ "serde",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "ic-error-types"
+version = "0.1.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "serde",
@@ -3700,8 +3744,8 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1",
@@ -3729,8 +3773,8 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk-timers 0.11.0",
  "ic-certification 3.0.2",
  "ic-crypto-tree-hash",
@@ -3793,7 +3837,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "ic-base-types",
  "ic-crypto-interfaces-sig-verification",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "ic-interfaces-state-manager",
  "ic-management-canister-types-private",
  "ic-protobuf",
@@ -3841,7 +3885,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -3955,6 +3999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-management-canister-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-management-canister-types-private"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
@@ -3963,7 +4018,7 @@ dependencies = [
  "ic-base-types",
  "ic-btc-interface",
  "ic-btc-replica-types",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "ic-protobuf",
  "ic-utils 0.9.0",
  "num-traits",
@@ -4052,7 +4107,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "ic-ledger-core",
  "ic-management-canister-types-private",
  "ic-nervous-system-canisters",
@@ -4174,7 +4229,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "candid",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -4207,7 +4262,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -4226,7 +4281,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4244,7 +4299,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4255,7 +4310,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -4300,7 +4355,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nns-constants",
@@ -4343,8 +4398,8 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
@@ -4462,7 +4517,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -4476,7 +4531,7 @@ dependencies = [
  "bincode",
  "candid",
  "erased-serde 0.3.31",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "prost",
  "serde",
  "serde_json",
@@ -4518,7 +4573,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
  "ic-nns-common",
@@ -4723,7 +4778,7 @@ dependencies = [
  "ic-certification-version",
  "ic-config",
  "ic-crypto-sha2",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "ic-interfaces",
  "ic-limits",
  "ic-logger",
@@ -4795,8 +4850,8 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
@@ -4897,7 +4952,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -4951,8 +5006,8 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk-timers 0.11.0",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -4982,8 +5037,8 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk-timers 0.11.0",
  "ic-ledger-core",
  "ic-metrics-encoder",
@@ -5034,7 +5089,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5119,7 +5174,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
- "ic-error-types",
+ "ic-error-types 0.1.0 (git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269)",
  "ic-limits",
  "ic-management-canister-types-private",
  "ic-protobuf",
@@ -5268,6 +5323,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
 
 [[package]]
+name = "ic0"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673a6b846467547f3fc61f95d246aadff03e368b53c931655300b9d1bd05a55a"
+
+[[package]]
 name = "ic_bls12_381"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5308,7 +5369,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -6169,17 +6230,19 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
+ "ic-cdk 0.18.0",
+ "ic-cdk-macros 0.18.0",
+ "ic-cdk-timers 0.12.0",
  "ic-interfaces-registry",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
  "ic-nervous-system-common",
+ "ic-nns-constants",
  "ic-protobuf",
  "ic-registry-canister-client",
  "ic-registry-keys",
+ "ic-registry-transport",
  "ic-stable-structures",
  "ic-types",
  "indexmap 2.9.0",
@@ -7359,7 +7422,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
@@ -7466,7 +7529,7 @@ version = "0.6.2"
 dependencies = [
  "chrono",
  "ic-base-types",
- "ic-cdk 0.17.1",
+ "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
  "ic-protobuf",
  "ic-types",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,19 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic0 0.23.0",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
-version = "0.17.1"
-source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
-dependencies = [
- "candid",
- "ic-cdk-macros 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk-macros 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3227,19 +3215,6 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.17.1"
-source = "git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815#929fd0b31e9ec69aad7cf6285df0394f25fe1815"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "ic-cdk-macros"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
@@ -3259,7 +3234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb8fd812a9e26f6aa00594546f8fbf4d4853f39c3ba794c8ff11ecf86fd3c9e4"
 dependencies = [
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -3744,8 +3719,8 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
  "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1",
@@ -3773,8 +3748,8 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
  "ic-cdk-timers 0.11.0",
  "ic-certification 3.0.2",
  "ic-crypto-tree-hash",
@@ -3885,7 +3860,7 @@ dependencies = [
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
@@ -4229,7 +4204,7 @@ version = "0.0.1"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
  "candid",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -4262,7 +4237,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-nervous-system-clients",
@@ -4281,7 +4256,7 @@ dependencies = [
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
 ]
 
 [[package]]
@@ -4299,7 +4274,7 @@ name = "ic-nervous-system-time-helpers"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=2fe8aefafcb2fbee6fdb2785374d5de715560269#2fe8aefafcb2fbee6fdb2785374d5de715560269"
 dependencies = [
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
 ]
 
 [[package]]
@@ -4310,7 +4285,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-metrics-encoder",
  "ic-nervous-system-time-helpers",
  "ic-nervous-system-timers",
@@ -4355,7 +4330,7 @@ dependencies = [
  "candid",
  "comparable",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nns-constants",
@@ -4398,8 +4373,8 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
  "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-dummy-getrandom-for-wasm",
@@ -4517,7 +4492,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -4573,7 +4548,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
  "ic-nns-common",
@@ -4850,8 +4825,8 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
  "ic-cdk-timers 0.11.0",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
@@ -4952,7 +4927,7 @@ dependencies = [
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -5006,8 +4981,8 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
  "ic-cdk-timers 0.11.0",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5037,8 +5012,8 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-cdk-macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
+ "ic-cdk-macros 0.17.1",
  "ic-cdk-timers 0.11.0",
  "ic-ledger-core",
  "ic-metrics-encoder",
@@ -5089,7 +5064,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
@@ -5369,7 +5344,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -7422,7 +7397,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "ic-base-types",
- "ic-cdk 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk 0.17.1",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
@@ -7529,7 +7504,7 @@ version = "0.6.2"
 dependencies = [
  "chrono",
  "ic-base-types",
- "ic-cdk 0.17.1 (git+https://github.com/dfinity/cdk-rs.git?rev=929fd0b31e9ec69aad7cf6285df0394f25fe1815)",
+ "ic-cdk 0.18.0",
  "ic-protobuf",
  "ic-types",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ ic-canister-client = { git = "https://github.com/dfinity/ic.git", rev = "2fe8aef
 ic-canister-client-sender = { git = "https://github.com/dfinity/ic.git", rev = "2fe8aefafcb2fbee6fdb2785374d5de715560269" }
 ic-canisters = { path = "rs/ic-canisters" }
 ic-canisters-http-types = { git = "https://github.com/dfinity/ic.git", rev = "2fe8aefafcb2fbee6fdb2785374d5de715560269" }
-ic-cdk = { git = "https://github.com/dfinity/cdk-rs.git", rev = "929fd0b31e9ec69aad7cf6285df0394f25fe1815" }
 ic-config = { git = "https://github.com/dfinity/ic.git", rev = "2fe8aefafcb2fbee6fdb2785374d5de715560269" }
 ic-crypto-utils-threshold-sig-der = { git = "https://github.com/dfinity/ic.git", rev = "2fe8aefafcb2fbee6fdb2785374d5de715560269" }
 ic-http-endpoints-metrics = { git = "https://github.com/dfinity/ic.git", rev = "2fe8aefafcb2fbee6fdb2785374d5de715560269" }
@@ -205,8 +204,9 @@ human_bytes = "0.4"
 mockall = "0.13.1"
 
 # dre-canisters dependencies
-ic-cdk-timers = { git = "https://github.com/dfinity/cdk-rs.git", rev = "929fd0b31e9ec69aad7cf6285df0394f25fe1815" }
-ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs.git", rev = "929fd0b31e9ec69aad7cf6285df0394f25fe1815" }
+ic-cdk = { version = "0.18.0" }
+ic-cdk-timers = { version = "0.12.0" }
+ic-cdk-macros = { version = "0.18.0" }
 ic-stable-structures = "0.6.8"
 dfn_core = { git = "https://github.com/dfinity/ic.git", rev = "2fe8aefafcb2fbee6fdb2785374d5de715560269" }
 rewards-calculation = { path = "rs/dre-canisters/node-provider-rewards/rewards-calculation" }

--- a/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
+++ b/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib"]
 async-trait = { workspace = true }
 chrono = { version = "0.4.41", default-features = false, features = [] }
 ic-canisters-http-types = { workspace = true }
-ic-cdk = { version = "0.18.0" }
-ic-cdk-timers = { version = "0.12.0" }
-ic-cdk-macros = { version = "0.18.0" }
+ic-cdk = { workspace = true }
+ic-cdk-timers = { workspace = true }
+ic-cdk-macros = { workspace = true }
 ic-stable-structures = { workspace = true }
 candid = { workspace = true }
 serde = { workspace = true }

--- a/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
+++ b/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib"]
 async-trait = { workspace = true }
 chrono = { version = "0.4.41", default-features = false, features = [] }
 ic-canisters-http-types = { workspace = true }
-ic-cdk = { workspace = true }
-ic-cdk-timers = { workspace = true }
-ic-cdk-macros = { workspace = true }
+ic-cdk = { version = "0.18.0" }
+ic-cdk-timers = { version = "0.12.0" }
+ic-cdk-macros = { version = "0.18.0" }
 ic-stable-structures = { workspace = true }
 candid = { workspace = true }
 serde = { workspace = true }
@@ -29,6 +29,8 @@ ic-management-canister-types-private = { workspace = true }
 ic-metrics-encoder = { workspace = true }
 ic-nervous-system-canisters = { workspace = true }
 ic-nervous-system-common = { workspace = true }
+ic-nns-constants = { workspace = true }
+ic-registry-transport = { workspace = true }
 ic-protobuf = { workspace = true }
 ic-registry-canister-client = { workspace = true }
 ic-types = { workspace = true }

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -194,7 +194,7 @@ fn post_upgrade() {
     setup_timers();
 }
 
-#[query]
+#[query(hidden = true)]
 fn http_request(request: HttpRequest) -> HttpResponse {
     match request.path() {
         "/metrics" => serve_metrics(|encoder| telemetry::PROMETHEUS_METRICS.with(|m| m.borrow().encode_metrics(encoder))),

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 mod metrics;
 mod metrics_types;
 mod registry;
+mod registry_canister;
 mod storage;
 mod telemetry;
 
@@ -160,10 +161,10 @@ fn setup_timers() {
         // It's 1AM since the canister was installed or upgraded.
         // Schedule a repeat timer to run sync_all() every 24 hours.
         // Sadly we ignore leap seconds here.
-        ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(DAY_IN_SECONDS), || ic_cdk::spawn(sync_all()));
+        ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(DAY_IN_SECONDS), || ic_cdk::futures::spawn(sync_all()));
 
         // Spawn a sync_all() right now.
-        ic_cdk::spawn(sync_all());
+        ic_cdk::futures::spawn(sync_all());
 
         // Hourly timers after first sync.
         ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(HOUR_IN_SECONDS), measure_get_node_providers_rewards_query);
@@ -176,7 +177,7 @@ fn setup_timers() {
     // Hourly timers.
     ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(HOUR_IN_SECONDS), || {
         // Retry subnets fetching every hour.
-        ic_cdk::spawn(async {
+        ic_cdk::futures::spawn(async {
             let metrics_manager = METRICS_MANAGER.with(|m| m.clone());
             metrics_manager.retry_failed_subnets().await;
         });
@@ -193,7 +194,7 @@ fn post_upgrade() {
     setup_timers();
 }
 
-#[query(hidden = true, decoding_quota = 10000)]
+#[query]
 fn http_request(request: HttpRequest) -> HttpResponse {
     match request.path() {
         "/metrics" => serve_metrics(|encoder| telemetry::PROMETHEUS_METRICS.with(|m| m.borrow().encode_metrics(encoder))),

--- a/rs/dre-canisters/node-provider-rewards/canister/src/metrics.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/metrics.rs
@@ -25,7 +25,6 @@ impl ManagementCanisterClient for ICCanisterClient {
     /// Queries the `node_metrics_history` endpoint of the management canisters of the subnet specified
     /// in the 'contract' to fetch daily node metrics.
     async fn node_metrics_history(&self, contract: NodeMetricsHistoryArgs) -> CallResult<Vec<NodeMetricsHistoryResponse>> {
-        // Call::bounded_wait(Principal::management_canister(), "node_metrics_history")
         let response = Call::bounded_wait(Principal::management_canister(), "node_metrics_history")
             .with_args(&(contract,))
             .await?

--- a/rs/dre-canisters/node-provider-rewards/canister/src/metrics.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/metrics.rs
@@ -2,7 +2,8 @@ use crate::metrics_types::{KeyRange, NodeMetricsDailyStored, SubnetIdKey, Subnet
 use async_trait::async_trait;
 use candid::Principal;
 use ic_base_types::SubnetId;
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::Call;
+use ic_cdk::call::CallResult;
 use ic_management_canister_types_private::{NodeMetricsHistoryArgs, NodeMetricsHistoryResponse};
 use ic_stable_structures::StableBTreeMap;
 use rewards_calculation::types::{NodeMetricsDailyRaw, SubnetMetricsDailyKey, UnixTsNanos};
@@ -13,7 +14,7 @@ pub type RetryCount = u64;
 
 #[async_trait]
 pub trait ManagementCanisterClient {
-    async fn node_metrics_history(&self, args: NodeMetricsHistoryArgs) -> CallResult<(Vec<NodeMetricsHistoryResponse>,)>;
+    async fn node_metrics_history(&self, args: NodeMetricsHistoryArgs) -> CallResult<Vec<NodeMetricsHistoryResponse>>;
 }
 
 /// Used to interact with remote Management canisters.
@@ -23,14 +24,14 @@ pub struct ICCanisterClient;
 impl ManagementCanisterClient for ICCanisterClient {
     /// Queries the `node_metrics_history` endpoint of the management canisters of the subnet specified
     /// in the 'contract' to fetch daily node metrics.
-    async fn node_metrics_history(&self, contract: NodeMetricsHistoryArgs) -> CallResult<(Vec<NodeMetricsHistoryResponse>,)> {
-        ic_cdk::api::call::call_with_payment128::<_, (Vec<NodeMetricsHistoryResponse>,)>(
-            Principal::management_canister(),
-            "node_metrics_history",
-            (contract,),
-            0_u128,
-        )
-        .await
+    async fn node_metrics_history(&self, contract: NodeMetricsHistoryArgs) -> CallResult<Vec<NodeMetricsHistoryResponse>> {
+        // Call::bounded_wait(Principal::management_canister(), "node_metrics_history")
+        let response = Call::bounded_wait(Principal::management_canister(), "node_metrics_history")
+            .with_args(&(contract,))
+            .await?
+            .candid::<Vec<NodeMetricsHistoryResponse>>()?;
+
+        Ok(response)
     }
 }
 
@@ -133,7 +134,7 @@ where
     async fn fetch_subnets_metrics(
         &self,
         last_timestamp_per_subnet: &BTreeMap<SubnetId, Option<UnixTsNanos>>,
-    ) -> BTreeMap<(SubnetId, Option<UnixTsNanos>), CallResult<(Vec<NodeMetricsHistoryResponse>,)>> {
+    ) -> BTreeMap<(SubnetId, Option<UnixTsNanos>), CallResult<Vec<NodeMetricsHistoryResponse>>> {
         let mut subnets_history = Vec::new();
 
         for (subnet_id, last_stored_ts) in last_timestamp_per_subnet {
@@ -174,7 +175,7 @@ where
         let subnets_metrics = self.fetch_subnets_metrics(&last_timestamp_per_subnet).await;
         for ((subnet_id, last_stored_ts), call_result) in subnets_metrics {
             match call_result {
-                Ok((subnet_update,)) => {
+                Ok(subnet_update) => {
                     if subnet_update.is_empty() {
                         ic_cdk::println!("No updates for subnet {}", subnet_id);
                     } else {
@@ -187,8 +188,8 @@ where
 
                     self.subnets_to_retry.borrow_mut().remove(&subnet_id.into());
                 }
-                Err((code, msg)) => {
-                    ic_cdk::println!("Error fetching metrics for subnet {}: CODE: {:?} MSG: {}", subnet_id, code, msg);
+                Err(e) => {
+                    ic_cdk::println!("Error fetching metrics for subnet {}: ERROR: {}", subnet_id, e);
 
                     // The call failed, will retry fetching metrics for this subnet.
                     let mut retry_count = self.subnets_to_retry.borrow().get(&subnet_id.into()).unwrap_or_default();

--- a/rs/dre-canisters/node-provider-rewards/canister/src/registry_canister.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/registry_canister.rs
@@ -1,0 +1,79 @@
+use async_trait::async_trait;
+use ic_base_types::{CanisterId, PrincipalId, RegistryVersion};
+use ic_cdk::call::{Call, CallErrorExt, CallFailed};
+use ic_nervous_system_canisters::registry::Registry;
+use ic_nervous_system_common::NervousSystemError;
+use ic_nns_constants::REGISTRY_CANISTER_ID;
+use ic_registry_transport::pb::v1::RegistryDelta;
+use ic_registry_transport::{deserialize_get_changes_since_response, deserialize_get_latest_version_response, serialize_get_changes_since_request};
+use std::future::Future;
+
+// TODO: Remove this when the RegistryCanister in the IC repo uses ic-cdk 0.18.0
+
+pub struct RegistryCanister {
+    canister_id: CanisterId,
+}
+
+impl RegistryCanister {
+    pub fn new() -> Self {
+        Self {
+            canister_id: REGISTRY_CANISTER_ID,
+        }
+    }
+
+    async fn execute_with_retries<F, Fut, Response>(&self, max_attempts: u8, call: F) -> Result<Response, NervousSystemError>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = Result<Response, CallFailed>>,
+    {
+        for _ in 0..max_attempts {
+            match call().await {
+                Ok(response) => return Ok(response),
+                Err(e) if e.is_immediately_retryable() => {
+                    continue;
+                }
+                Err(e) => {
+                    return Err(NervousSystemError::new_with_message(format!("Request failed with error: {e}")));
+                }
+            }
+        }
+
+        Err(NervousSystemError::new_with_message(format!(
+            "Request failed after {max_attempts} attempts"
+        )))
+    }
+}
+#[async_trait]
+impl Registry for RegistryCanister {
+    async fn get_latest_version(&self) -> Result<RegistryVersion, NervousSystemError> {
+        self.execute_with_retries(5, || async {
+            Call::bounded_wait(PrincipalId::from(self.canister_id).into(), "get_latest_version")
+                .with_raw_args(&[])
+                .await
+        })
+        .await
+        .and_then(|response| {
+            deserialize_get_latest_version_response(response.into_bytes())
+                .map_err(|e| NervousSystemError::new_with_message(format!("Could not decode response {e:?}")))
+                .map(RegistryVersion::new)
+        })
+    }
+
+    async fn registry_changes_since(&self, version: RegistryVersion) -> Result<Vec<RegistryDelta>, NervousSystemError> {
+        let bytes = serialize_get_changes_since_request(version.get()).map_err(|e| {
+            NervousSystemError::new_with_message(format!("Could not encode request for get_changes_since for version {:?}: {}", version, e))
+        })?;
+
+        self.execute_with_retries(5, || async {
+            Call::bounded_wait(PrincipalId::from(self.canister_id).into(), "get_changes_since")
+                .with_raw_args(&bytes)
+                .await
+        })
+        .await
+        .and_then(|response| {
+            deserialize_get_changes_since_response(response.into_bytes())
+                .map_err(|e| NervousSystemError::new_with_message(format!("Could not decode response {e:?}")))
+                .map(|(deltas, _)| deltas)
+        })
+    }
+}

--- a/rs/dre-canisters/node-provider-rewards/canister/src/storage.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::metrics::{ICCanisterClient, MetricsManager};
 use crate::registry::RegistryClient;
-use ic_nervous_system_canisters::registry::RegistryCanister;
+use crate::registry_canister::RegistryCanister;
 use ic_registry_canister_client::{RegistryDataStableMemory, StableCanisterRegistryClient, StorableRegistryKey, StorableRegistryValue};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap, Storable};


### PR DESCRIPTION
Changes:

- Bump `ic-cdk `dep to 0.18 (where bounded calls are supported)
- Adapt metrics fetching to use bounded calls
- Adapt tests 
- Introducing `RegistryClient` to query registry using bounded calls

TODO:

- Remove `RegistryClient` once `RegistryClient` in IC repo depends on `ic-cdk 0.18`