### PR TITLE
Disable team reviews for changelogs of HostOS and GuestOS

### DIFF
--- a/release-controller/publish_notes.py
+++ b/release-controller/publish_notes.py
@@ -169,6 +169,12 @@ class PublishNotesClient:
                 "Could not find release notes section for version %s" % version
             )
 
+        # Attempt to find NO text between the Review checklist sentence and the Release notes headline.
+        # The post_process_release_notes function above should have removed all crossed-out teams
+        # from the list of teams that are supposed to review the changelog.  If that list was empty
+        # because all teams elected to not review the changelog, then this should immediately succeed
+        # and the reconciler (which calls this code) should proceed immediately with publishing the
+        # post-processed changelog (from Google Drive) to Github.
         if not re.match(
             r"^Review checklist=+Please cross(\\|)-out your team once you finished the review\s*$",
             changelog[:release_notes_start].replace("\n", ""),

--- a/release-controller/release_notes_composer.py
+++ b/release-controller/release_notes_composer.py
@@ -82,15 +82,15 @@ class Team:
 GUESTOS_RELEASE_NOTES_REVIEWERS = [
     Team("consensus", "@team-consensus", "SRJ3R849E", False),
     Team("crypto", "@team-crypto", "SU7BZQ78E", False),
-    Team("execution", "@team-execution", "S01A577UL56", True),
-    Team("messaging", "@team-messaging", "S01SVC713PS", True),
+    Team("execution", "@team-execution", "S01A577UL56", False),
+    Team("messaging", "@team-messaging", "S01SVC713PS", False),
     Team("networking", "@team-networking", "SR6KC1DMZ", False),
     Team("node", "@node-team", "S027838EY30", False),
     Team("runtime", "@team-runtime", "S03BM6C0CJY", False),
 ]
 
 HOSTOS_RELEASE_NOTES_REVIEWERS = [
-    Team("node", "@node-team", "S027838EY30", True)
+    Team("node", "@node-team", "S027838EY30", False),
 ]
 
 TYPE_PRETTY_MAP = {


### PR DESCRIPTION
With this, Slack announcements will continue to happen when release notes are prepared for review.  However, no teams will be pinged on Slack or listed in the document for cross-out to mark review as reviewed. This in turn means that the reconciler will proceed immediately to publishing the changelog as-is to the Github repository, in preparation for creation of the proposal.

Motivated by teams asking not to be reviewing the changelog anymore.

We elect to keep the functionality to have the option of re-enabling changelog review, should the future show us that a team wants to review their changes again.

Closes https://dfinity.atlassian.net/browse/DRE-465 .