### PR TITLE
refactor(cli): rename update-authorized-subnets to update-default-subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dre get            # Wrapper around ic-admin get-* commands
 dre propose        # Wrapper around ic-admin propose-* commands
 dre firewall       # Submitting proposals for firewall updates
 dre node-metrics   # Getting the trustworthy node metrics
-dre update-authorized-subnets  # Automatically updating the list of public IC subnets, based on subnet utilization
+dre update-default-subnets  # Automatically updating the list of default (public) IC subnets, based on subnet utilization
 dre neuron         # Neuron topping up and checking balance
 ```
 

--- a/facts-db/non_default_subnets.csv
+++ b/facts-db/non_default_subnets.csv
@@ -2,4 +2,3 @@ subnet id,description
 x33ed,SNS subnet
 bkfrj,European subnet
 pzp6e,Fiduciary subnet
-shefu,Distrikt subnet cannot be public before migrating away from ICQC

--- a/facts-db/non_public_subnets.csv
+++ b/facts-db/non_public_subnets.csv
@@ -1,5 +1,0 @@
-subnet id,description
-x33ed,SNS subnet
-bkfrj,European subnet
-pzp6e,Fiduciary subnet
-shefu,Distrikt subnet cannot be public before migrating away from ICQC

--- a/rs/cli/src/commands/main_command.rs
+++ b/rs/cli/src/commands/main_command.rs
@@ -12,7 +12,7 @@ use super::proposals::Proposals;
 use super::propose::Propose;
 use super::qualify::Qualify;
 use super::registry::Registry;
-use super::update_authorized_subnets::UpdateAuthorizedSubnets;
+use super::update_default_subnets::UpdateDefaultSubnets;
 use super::update_unassigned_nodes::UpdateUnassignedNodes;
 use super::upgrade::Upgrade;
 use super::version::Version;
@@ -33,7 +33,7 @@ pub struct MainCommand {
     pub subcommands: Subcommands,
 }
 
-impl_executable_command_for_enums! { MainCommand, DerToPrincipal, Network, Subnet, Get, Propose, UpdateUnassignedNodes, Version, NodeMetrics, HostOs, Nodes, ApiBoundaryNodes, Vote, Registry, Firewall, Upgrade, Proposals, Completions, Qualify, UpdateAuthorizedSubnets, Neuron, Governance }
+impl_executable_command_for_enums! { MainCommand, DerToPrincipal, Network, Subnet, Get, Propose, UpdateUnassignedNodes, Version, NodeMetrics, HostOs, Nodes, ApiBoundaryNodes, Vote, Registry, Firewall, Upgrade, Proposals, Completions, Qualify, UpdateDefaultSubnets, Neuron, Governance }
 
 #[derive(Args, Debug)]
 pub struct Completions {

--- a/rs/cli/src/commands/mod.rs
+++ b/rs/cli/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod propose;
 pub mod qualify;
 pub(crate) mod registry;
 pub(crate) mod subnet;
-pub(crate) mod update_authorized_subnets;
+pub(crate) mod update_default_subnets;
 pub(crate) mod update_unassigned_nodes;
 pub mod upgrade;
 pub(crate) mod version;

--- a/rs/ic-canisters/src/cycles_minting.rs
+++ b/rs/ic-canisters/src/cycles_minting.rs
@@ -18,7 +18,7 @@ impl From<IcAgentCanisterClient> for CyclesMintingCanisterWrapper {
 }
 
 impl CyclesMintingCanisterWrapper {
-    pub async fn get_authorized_subnets(&self) -> anyhow::Result<Vec<PrincipalId>> {
+    pub async fn get_default_subnets(&self) -> anyhow::Result<Vec<PrincipalId>> {
         self.agent
             .query(&self.canister_id.into(), "get_default_subnets", candid::encode_one(())?)
             .await


### PR DESCRIPTION
### Major changes

- Renamed CLI command and alias:
  - `update-authorized-subnets` → `update-default-subnets` (with visible alias for backward compatibility)
- Updated code identifiers to match new name:
  - Module, struct, and function names (`UpdateAuthorizedSubnets` → `UpdateDefaultSubnets`, `get_authorized_subnets` → `get_default_subnets`)
- Cleaned up facts database:
  - Removed `non_public_subnets.csv`
  - Dropped obsolete `shefu` entry from `non_default_subnets.csv` as per https://github.com/dfinity/ic/pull/592
- Updated documentation in `README.md` to reflect the new command name