### PR TITLE
fix: `log-fetcher` proper buffering logic

### DIFF
--- a/rs/log-fetcher/src/journald_parser.rs
+++ b/rs/log-fetcher/src/journald_parser.rs
@@ -1,13 +1,13 @@
 use serde::Serialize;
 use std::collections::VecDeque;
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 pub enum JournalField {
     Utf8(String),
     Binary(String),
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 pub struct JournalEntry {
     pub fields: Vec<(String, JournalField)>,
 }

--- a/rs/log-fetcher/src/main.rs
+++ b/rs/log-fetcher/src/main.rs
@@ -199,10 +199,9 @@ async fn main() -> Result<(), anyhow::Error> {
             leftover_buffer.clear();
         }
     }
-    Ok(())
 
-    // info!("Writing cursor {}...", cursor);
-    // write_cursor(&args.cursor_path, cursor)
+    info!("Writing cursor {}...", cursor);
+    write_cursor(&args.cursor_path, cursor)
 }
 
 fn fetch_cursor(path: &PathBuf) -> Result<String, anyhow::Error> {

--- a/rs/log-fetcher/src/main.rs
+++ b/rs/log-fetcher/src/main.rs
@@ -177,6 +177,7 @@ async fn main() -> Result<(), anyhow::Error> {
                                 serde_json::to_string(&leftover_entry).unwrap(),
                             );
                         }
+                        leftover_entry = Some(entry.clone());
                     }
                 }
 


### PR DESCRIPTION
Given the journald protocol it is possible to fetch partial messages when fetching chunks. If the field is binary encoded it will contain the `\n\n` that we used for determining if the message is complete or not. Given that regular nodes rarely have binary encoded fields we didn't notice it. 

When developing configuration for new http-gateway scraping the issue came up as they have a couple of fields within the same log entry that are binary encoded. This will fix that issue and allow for proper batching