### PR TITLE
fix: align the ic-admin version with the registry canister

### DIFF
--- a/rs/cli/src/ctx/unit_tests.rs
+++ b/rs/cli/src/ctx/unit_tests.rs
@@ -62,7 +62,7 @@ impl<'a> AdminVersionTestScenario<'a> {
     fn new(name: &'static str) -> Self {
         Self {
             name,
-            version: IcAdminVersion::FromGovernance,
+            version: IcAdminVersion::FromRegistry,
             should_delete_status_file: false,
             should_contain: None,
         }

--- a/rs/cli/src/exe/args.rs
+++ b/rs/cli/src/exe/args.rs
@@ -17,7 +17,7 @@ pub struct GlobalArgs {
     #[clap(long, global = true, env = "IC_ADMIN")]
     pub ic_admin: Option<String>,
 
-    #[clap(long, global = true, env = "IC_ADMIN_VERSION", default_value = "from-governance", value_parser = clap::value_parser!(IcAdminVersion), help = r#"Specify the version of ic admin to use
+    #[clap(long, global = true, env = "IC_ADMIN_VERSION", default_value = "from-registry", value_parser = clap::value_parser!(IcAdminVersion), help = r#"Specify the version of ic admin to use
 Options:
     1. from-governance, governance, govn, g => same as governance canister
     2. default, d => strict default version, embedded at build time
@@ -57,7 +57,7 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
 
 #[derive(Debug, Display, Clone)]
 pub enum IcAdminVersion {
-    FromGovernance,
+    FromRegistry,
     Fallback,
     Strict(String),
 }
@@ -65,7 +65,7 @@ pub enum IcAdminVersion {
 impl From<&str> for IcAdminVersion {
     fn from(value: &str) -> Self {
         match value {
-            "from-governance" | "governance" | "g" | "govn" => Self::FromGovernance,
+            "from-registry" | "registry" | "r" | "reg" => Self::FromRegistry,
             "fallback" | "f" => Self::Fallback,
             s => Self::Strict(s.to_string()),
         }

--- a/rs/cli/src/store.rs
+++ b/rs/cli/src/store.rs
@@ -1,5 +1,5 @@
 use flate2::bufread::GzDecoder;
-use ic_canisters::governance::governance_canister_version;
+use ic_canisters::registry::registry_canister_version;
 use ic_management_backend::{
     health::{HealthClient, HealthStatusQuerier},
     lazy_registry::{LazyRegistry, LazyRegistryImpl},
@@ -210,7 +210,7 @@ impl Store {
             IcAdminVersion::Fallback => self.init_ic_admin(FALLBACK_IC_ADMIN_VERSION, network, neuron).await,
             IcAdminVersion::Strict(ver) => self.init_ic_admin(ver, network, neuron).await,
             // This is the most probable way of running
-            IcAdminVersion::FromGovernance => {
+            IcAdminVersion::FromRegistry => {
                 let mut status_file = fs_err::File::open(&self.ic_admin_status_file()?)?;
                 let elapsed = status_file.metadata()?.modified()?.elapsed().unwrap_or_default();
 
@@ -242,12 +242,12 @@ impl Store {
                     // Check should be performed
                     (false, _) => {
                         info!("Checking for new ic-admin version");
-                        let govn_canister_version = governance_canister_version(network.get_nns_urls()).await?;
+                        let registry_version = registry_canister_version(network.get_nns_urls()[0].clone()).await?;
                         debug!(
-                            "Using ic-admin matching the version of governance canister, version: {}",
-                            govn_canister_version.stringified_hash
+                            "Using ic-admin matching the version of registry canister, version: {}",
+                            registry_version.stringified_hash
                         );
-                        let version = match govn_canister_version.stringified_hash.as_str() {
+                        let version = match registry_version.stringified_hash.as_str() {
                             // This usually happens on testnets deployed
                             // from the HEAD of branch
                             "0000000000000000000000000000000000000000" => FALLBACK_IC_ADMIN_VERSION,

--- a/rs/ic-canisters/src/registry.rs
+++ b/rs/ic-canisters/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::IcAgentCanisterClient;
+use crate::{CanisterVersion, IcAgentCanisterClient};
 use ic_agent::Agent;
 use ic_base_types::PrincipalId;
 use ic_interfaces_registry::RegistryRecord;
@@ -26,6 +26,10 @@ impl From<IcAgentCanisterClient> for RegistryCanisterWrapper {
             ic_wrapper: RegistryCanister::new(vec![value.nns_url]),
         }
     }
+}
+
+pub async fn registry_canister_version(url: Url) -> anyhow::Result<CanisterVersion> {
+    super::canister_version(url, REGISTRY_CANISTER_ID.into()).await
 }
 
 impl RegistryCanisterWrapper {


### PR DESCRIPTION
For context here is a [slack conversation](https://dfinity.slack.com/archives/C0175CHJ0P6/p1755773853792679)