### PR TITLE
chore: cleaner title and summary for subnet create command

### DIFF
--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -169,6 +169,12 @@ impl Runner {
                 .expect("Failed to get a GuestOS version of the NNS subnet"),
         );
 
+        let summary_nodes = subnet_creation_data
+            .node_ids_added
+            .iter()
+            .map(|i| i.to_string().split_once("-").unwrap().0.to_string())
+            .join(", ");
+
         Ok(Some(IcAdminProposal::new(
             IcAdminProposalCommand::CreateSubnet {
                 node_ids: subnet_creation_data.node_ids_added,
@@ -176,8 +182,8 @@ impl Runner {
                 other_args,
             },
             IcAdminProposalOptions {
-                title: Some("Creating new subnet".into()),
-                summary: Some("# Creating new subnet with nodes: ".into()),
+                title: Some("Creating a new subnet".into()),
+                summary: Some(format!("# Creating a new subnet with nodes: [{}]", summary_nodes)),
                 motivation: Some(motivation),
             },
         )))


### PR DESCRIPTION
Example run:
```bash
cargo run --bin dre -- \                                                                                       ✔
 subnet create --motivation "$(cat ~/Downloads/summary.md)" --size 0 \
--replica-version 60fb469c46e44e6071193a3314cc442044fcf17a --dry-run \
--only 5oph7-csqih-dxfky-syp3w-fvcpv-2vfmy-gh3i6-mcpko-j2cmp-radto-wae \
--only 6qf6k-fjcct-wl47g-3onza-lzdjg-5z2mp-u6n7c-hbirw-ovirx-izl67-iae \
--only bjhao-hlctl-g24ce-7hfcg-mqxbw-yxhyq-q23mj-smxsk-4o2s4-u353p-zqe \
--only chcww-h4keq-lv3sn-kly6y-g3msn-tfy4p-kvlnm-fjurq-5mrw3-i73x5-sqe \
--only gzwoq-ajoox-o6vj3-rncja-nekig-dhmqo-pxuwj-yu6a3-w4ygh-wof6w-6ae \
--only j7mu5-sfjx5-rflso-aqhd5-ymijf-glw4a-ovi6i-f3blz-o54sg-a2rfk-bae \
--only jfxia-ws3mm-ubuvq-vaxkd-db5pt-mni5j-3e3lr-azcgb-olp67-2zret-cae \
--only k7gev-k24qh-2ezw5-wv7j6-36euu-mot5i-ig7ja-52kit-vmj5s-5pgor-iqe \
--only rv4uk-b3egt-xwgor-q26dh-7yv4s-er4s5-kn5a2-nlrht-zsatl-47q3w-zqe \
--only suty3-goyd2-t6ngb-dsgzv-vkvt6-w2x4t-lioxl-2xsaa-ztaly-y2ov2-hae \
--only tzemr-r46wi-fcc6e-ivt6z-cfg6k-yyido-j76or-bxwk4-s2dty-dsj3i-pae \
--only vhw7k-ajobo-4e3gl-dninw-4tovw-th6o5-z4fx6-7favv-m4qaw-xovu3-6qe \
--only wagpy-b4c35-wwopp-jmiro-bqnsq-uo2i5-iai72-4yitf-lo7vy-rs5wa-2ae

   Compiling dre v0.6.3 (/home/nikola/work/Dfinity/dre/rs/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.75s
     Running `target/debug/dre subnet create --motivation '## Creation of a new Application Subnet

This proposal outlines the creation of **application subnet** to support the growth and scaling of **Caffeine**, one of our key products.

The initiative is fully aligned with the previously accepted motion proposal ([137147](https://dashboard.internetcomputer.org/proposal/137147)), which provides the strategic foundation for this expansion. By establishing dedicated subnets, we aim to optimize network resources, enhance performance, and ensure better isolation for Caffeine'\''s operational needs.

This step is critical to sustaining Caffeine’s continued growth and delivering on our long-term infrastructure strategy.' --size 0 --replica-version 60fb469c46e44e6071193a3314cc442044fcf17a --dry-run --only 5oph7-csqih-dxfky-syp3w-fvcpv-2vfmy-gh3i6-mcpko-j2cmp-radto-wae --only 6qf6k-fjcct-wl47g-3onza-lzdjg-5z2mp-u6n7c-hbirw-ovirx-izl67-iae --only bjhao-hlctl-g24ce-7hfcg-mqxbw-yxhyq-q23mj-smxsk-4o2s4-u353p-zqe --only chcww-h4keq-lv3sn-kly6y-g3msn-tfy4p-kvlnm-fjurq-5mrw3-i73x5-sqe --only gzwoq-ajoox-o6vj3-rncja-nekig-dhmqo-pxuwj-yu6a3-w4ygh-wof6w-6ae --only j7mu5-sfjx5-rflso-aqhd5-ymijf-glw4a-ovi6i-f3blz-o54sg-a2rfk-bae --only jfxia-ws3mm-ubuvq-vaxkd-db5pt-mni5j-3e3lr-azcgb-olp67-2zret-cae --only k7gev-k24qh-2ezw5-wv7j6-36euu-mot5i-ig7ja-52kit-vmj5s-5pgor-iqe --only rv4uk-b3egt-xwgor-q26dh-7yv4s-er4s5-kn5a2-nlrht-zsatl-47q3w-zqe --only suty3-goyd2-t6ngb-dsgzv-vkvt6-w2x4t-lioxl-2xsaa-ztaly-y2ov2-hae --only tzemr-r46wi-fcc6e-ivt6z-cfg6k-yyido-j76or-bxwk4-s2dty-dsj3i-pae --only vhw7k-ajobo-4e3gl-dninw-4tovw-th6o5-z4fx6-7favv-m4qaw-xovu3-6qe --only wagpy-b4c35-wwopp-jmiro-bqnsq-uo2i5-iai72-4yitf-lo7vy-rs5wa-2ae`
 2025-07-04T10:15:42.784Z INFO  dre > Running version 0.6.3-b39abf6c
 2025-07-04T10:15:42.820Z INFO  dre::store > Using local registry path for network mainnet: /home/nikola/.cache/dre-store/local_registry/mainnet
 2025-07-04T10:15:48.483Z INFO  decentralization::network::request > Evaluating change in subnet aaaaa membership: removing (0 healthy + 0 unhealthy) and adding 13 node. Total available 716 healthy nodes.
Decentralization Nakamoto coefficient changes for subnet `aaaaa-aa`:
```
    node_provider: 0.00 -> 5.00  (+inf%)
      data_center: 0.00 -> 5.00  (+inf%)
data_center_owner: 0.00 -> 5.00  (+inf%)
             area: 0.00 -> 5.00  (+inf%)
          country: 0.00 -> 3.00  (+inf%)
```

**Mean Nakamoto comparison:** 0.00 -> 4.67  (+inf%)

Overall replacement impact: (gets better) the average log2 of Nakamoto Coefficients across all features increases from 0.0000 to 2.1991

Impact on business rules penalties: 1 -> 0


# Details

Nodes removed:

Nodes added:
- `6qf6k-fjcct-wl47g-3onza-lzdjg-5z2mp-u6n7c-hbirw-ovirx-izl67-iae` [health: healthy]
- `vhw7k-ajobo-4e3gl-dninw-4tovw-th6o5-z4fx6-7favv-m4qaw-xovu3-6qe` [health: healthy]
- `gzwoq-ajoox-o6vj3-rncja-nekig-dhmqo-pxuwj-yu6a3-w4ygh-wof6w-6ae` [health: healthy]
- `5oph7-csqih-dxfky-syp3w-fvcpv-2vfmy-gh3i6-mcpko-j2cmp-radto-wae` [health: healthy]
- `jfxia-ws3mm-ubuvq-vaxkd-db5pt-mni5j-3e3lr-azcgb-olp67-2zret-cae` [health: healthy]
- `k7gev-k24qh-2ezw5-wv7j6-36euu-mot5i-ig7ja-52kit-vmj5s-5pgor-iqe` [health: healthy]
- `bjhao-hlctl-g24ce-7hfcg-mqxbw-yxhyq-q23mj-smxsk-4o2s4-u353p-zqe` [health: healthy]
- `rv4uk-b3egt-xwgor-q26dh-7yv4s-er4s5-kn5a2-nlrht-zsatl-47q3w-zqe` [health: healthy]
- `wagpy-b4c35-wwopp-jmiro-bqnsq-uo2i5-iai72-4yitf-lo7vy-rs5wa-2ae` [health: healthy]
- `chcww-h4keq-lv3sn-kly6y-g3msn-tfy4p-kvlnm-fjurq-5mrw3-i73x5-sqe` [health: healthy]
- `tzemr-r46wi-fcc6e-ivt6z-cfg6k-yyido-j76or-bxwk4-s2dty-dsj3i-pae` [health: healthy]
- `j7mu5-sfjx5-rflso-aqhd5-ymijf-glw4a-ovi6i-f3blz-o54sg-a2rfk-bae` [health: healthy]
- `suty3-goyd2-t6ngb-dsgzv-vkvt6-w2x4t-lioxl-2xsaa-ztaly-y2ov2-hae` [health: healthy]


```
    node_provider                                                              data_center            data_center_owner              area                        country
    -------------                                                              -----------            -----------------              ----                        -------
    6r5lw-l7db7-uwixn-iw5en-yy55y-ilbtq-e6gcv-g22r2-j3g6q-y37jk-jqe  0 -> 1    br1          0 -> 1    Africa Data Centres  0 -> 1    Brussels Capital  0 -> 1    AU       0 -> 1
    7at4h-nhtvt-a4s55-jigss-wr2ha-ysxkn-e6w7x-7ggnm-qd3d5-ry66r-cae  0 -> 1    bu1          0 -> 1    Cyxtera              0 -> 1    Bucuresti         0 -> 1    BE       0 -> 1
    7ryes-jnj73-bsyu4-lo6h7-lbxk5-x4ien-lylws-5qwzl-hxd5f-xjh3w-mqe  0 -> 1    cm1          0 -> 1    Digital Realty       0 -> 1    Colombo           0 -> 1    CA       0 -> 1
    bvcsg-3od6r-jnydw-eysln-aql7w-td5zn-ay5m6-sibd2-jzojt-anwag-mqe  0 -> 1    ge1          0 -> 1    Dotsi                0 -> 1    Gauteng           0 -> 1    CH       0 -> 2
    dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae  0 -> 1    jb2          0 -> 1    Equinix              0 -> 1    Geneva            0 -> 1    JP       0 -> 1
    eipr5-izbom-neyqh-s3ec2-52eww-cyfpg-qfomg-3dpwj-4pffh-34xcu-7qe  0 -> 1    li1          0 -> 1    Evocative            0 -> 1    Lisbon            0 -> 1    LK       0 -> 1
    eybf4-6t6bb-unfb2-h2hhn-rrfi2-cd2vs-phksn-jdmbn-i463m-4lzds-vqe  0 -> 1    lj1          0 -> 1    Flexential           0 -> 1    Ljubljana         0 -> 1    PT       0 -> 1
    i7dto-bgkj2-xo5dx-cyrb7-zkk5y-q46eh-gz6iq-qkgyc-w4qte-scgtb-6ae  0 -> 1    lv1          0 -> 1    Green.ch             0 -> 1    Melbourne         0 -> 1    RO       0 -> 1
    ihbuj-erwnc-tkjux-tqtnv-zkoar-uniy2-sk2go-xfpkc-znbb4-seukm-wqe  0 -> 1    mn2          0 -> 1    HighDC               0 -> 1    Nevada            0 -> 1    SI       0 -> 1
    ivf2y-crxj4-y6ewo-un35q-a7pum-wqmbw-pkepy-d6uew-bfmff-g5yxe-eae  0 -> 1    se1          0 -> 1    M247                 0 -> 1    Ontario           0 -> 1    US       0 -> 2
    nmdd6-rouxw-55leh-wcbkn-kejit-njvje-p4s6e-v64d3-nlbjb-vipul-mae  0 -> 1    to2          0 -> 1    NEXTDC               0 -> 1    Tokyo             0 -> 1    ZA       0 -> 1
    rbn2y-6vfsb-gv35j-4cyvy-pzbdu-e5aum-jzjg6-5b4n5-vuguf-ycubq-zae  0 -> 1    ty2          0 -> 1    OrionStellar         0 -> 1    Washington        0 -> 1
    wdjjk-blh44-lxm74-ojj43-rvgf4-j5rie-nm6xs-xvnuv-j3ptn-25t4v-6ae  0 -> 1    zh7          0 -> 1    Posita.si            0 -> 1    Zurich            0 -> 1
```

 2025-07-04T10:15:48.550Z WARN  dre::ctx                           > Couldn't detect neuron due to: Hardware security key not found: No hardware security module detected.  Will fall back to anonymous in dry-run operations.
 2025-07-04T10:15:48.551Z INFO  dre::store                         > Using cached ic admin version: cc066e9957ad2f4f7515e9906bb7df4d2fcf78b7
 2025-07-04T10:15:48.551Z INFO  dre::store                         > Using ic-admin: /home/nikola/.cache/dre-store/ic-admin.revisions/cc066e9957ad2f4f7515e9906bb7df4d2fcf78b7/ic-admin
 2025-07-04T10:15:48.551Z INFO  dre::ic_admin                      > Running ic-admin:
$ /home/nikola/.cache/dre-store/ic-admin.revisions/cc066e9957ad2f4f7515e9906bb7df4d2fcf78b7/ic-admin \
    --secret-key-pem /home/nikola/.config/dfx/identity/test_neuron_1/identity.pem \
    --nns-urls https://ic0.app/ \
  propose-to-create-subnet \
    --silence-notices \
    --proposal-title 'Creating a new subnet' \
    --summary '# Creating a new subnet with nodes: [6qf6k, vhw7k, gzwoq, 5oph7, jfxia, k7gev, bjhao, rv4uk, wagpy, chcww, tzemr, j7mu5, suty3]

Motivation: ## Creation of a new Application Subnet

This proposal outlines the creation of **application subnet** to support the growth and scaling of **Caffeine**, one of our key products.

The initiative is fully aligned with the previously accepted motion proposal ([137147](https://dashboard.internetcomputer.org/proposal/137147)), which provides the strategic foundation for this expansion. By establishing dedicated subnets, we aim to optimize network resources, enhance performance, and ensure better isolation for Caffeine'\''s operational needs.

This step is critical to sustaining Caffeine’s continued growth and delivering on our long-term infrastructure strategy.' \
    --subnet-type application \
    --replica-version-id 60fb469c46e44e6071193a3314cc442044fcf17a \
  6qf6k-fjcct-wl47g-3onza-lzdjg-5z2mp-u6n7c-hbirw-ovirx-izl67-iae \
  vhw7k-ajobo-4e3gl-dninw-4tovw-th6o5-z4fx6-7favv-m4qaw-xovu3-6qe \
  gzwoq-ajoox-o6vj3-rncja-nekig-dhmqo-pxuwj-yu6a3-w4ygh-wof6w-6ae \
  5oph7-csqih-dxfky-syp3w-fvcpv-2vfmy-gh3i6-mcpko-j2cmp-radto-wae \
  jfxia-ws3mm-ubuvq-vaxkd-db5pt-mni5j-3e3lr-azcgb-olp67-2zret-cae \
  k7gev-k24qh-2ezw5-wv7j6-36euu-mot5i-ig7ja-52kit-vmj5s-5pgor-iqe \
  bjhao-hlctl-g24ce-7hfcg-mqxbw-yxhyq-q23mj-smxsk-4o2s4-u353p-zqe \
  rv4uk-b3egt-xwgor-q26dh-7yv4s-er4s5-kn5a2-nlrht-zsatl-47q3w-zqe \
  wagpy-b4c35-wwopp-jmiro-bqnsq-uo2i5-iai72-4yitf-lo7vy-rs5wa-2ae \
  chcww-h4keq-lv3sn-kly6y-g3msn-tfy4p-kvlnm-fjurq-5mrw3-i73x5-sqe \
  tzemr-r46wi-fcc6e-ivt6z-cfg6k-yyido-j76or-bxwk4-s2dty-dsj3i-pae \
  j7mu5-sfjx5-rflso-aqhd5-ymijf-glw4a-ovi6i-f3blz-o54sg-a2rfk-bae \
  suty3-goyd2-t6ngb-dsgzv-vkvt6-w2x4t-lioxl-2xsaa-ztaly-y2ov2-hae \
    --proposer 123 \
    --dry-run
Using NNS URLs: ["https://ic0.app/"]
Title: Creating a new subnet

Summary: # Creating a new subnet with nodes: [6qf6k, vhw7k, gzwoq, 5oph7, jfxia, k7gev, bjhao, rv4uk, wagpy, chcww, tzemr, j7mu5, suty3]

Motivation: ## Creation of a new Application Subnet

This proposal outlines the creation of **application subnet** to support the growth and scaling of **Caffeine**, one of our key products.

The initiative is fully aligned with the previously accepted motion proposal ([137147](https://dashboard.internetcomputer.org/proposal/137147)), which provides the strategic foundation for this expansion. By establishing dedicated subnets, we aim to optimize network resources, enhance performance, and ensure better isolation for Caffeine's operational needs.

This step is critical to sustaining Caffeine’s continued growth and delivering on our long-term infrastructure strategy.

URL:

Payload: CreateSubnetPayload {
    node_ids: [
        6qf6k-fjcct-wl47g-3onza-lzdjg-5z2mp-u6n7c-hbirw-ovirx-izl67-iae,
        vhw7k-ajobo-4e3gl-dninw-4tovw-th6o5-z4fx6-7favv-m4qaw-xovu3-6qe,
        gzwoq-ajoox-o6vj3-rncja-nekig-dhmqo-pxuwj-yu6a3-w4ygh-wof6w-6ae,
        5oph7-csqih-dxfky-syp3w-fvcpv-2vfmy-gh3i6-mcpko-j2cmp-radto-wae,
        jfxia-ws3mm-ubuvq-vaxkd-db5pt-mni5j-3e3lr-azcgb-olp67-2zret-cae,
        k7gev-k24qh-2ezw5-wv7j6-36euu-mot5i-ig7ja-52kit-vmj5s-5pgor-iqe,
        bjhao-hlctl-g24ce-7hfcg-mqxbw-yxhyq-q23mj-smxsk-4o2s4-u353p-zqe,
        rv4uk-b3egt-xwgor-q26dh-7yv4s-er4s5-kn5a2-nlrht-zsatl-47q3w-zqe,
        wagpy-b4c35-wwopp-jmiro-bqnsq-uo2i5-iai72-4yitf-lo7vy-rs5wa-2ae,
        chcww-h4keq-lv3sn-kly6y-g3msn-tfy4p-kvlnm-fjurq-5mrw3-i73x5-sqe,
        tzemr-r46wi-fcc6e-ivt6z-cfg6k-yyido-j76or-bxwk4-s2dty-dsj3i-pae,
        j7mu5-sfjx5-rflso-aqhd5-ymijf-glw4a-ovi6i-f3blz-o54sg-a2rfk-bae,
        suty3-goyd2-t6ngb-dsgzv-vkvt6-w2x4t-lioxl-2xsaa-ztaly-y2ov2-hae,
    ],
    subnet_id_override: None,
    max_ingress_bytes_per_message: 2097152,
    max_ingress_messages_per_block: 1000,
    max_block_payload_size: 4194304,
    unit_delay_millis: 1000,
    initial_notary_delay_millis: 300,
    replica_version_id: "60fb469c46e44e6071193a3314cc442044fcf17a",
    dkg_interval_length: 499,
    dkg_dealings_per_block: 1,
    start_as_nns: false,
    subnet_type: Application,
    is_halted: false,
    features: SubnetFeatures {
        canister_sandboxing: false,
        http_requests: true,
        sev_enabled: None,
    },
    max_number_of_canisters: 0,
    ssh_readonly_access: [],
    ssh_backup_access: [],
    chain_key_config: None,
    ingress_bytes_per_block_soft_cap: 0,
    gossip_max_artifact_streams_per_peer: 0,
    gossip_max_chunk_wait_ms: 0,
    gossip_max_duplicity: 0,
    gossip_max_chunk_size: 0,
    gossip_receive_check_cache_size: 0,
    gossip_pfn_evaluation_period_ms: 0,
    gossip_registry_poll_period_ms: 0,
    gossip_retransmission_request_ms: 0,
}
```