### PR TITLE
Manual annotation mode for commit annotator.

### DIFF
--- a/release-controller/commit_annotation.py
+++ b/release-controller/commit_annotation.py
@@ -1,5 +1,6 @@
 import collections
 import logging
+import os
 import pathlib
 import subprocess
 import typing
@@ -125,6 +126,8 @@ class GitRepoAnnotator(object):
 
     def push(self) -> None:
         if self.changed:
+            env = os.environ.copy()
+            env["GIT_TERMINAL_PROMPT"] = "0"
             for namespace in self.namespaces:
                 check_call(
                     [
@@ -135,6 +138,7 @@ class GitRepoAnnotator(object):
                         "-f",
                         "--quiet",
                     ],
+                    env=env,
                     cwd=self.dir,
                 )
 

--- a/release-controller/commit_annotator.py
+++ b/release-controller/commit_annotator.py
@@ -24,7 +24,7 @@ from commit_annotation import (
 )
 from git_repo import GitRepo
 from datetime import datetime
-from util import conventional_logging, resolve_binary
+from util import conventional_logging, resolve_binary, DefaultSubcommandArgParser
 from watchdog import Watchdog
 
 from const import (
@@ -296,7 +296,9 @@ def annotate_commits_of_branch(
             unannotated_commits = unannotated_commits - 1
             COMMITS_BEHIND.labels(branch).set(unannotated_commits)
             watchdog.report_healthy()
-        logger.info("Successfully annotated %s commits", len(commits_from_newest_to_oldest))
+        logger.info(
+            "Successfully annotated %s commits", len(commits_from_newest_to_oldest)
+        )
     else:
         COMMITS_BEHIND.labels(branch).set(0)
 
@@ -359,41 +361,62 @@ def start_api_server(annotator: GitRepoAnnotator, port: int) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
+    parser = DefaultSubcommandArgParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument(
-        "--no-push-annotations",
-        action="store_false",
-        dest="push_annotations",
-        help="The default is to push annotations to remote server.  This option turns it off.",
-    )
-    parser.add_argument(
+    ann_behavior = parser.add_argument_group(title="Annotation behavior")
+    ann_behavior.add_argument(
         "--no-save-annotations",
         action="store_false",
         dest="save_annotations",
         help="The default is to save annotations locally.  This option turns it off.  The upside is that, on every loop, the annotator attempts to re-annotate the same commits it had annotated before.",
     )
-    parser.add_argument(
+    ann_behavior.add_argument(
         "--no-fetch-annotations",
         action="store_false",
         dest="fetch_annotations",
         help="The default is to fetch annotations from the repository on every loop, overwriting local annotations. This option turns off that behavior.",
     )
-    parser.add_argument(
+    ann_behavior.add_argument(
+        "--no-push-annotations",
+        action="store_false",
+        dest="push_annotations",
+        help="The default is to push annotations to remote server.  This option turns it off.",
+    )
+    ann_behavior.add_argument(
+        "--github-token",
+        action="store_true",
+        dest="github_token",
+        default=None,
+        help="Which Github token to use in order to push annotations (defaults to the contents"
+        " of the GITHUB_TOKEN environment variable).  Not necessary, but if unset, specify"
+        " --no-push-annotations to skip pushing.",
+    )
+    logging_opts = parser.add_argument_group(title="Logging options")
+    logging_opts.add_argument(
         "--verbose",
         "--debug",
         action="store_true",
         dest="verbose",
         help="Bump log level.",
     )
-    parser.add_argument(
+    logging_opts.add_argument(
         "--one-line-logs",
         action="store_true",
         dest="one_line_logs",
         help="Make log lines one-line without timestamps (useful in production container for better filtering).",
     )
-    parser.add_argument(
+    subparsers = parser.add_subparsers(
+        title="This program supports several subcommands", dest="cmd"
+    )
+    run_opts = subparsers.add_parser(
+        "run",
+        help=(
+            "Run the annotator in service mode (the default).  See run --help"
+            " for options influencing the behavior of the annotator service"
+        ),
+    )
+    run_opts.add_argument(
         "--loop-every",
         action="store",
         type=int,
@@ -401,7 +424,7 @@ def main() -> None:
         default=30,
         help="Time to wait (in seconds) between loop executions.  If 0 or less, exit immediately after the first loop.",
     )
-    parser.add_argument(
+    run_opts.add_argument(
         "--watchdog-timer",
         action="store",
         type=int,
@@ -409,44 +432,74 @@ def main() -> None:
         default=1200,
         help="Kill the annotator if a loop has not completed in this many seconds.",
     )
-    parser.add_argument(
+    run_opts.add_argument(
         "--branch-globs",
         default="master,rc--*",
         type=str,
         dest="branch_globs",
         help="Use this branch glob (or comma-separated list of globs) to determine which branches to annotate.",
     )
-    parser.add_argument(
+    run_opts.add_argument(
         "--skip-branch-older-than",
         default=20,
         type=int,
         dest="max_branch_age_days",
         help="Skip annotating branches older than this value (in days).",
     )
-    parser.add_argument(
+    run_opts.add_argument(
         "--max-commit-depth",
         default=500,
         type=int,
         dest="max_commit_depth",
         help="Maximum number of commits to annotate starting from each branch and going back.",
     )
-    parser.add_argument(
+    run_opts.add_argument(
         "--api-port",
         type=int,
         dest="api_port",
         default=9469,
         help="Port for API service to retrieve annotations.  Only served if --loop-every is greater than 0.  Disabled if less than 1.",
     )
-    parser.add_argument(
+    run_opts.add_argument(
         "--telemetry-port",
         type=int,
         dest="telemetry_port",
         default=9468,
         help="Set the Prometheus telemetry port to listen on.  Telemetry is only served if --loop-every is greater than 0.  Disabled if less than 1.",
     )
+    manual_annotation_opts = subparsers.add_parser(
+        "manually-annotate",
+        help=(
+            "Annotate a commit ID as either affecting HostOS/GuestOS (see flag --os-kind)"
+            " or not affecting it.  This option takes two arguments: the commit ID followed"
+            " by a boolean indicating whether the commit ID affects the OS specified.  Use"
+            " of this option suppresses the execution of the normal annotation loop, and"
+            " conflicts with most other options intended to be used in it (general options"
+            " like --verbose or --no-push-annotations are honored)."
+            " If pushing annotations is desired (the default) then ensure to set a"
+            " --github-token with write access to the IC repository."
+        ),
+    )
+    manual_annotation_opts.add_argument(
+        "--os-kind",
+        help="Which OS kind to manually annotate this commit for (one of %s, default all)."
+        % OS_KINDS,
+        choices=OS_KINDS,
+    )
+    manual_annotation_opts.add_argument(
+        "COMMIT_ID",
+        help="The commit ID to annotate.",
+        type=str,
+    )
+    manual_annotation_opts.add_argument(
+        "AFFECTED",
+        help="Whether the commit ID is affected.",
+        choices=["yes", "no"],
+    )
+    parser.set_default_subparser("run")
     opts = parser.parse_args()
 
-    github_token = os.getenv("GITHUB_TOKEN", None)
+    github_token = opts.github_token or os.getenv("GITHUB_TOKEN", None)
     github_org = os.getenv("GITHUB_ORG", "dfinity")
     creds = f"oauth2:{github_token}@" if github_token else ""
 
@@ -464,103 +517,157 @@ def main() -> None:
         opts.save_annotations,
     )
 
-    # Watchdog needs to be fed (to report healthy progress) every watchdog_timer seconds
-    watchdog = Watchdog(timeout_seconds=opts.watchdog_timer)
-    watchdog.start()
-
     logger = _LOGGER.getChild("annotator")
-    branch_globs = opts.branch_globs.split(",")
 
-    if opts.loop_every > 0:
-        if int(opts.telemetry_port) > 0:
-            start_http_server(port=int(opts.telemetry_port))
-        if int(opts.api_port) > 0:
-            start_api_server(annotator, port=int(opts.api_port))
+    if opts.cmd == "run":
+        branch_globs = opts.branch_globs.split(",")
+        # Watchdog needs to be fed (to report healthy progress) every watchdog_timer seconds
+        watchdog = Watchdog(timeout_seconds=opts.watchdog_timer)
+        watchdog.start()
 
-    while True:
-        try:
-            now = time.time()
-            LAST_CYCLE_START_TIMESTAMP_SECONDS.set(int(now))
-            ic_repo.fetch()
+        if opts.loop_every > 0:
+            if int(opts.telemetry_port) > 0:
+                start_http_server(port=int(opts.telemetry_port))
+            if int(opts.api_port) > 0:
+                start_api_server(annotator, port=int(opts.api_port))
 
-            if opts.fetch_annotations:
-                annotator.fetch()
+        while True:
+            try:
+                now = time.time()
+                LAST_CYCLE_START_TIMESTAMP_SECONDS.set(int(now))
+                ic_repo.fetch()
 
-            # Performance optimization to avoid calling git notes on every
-            # commit once per branch.  Should only need to call it once.
-            commits_to_annotate: dict[OsKind, set[str]] = {k: set() for k in OS_KINDS}
-            unannotated_commits_by_ref: dict[str, dict[OsKind, list[str]]] = {}
-            for b in [
-                branch for glob in branch_globs for branch in ic_repo.branch_list(glob)
-            ]:
-                # if b is a directly-specified branch instead of a glob
-                # then assume the date is "now" rather than fool around
-                # with trying to determine the branch date.
-                branch_date = (
-                    datetime.now() if b in branch_globs else release_branch_date(b)
-                )
-                if (
-                    not branch_date
-                    or (datetime.now() - branch_date).days > opts.max_branch_age_days
-                ):
-                    logger.debug(
-                        "Ignoring branch as older than %s days: %s",
-                        opts.max_branch_age_days,
-                        b,
+                if opts.fetch_annotations:
+                    annotator.fetch()
+
+                # Performance optimization to avoid calling git notes on every
+                # commit once per branch.  Should only need to call it once.
+                commits_to_annotate: dict[OsKind, set[str]] = {
+                    k: set() for k in OS_KINDS
+                }
+                unannotated_commits_by_ref: dict[str, dict[OsKind, list[str]]] = {}
+                for b in [
+                    branch
+                    for glob in branch_globs
+                    for branch in ic_repo.branch_list(glob)
+                ]:
+                    # if b is a directly-specified branch instead of a glob
+                    # then assume the date is "now" rather than fool around
+                    # with trying to determine the branch date.
+                    branch_date = (
+                        datetime.now() if b in branch_globs else release_branch_date(b)
                     )
-                    continue
-                outstanding_commits = plan_to_annotate_branch(
-                    annotator,
-                    branch=b,
-                    skip_checking_commits=commits_to_annotate,
-                    max_commit_depth=opts.max_commit_depth,
-                )
-                unannotated_commits_by_ref[b] = outstanding_commits
-                for k, v in commits_to_annotate.items():
-                    v.update(outstanding_commits[k])
-            # Make a little cache for this loop's run, saving time not invoking
-            # the annotation for a simgle commit twice.  Git history of different
-            # branches often shares commits in both branches.
-            annotated_commits: dict[OsKind, set[str]] = {k: set() for k in OS_KINDS}
-            for b, kinds_and_commits in unannotated_commits_by_ref.items():
-                # Remove any commits already annotated so as to not waste time,
-                # but preserve the ordering since that seems (to me) to matter.
-                for kind, outstanding_commits_by_kind in kinds_and_commits.items():
-                    tbd = [
-                        c
-                        for c in outstanding_commits_by_kind
-                        if c not in annotated_commits[kind]
-                    ]
-                    annotate_commits_of_branch(annotator, b, tbd, kind, watchdog, opts.push_annotations)
-                    # Remember these were annotated, avoid wasting time next loop.
-                    annotated_commits[kind].update(tbd)
+                    if (
+                        not branch_date
+                        or (datetime.now() - branch_date).days
+                        > opts.max_branch_age_days
+                    ):
+                        logger.debug(
+                            "Ignoring branch as older than %s days: %s",
+                            opts.max_branch_age_days,
+                            b,
+                        )
+                        continue
+                    outstanding_commits = plan_to_annotate_branch(
+                        annotator,
+                        branch=b,
+                        skip_checking_commits=commits_to_annotate,
+                        max_commit_depth=opts.max_commit_depth,
+                    )
+                    unannotated_commits_by_ref[b] = outstanding_commits
+                    for k, v in commits_to_annotate.items():
+                        v.update(outstanding_commits[k])
+                # Make a little cache for this loop's run, saving time not invoking
+                # the annotation for a simgle commit twice.  Git history of different
+                # branches often shares commits in both branches.
+                annotated_commits: dict[OsKind, set[str]] = {k: set() for k in OS_KINDS}
+                for b, kinds_and_commits in unannotated_commits_by_ref.items():
+                    # Remove any commits already annotated so as to not waste time,
+                    # but preserve the ordering since that seems (to me) to matter.
+                    for kind, outstanding_commits_by_kind in kinds_and_commits.items():
+                        tbd = [
+                            c
+                            for c in outstanding_commits_by_kind
+                            if c not in annotated_commits[kind]
+                        ]
+                        annotate_commits_of_branch(
+                            annotator, b, tbd, kind, watchdog, opts.push_annotations
+                        )
+                        # Remember these were annotated, avoid wasting time next loop.
+                        annotated_commits[kind].update(tbd)
 
-            and_now = time.time()
-            LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS.set(int(and_now))
-            LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
-            LAST_CYCLE_SUCCESSFUL.set(1)
-            watchdog.report_healthy()
-            if opts.loop_every <= 0:
-                break
-            else:
-                sleepytime = opts.loop_every - (time.time() - now)
-                if sleepytime > 0.0:
-                    time.sleep(sleepytime)
-        except KeyboardInterrupt:
-            logger.info("Interrupted.")
-            raise
-        except Exception:
-            if opts.loop_every <= 0:
-                raise
-            else:
-                watchdog.report_healthy()
                 and_now = time.time()
+                LAST_CYCLE_SUCCESS_TIMESTAMP_SECONDS.set(int(and_now))
                 LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
-                LAST_CYCLE_SUCCESSFUL.set(0)
-                logger.exception(
-                    f"Failed to annotate.  Retrying in {opts.loop_every} seconds.  Traceback:"
-                )
-                time.sleep(opts.loop_every)
+                LAST_CYCLE_SUCCESSFUL.set(1)
+                watchdog.report_healthy()
+                if opts.loop_every <= 0:
+                    break
+                else:
+                    sleepytime = opts.loop_every - (time.time() - now)
+                    if sleepytime > 0.0:
+                        time.sleep(sleepytime)
+            except KeyboardInterrupt:
+                logger.info("Interrupted.")
+                raise
+            except Exception:
+                if opts.loop_every <= 0:
+                    raise
+                else:
+                    watchdog.report_healthy()
+                    and_now = time.time()
+                    LAST_CYCLE_END_TIMESTAMP_SECONDS.set(int(and_now))
+                    LAST_CYCLE_SUCCESSFUL.set(0)
+                    logger.exception(
+                        f"Failed to annotate.  Retrying in {opts.loop_every} seconds.  Traceback:"
+                    )
+                    time.sleep(opts.loop_every)
+    elif opts.cmd == "manually-annotate":
+        ic_repo.fetch()
+        if opts.fetch_annotations:
+            logger.info("Fetching annotations in preparation for manual annotation.")
+            annotator.fetch()
+        else:
+            logger.warning(
+                "Not fetching annotations per request.  This may"
+                " cause push to fail if/when push is attempted."
+            )
+
+        os_kinds = [opts.os_kind] if opts.os_kind else OS_KINDS
+        commit_id = opts.COMMIT_ID
+        affected = True if opts.AFFECTED == "yes" else False
+        for os_kind in os_kinds:
+            val = COMMIT_BELONGS if affected else COMMIT_DOES_NOT_BELONG
+            logger.info(
+                "Manually annotating %s at commit %s as %s (%r) by the commit.",
+                os_kind,
+                commit_id,
+                "affected" if affected else "not affected",
+                val,
+            )
+            annotator.checkout(commit_id)
+            annotator.add(
+                object=commit_id,
+                namespace=TARGETS_NOTES_NAMESPACES[os_kind],
+                content="# This commit was manually annotated by commit-annotator manually-annotate command.",
+            )
+            annotator.add(
+                object=commit_id,
+                namespace=CHANGED_NOTES_NAMESPACES[os_kind],
+                content=val,
+            )
+            if opts.push_annotations:
+                if not github_token:
+                    logger.warning(
+                        "About to push annotations, but no --github-token set.  This may fail or hang!"
+                    )
+                # Eagerly push each successful annotation to ensure that
+                # the commit annotator can continue where it left off upon restart,
+                # and also to ensure that manual interventions such as annotations
+                # by a person don't end up having to be "annotate a whole branch worth
+                # of commits" kinda work.
+                logger.info("Pushing annotations after manual commit annotation.")
+                annotator.push()
 
 
 if __name__ == "__main__":

--- a/release-controller/git_repo.py
+++ b/release-controller/git_repo.py
@@ -403,6 +403,8 @@ class GitRepo:
                 _LOGGER.info(
                     "RC %s: pushing tag %s to the origin", release.rc_name, tag
                 )
+                env = os.environ.copy()
+                env["GIT_TERMINAL_PROMPT"] = "0"
                 check_call(
                     [
                         "git",
@@ -413,6 +415,7 @@ class GitRepo:
                         "-f",
                     ],
                     cwd=self.dir,
+                    env=env,
                 )
 
 


### PR DESCRIPTION
You can now run:

```bash
bazel run //release-controller:commit-annotator -- manually-annotate COMMIT_ID yes/no [--os-kind GuestOS/HostOS]
```

to manually annotate a commit as affecting a specific OS kind (or both, if left out).

Useful to help the commit annotator "get over a hump" when a commit pushed to the IC repo cannot be built by Bazel.