### PR TITLE
Improve logging in the reconciler

### DIFF
--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -696,6 +696,7 @@ class Reconciler:
                     revlogger.info("Preparing proposal for %s", release_commit)
                     try:
                         checksum = version_package_checksum(release_commit, v.os_kind)
+                        revlogger.info("Package checksum is %s", checksum)
                     except requests.exceptions.HTTPError as e:
                         if (
                             hasattr(e, "response")
@@ -732,6 +733,10 @@ class Reconciler:
                                     )
                                 ],
                             ),
+                        )
+                        revlogger.info(
+                            "The following revisions will be unelected: %s",
+                            ", ".join(unelect_versions),
                         )
                     try:
                         proposal_id = self.dre.propose_to_revise_elected_os_versions(

--- a/rs/cli/src/main.rs
+++ b/rs/cli/src/main.rs
@@ -13,7 +13,9 @@ use log::{info, warn};
 async fn main() -> anyhow::Result<()> {
     init_logger();
     let curr_version = env!("CARGO_PKG_VERSION");
-    info!("Running version {}", curr_version);
+    if curr_version != "0.0.0" {
+        info!("Running version {}", curr_version);
+    }
 
     dotenv().ok();
 


### PR DESCRIPTION
* Add package checksum and unelected revisions logging, to verify during the next release that revisions are being unelected.
* Remove constant "Running version 0.0.0" when running `dre-embedded` in the reconciler.  Pointless, spams the log.