### PR TITLE
Instant synchronization feature.

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "93eb173474b738829386a93aa1c4fe928fa11cc79c0e225995cf6a3c621f2f5c",
+  "checksum": "5a594c10fdeada9c26d1d74018cd82f7bf918f006aa356d441cb390d5e5192f2",
   "crates": {
     "actix-codec 0.5.2": {
       "name": "actix-codec",

--- a/rs/dre-canisters/node-provider-rewards/canister/BUILD.bazel
+++ b/rs/dre-canisters/node-provider-rewards/canister/BUILD.bazel
@@ -43,6 +43,23 @@ rust_library(
        ) + [":build_script"],
 )
 
+rust_library(
+    name = "node_provider_rewards_canister_instant_sync",
+    srcs = glob(["src/**/*.rs"]),
+    aliases = ALIASES,
+    crate_name = "node_provider_rewards_canister",
+    crate_features = [
+        "instant-sync"
+    ],
+    proc_macro_deps = all_crate_deps(
+           proc_macro = True,
+       ),
+    version = "0.9.0",
+    deps = DEPS + all_crate_deps(
+           normal = True,
+       ) + [":build_script"],
+)
+
 rust_test(
     name = "npr_test",
     crate = ":node_provider_rewards_canister",

--- a/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
+++ b/rs/dre-canisters/node-provider-rewards/canister/Cargo.toml
@@ -7,6 +7,9 @@ description.workspace = true
 documentation.workspace = true
 license.workspace = true
 
+[features]
+instant-sync = []
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
+++ b/rs/dre-canisters/node-provider-rewards/canister/src/lib.rs
@@ -173,16 +173,17 @@ fn setup_timers() {
         ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(DAY_IN_SECONDS), || ic_cdk::futures::spawn(sync_all()));
 
         // Spawn a sync_all() right now.
-        ic_cdk::futures::spawn(sync_all());
-
-        #[cfg(feature = "instant-sync")]
-        {
-            let in_15_seconds = std::time::Duration::from_secs(15);
-            ic_cdk_timers::set_timer(in_15_seconds, || measure_get_node_providers_rewards_query());
-            for np in NODE_PROVIDERS_USED_DURING_CALCULATION_MEASUREMENT {
-                ic_cdk_timers::set_timer(in_15_seconds, || measure_get_node_provider_rewards_calculation_query(np));
+        ic_cdk::futures::spawn(async {
+            sync_all().await;
+            #[cfg(feature = "instant-sync")]
+            {
+                let in_1_second = std::time::Duration::from_secs(1);
+                ic_cdk_timers::set_timer(in_1_second, || measure_get_node_providers_rewards_query());
+                for np in NODE_PROVIDERS_USED_DURING_CALCULATION_MEASUREMENT {
+                    ic_cdk_timers::set_timer(in_1_second, || measure_get_node_provider_rewards_calculation_query(np));
+                }
             }
-        }
+        });
 
         // Hourly timers after first sync.  One for rewards query, and N for rewards calculation query.
         ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(HOUR_IN_SECONDS), measure_get_node_providers_rewards_query);


### PR DESCRIPTION
This is an optional feature!

When the canister built with this feature is implemented, sync_all runs right away (3 seconds after start) and 1 second after sync_all, metrics are measured right away too.