### PR TITLE
Fix(dre): Handle unexpected zero node reward types count

### DIFF
--- a/rs/cli/src/commands/registry.rs
+++ b/rs/cli/src/commands/registry.rs
@@ -219,7 +219,11 @@ fn fetch_max_rewardable_count(record: &Operator, nodes_in_registry: u64) -> BTre
     if nodes_in_registry == 0 {
         return BTreeMap::new();
     }
-    panic!("This should never happen");
+    warn!(
+        "Node operator {} has {} nodes in registry with {} node allowance total, but {} reward types!  The rewardable nodes by reward type for this operator are: {:?}",
+        record.principal, nodes_in_registry, node_allowance_total, nodes_rewards_types_count, record.rewardable_nodes
+    );
+    BTreeMap::new()
 }
 
 async fn get_node_operators(local_registry: &Arc<dyn LazyRegistry>, network: &Network) -> anyhow::Result<IndexMap<PrincipalId, NodeOperator>> {


### PR DESCRIPTION
Resolved panic by logging warning and returning an empty map when the node operator has nodes in the registry and rewardable nodes, but somehow no node reward types.

- Replaced `panic!` with `warn!` to log the issue instead of terminating execution.
- Provided detailed information in the log, including the principal, total nodes allowed, and reward types count.

Addresses (but does not necessarily fix) https://dfinity.atlassian.net/browse/DRE-466 .