### PR TITLE
Unelect versions only on base releases, as opposed to feature releases.

### DIFF
--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -714,7 +714,7 @@ class Reconciler:
 
                     urls = version_package_urls(release_commit, v.os_kind)
                     unelect_versions = []
-                    if v.is_base == 0:
+                    if v.is_base:
                         unelect_versions.extend(
                             versions_to_unelect(
                                 index,


### PR DESCRIPTION
Ever since the release controller gained the ability to generate version proposals for HostOS, we had a change in logic for selection of unelect_versions.  Before, we checked if the index of the version within the release is zero, and (because that is assumed to be the base release) we add the versions to unelect to the proposal associated with that version.  Today, we use an object that tracks whether the version is the base version using a boolean is_base -- but the comparison remained the same, so now we are comparing a boolean (which is supposed to be true in the case of base version) to zero, which is always false.

Since we have not had a feature release in quite a while, that has resulted in no proposals (for about seven weeks more or less?) that feature the unelect_versions field, and therefore many versions remain elected.  The type checker also did not catch this comparison between bool and int because, in Python, booleans are subclasses of int.

We fix this comparison by removing the equals to zero part of the comparison.

Old-school assert-based local testing indicates that the unelect_versions field is now properly filled for base releases:

```
  File "/home/manuel/.cache/bazel/_bazel_manuel/afe89085919102cb41f021ef36299e64/execroot/_main/bazel-out/k8-opt/bin/release-controller/release-controller.runfiles/_main/release-controller/reconciler.py", line 736, in reconcile
    assert 0, (v.is_base, unelect_versions)
           ^
AssertionError: (True, ['c9210f4d299546658760465d7fde93913989f70b', 'f195ba756bc3bf170a2888699e5e74101fdac6ba', '3ae3649a2366aaca83404b692fc58e4c6e604a25', '68fc31a141b25f842f078c600168d8211339f422', '2f52f298de53944209f550774505aa72a1a3ed17', '579b8ba3a31341f354f4ddb3d60ac44548a91bc2', 'f8131bfbc2d339716a9cff06e04de49a68e5a80b'])
```

As long as this fix is rolled out to production before the next release, the next release will therefore correctly unelect versions.