### PR TITLE
Release controller fixes

### DIFF
--- a/release-controller/BUILD.bazel
+++ b/release-controller/BUILD.bazel
@@ -124,6 +124,13 @@ py_library (
 )
 
 py_library (
+    name = "public_dashboard",
+    srcs = ["public_dashboard.py"],
+    deps = ["const", "dre_cli", requirement("requests")],
+    tags = ["typecheck"],
+)
+
+py_library (
     name = "watchdog",
     srcs = ["watchdog.py"],
     tags = ["typecheck"],
@@ -174,7 +181,7 @@ py_binary(
     main = "reconciler.py",
     srcs = ["reconciler.py", "slack_announce.py"],
     tags = ["typecheck"],
-    deps = ["dre_cli", "publish_notes", "forum", "watchdog", "prometheus", "release_notes_composer", "release_index_loader", "dryrun"] + [
+    deps = ["dre_cli", "public_dashboard", "publish_notes", "forum", "watchdog", "prometheus", "release_notes_composer", "release_index_loader", "dryrun"] + [
         requirement("pydiscourse"),
         requirement("requests"),
         requirement("types-requests"),

--- a/release-controller/public_dashboard.py
+++ b/release-controller/public_dashboard.py
@@ -1,0 +1,68 @@
+import dre_cli
+import logging
+import requests
+import typing
+
+
+LOGGER = logging.getLogger(__name__)
+URL = "https://ic-api.internetcomputer.org/api/v3"
+
+
+class DashboardAPI:
+    def __init__(self) -> None:
+        self._logger = LOGGER.getChild(self.__class__.__name__)
+
+    def get_past_election_proposals(self) -> list[dre_cli.ElectionProposal]:
+        """Get 50 GuestOS / HostOS election proposals known to the dashboard."""
+        r = requests.get(
+            URL + "/proposals?limit=50&include_topic=TOPIC_IC_OS_VERSION_ELECTION"
+        )
+        r.raise_for_status()
+        props = r.json()["data"]
+        proplist: list[dre_cli.ElectionProposal] = []
+
+        for prop in props:
+            prop["proposer"] = int(prop["proposer"])
+            prop["id"] = prop["proposal_id"]
+            del prop["proposal_id"]
+            proplist.append(typing.cast(dre_cli.ElectionProposal, prop))
+        return proplist
+
+    def get_election_proposals_by_version(
+        self,
+    ) -> tuple[
+        dict[str, dre_cli.ElectionProposal], dict[str, dre_cli.ElectionProposal]
+    ]:
+        """
+        Get IC OS election proposals in two separate dictionaries keyed
+        by version -- the first dictionary contains GuestOS proposals, and
+        the second contains HostOS proposals."""
+
+        d: dict[str, dre_cli.ElectionProposal] = {}
+        od: dict[str, dre_cli.ElectionProposal] = {}
+        known_proposals = self.get_past_election_proposals()
+        for proposal in known_proposals:
+            for proposal in known_proposals:
+                payload = proposal["payload"]
+                if "replica_version_to_elect" in payload:
+                    replica_version = typing.cast(
+                        dre_cli.GuestosElectionProposalPayload, payload
+                    ).get("replica_version_to_elect")
+                    if not replica_version:
+                        continue
+                    d[replica_version] = proposal
+                if "hostos_version_to_elect" in payload:
+                    hostos_version = typing.cast(
+                        dre_cli.HostosElectionProposalPayload, payload
+                    ).get("hostos_version_to_elect")
+                    if not hostos_version:
+                        continue
+                    od[hostos_version] = proposal
+        return d, od
+
+
+if __name__ == "__main__":
+    cli = DashboardAPI()
+    import json
+
+    print(json.dumps(cli.get_past_election_proposals()))

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -434,8 +434,9 @@ class Reconciler:
             raise
 
         # As a matter of principle, we will only process the very top
-        # release (and all its versions).
-        releases = index.root.releases[:1]
+        # two releases (and all its versions).  All else will be
+        # assumed to have been prepared before.
+        releases = index.root.releases[:2]
         # Remove ignored releases from list to process.
         releases = [r for r in releases if r.rc_name not in self.ignore_releases]
 

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -576,7 +576,7 @@ class Reconciler:
 
             needs_announce = False
 
-            with phase("release notes preparation") as p:
+            with phase("release notes preparation"):
                 if markdown_file := self.notes_client.markdown_file(
                     release_commit, v.os_kind
                 ):

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -652,7 +652,11 @@ class Reconciler:
                     try:
                         checksum = version_package_checksum(release_commit, v.os_kind)
                     except requests.exceptions.HTTPError as e:
-                        if e.response.status_code == 404:
+                        if (
+                            hasattr(e, "response")
+                            and e.response is not None
+                            and e.response.status_code == 404
+                        ):
                             phase.incomplete()
                             revlogger.warning(
                                 "Proposal cannot be placed because one of the URLs"
@@ -661,6 +665,7 @@ class Reconciler:
                                 " all the URLs required for the proposal."
                             )
                             continue
+                        raise
 
                     urls = version_package_urls(release_commit, v.os_kind)
                     unelect_versions = []

--- a/release-controller/release_index_loader.py
+++ b/release-controller/release_index_loader.py
@@ -100,7 +100,12 @@ class DevReleaseLoader(ReleaseLoader):
     """Load release information from the current git repository."""
 
     def __init__(self, path: str) -> None:
-        """Create a new DevReleaseLoader."""
+        """
+        Create a new DevReleaseLoader.
+
+        Args:
+            path (str): The filesystem path to a local git repository.
+        """
         super().__init__(pathlib.Path(path))
 
 

--- a/release-controller/release_index_loader.py
+++ b/release-controller/release_index_loader.py
@@ -1,8 +1,6 @@
 import logging
 import pathlib
 import re
-import subprocess
-import sys
 import tempfile
 
 import release_index
@@ -101,18 +99,9 @@ class ReleaseLoader:
 class DevReleaseLoader(ReleaseLoader):
     """Load release information from the current git repository."""
 
-    def __init__(self) -> None:
+    def __init__(self, path: str) -> None:
         """Create a new DevReleaseLoader."""
-        dev_repo_root = (
-            subprocess.check_output(
-                ["git", "rev-parse", "--show-toplevel"], stderr=subprocess.DEVNULL
-            )
-            .decode(sys.stdout.encoding)
-            .strip()
-        )
-        if not dev_repo_root:
-            raise RuntimeError("Not running in a dev environment")
-        super().__init__(pathlib.Path(dev_repo_root))
+        super().__init__(pathlib.Path(path))
 
 
 class GitReleaseLoader(ReleaseLoader):

--- a/release-controller/tests/test_reconciler.py
+++ b/release-controller/tests/test_reconciler.py
@@ -17,6 +17,8 @@ from reconciler import Reconciler
 from reconciler_state import ReconcilerState
 from reconciler import version_package_checksum
 from reconciler import versions_to_unelect
+from public_dashboard import DashboardAPI
+from dre_cli import ElectionProposal
 from release_index_loader import StaticReleaseLoader
 
 from tests.fixtures import ic_repo as ic_repo
@@ -27,6 +29,41 @@ class AmnesiacReconcilerState(ReconcilerState):
 
     def __init__(self) -> None:
         super().__init__()
+
+
+class MockDashboard(DashboardAPI):
+    """Reconciler state that uses static proposal data."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_past_election_proposals(self) -> list[ElectionProposal]:
+        return [
+            {
+                "id": 136070,
+                "payload": {
+                    "hostos_version_to_elect": "68fc31a141b25f842f078c600168d8211339f422",
+                    "release_package_sha256_hex": "9a2600d06c6e6ed15eb3f061ed024b9e3b9f355b9f81e198457dd9cf86eb19d4",
+                },
+                "proposal_timestamp_seconds": 1743789296,
+                "proposer": 61,
+                "status": "EXECUTED",
+                "summary": "Elect new HostOS binary revision [68fc31a141b25f842f078c600168d8211339f422](https://github.com/dfinity/ic/tree/release-2025-04-03_03-15-base)\nStubbed out.",
+                "title": "Elect new IC/Hostos revision (commit 68fc31a1), and retire old replica version ec140b74",
+            },
+            {
+                "payload": {
+                    "release_package_sha256_hex": "c6857ecf2ab737850ff4aa4445bf57417d5fb302c00117bfb3b8ba3d1bde41b8",
+                    "replica_version_to_elect": "34e659ec3272fa2d884f48cb8229140e512f7f5e",
+                },
+                "proposal_timestamp_seconds": 1731672225,
+                "proposer": 1730676817598423123,
+                "id": 134187,
+                "status": "EXECUTED",
+                "summary": "Release Notes for [**release\\-2024\\-11\\-14\\_03\\-07\\-6\\.11\\-kernel**](https://github.com/dfinity/ic/tree/release-2024-11-14_03-07-6.11-kernel) (34e659ec3272fa2d884f48cb8229140e512f7f5e)\nStubbed out",
+                "title": "Elect new IC/Replica revision (commit 34e659e)",
+            },
+        ]
 
 
 class MockActiveVersionProvider(object):
@@ -87,6 +124,7 @@ releases:
         ignore_releases=[""],
         active_version_provider=MockActiveVersionProvider(),
         dre=dre,
+        dashboard=MockDashboard(),
         slack_announcer=slack_announcer,
     )
 

--- a/release-index-schema.json
+++ b/release-index-schema.json
@@ -13,7 +13,9 @@
           }
         }
       },
-      "required": ["releases"],
+      "required": [
+        "releases"
+      ],
       "title": "ReleaseIndex"
     },
     "Release": {
@@ -30,7 +32,10 @@
           }
         }
       },
-      "required": ["rc_name", "versions"],
+      "required": [
+        "rc_name",
+        "versions"
+      ],
       "title": "Release"
     },
     "Version": {
@@ -45,10 +50,49 @@
         },
         "security_fix": {
           "type": "boolean"
+        },
+        "changelog_base": {
+          "type": "object",
+          "$ref": "#/definitions/ChangelogBaseForVariants"
         }
       },
-      "required": ["name", "version"],
+      "required": [
+        "name",
+        "version"
+      ],
       "title": "Version"
+    },
+    "ChangelogBaseForVariants": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "HostOS": {
+          "type": "object",
+          "$ref": "#/definitions/ChangelogBase"
+        },
+        "GuestOS": {
+          "type": "object",
+          "$ref": "#/definitions/ChangelogBase"
+        }
+      },
+      "title": "ChangelogBaseForVariants"
+    },
+    "ChangelogBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rc_name": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "rc_name",
+        "name"
+      ],
+      "title": "ChangelogBase"
     }
   }
 }

--- a/release-index.yaml
+++ b/release-index.yaml
@@ -1,5 +1,22 @@
 releases:
   # NOTE: Make sure to mark security hotfixes with the `security_fix: true` flag.
+  #
+  # To override the automatic selection of a base release for the purposes of
+  # changelog, add a changelog_base dictionary to a version.  The changelog_base
+  # dictionary may contain keys HostOS and/or GuestOS.  The value for each one
+  # of those keys is always a dictionary with rc_name (refers to another RC name
+  # in this file) and name (refers to the name of a version within that RC).
+  #
+  # Example:
+  # - rc_name: rc--2025-05-23_03-21
+  #   versions:
+  #     - name: base
+  #       version: 16825c5cbff83a51983d849b60c9d26b3268bbb6
+  #       changelog_base:
+  #         GuestOS:
+  #           rc_name: rc--2025-05-01_03-23
+  #           name: base
+
   - rc_name: rc--2025-05-23_03-21
     versions:
       - name: base

--- a/rs/cli/src/commands/proposals/filter.rs
+++ b/rs/cli/src/commands/proposals/filter.rs
@@ -284,6 +284,7 @@ impl ExecutableCommand for Filter {
                 include_all_manage_neuron_proposals: Some(true),
                 ..Default::default()
             };
+            info!("{:?}", payload);
 
             if current_batch.len() > remaining as usize {
                 let current_batch = current_batch.into_iter().take(remaining as usize).collect_vec();

--- a/rs/cli/src/commands/proposals/filter.rs
+++ b/rs/cli/src/commands/proposals/filter.rs
@@ -284,7 +284,6 @@ impl ExecutableCommand for Filter {
                 include_all_manage_neuron_proposals: Some(true),
                 ..Default::default()
             };
-            info!("{:?}", payload);
 
             if current_batch.len() > remaining as usize {
                 let current_batch = current_batch.into_iter().take(remaining as usize).collect_vec();


### PR DESCRIPTION
* Process for proposal creation only latest two release.
* Handle potential errors fetching the image packages better.
* Allow override of the base version used for the changelog in the index.
* Consult dashboard API (optionally) to obtain latest proposals, and thus prevent resubmission of versions already submitted in the past.  The option to disable this behavior has been removed.