### PR TITLE
feat(health): allow overriding node health via CLI and env

### DIFF
--- a/rs/cli/src/ctx/mod.rs
+++ b/rs/cli/src/ctx/mod.rs
@@ -99,6 +99,12 @@ impl DreContext {
             true => Network::new_unchecked(args.network.clone(), &args.nns_urls)?,
         };
 
+        // Propagate health overrides to backend via env var for health client implementations
+        if !args.override_health.is_empty() {
+            let overrides = args.override_health.join(",");
+            std::env::set_var("DRE_OVERRIDE_HEALTH", overrides);
+        }
+
         Self::new(
             network.clone(),
             args.auth_opts.clone(),

--- a/rs/cli/src/exe/args.rs
+++ b/rs/cli/src/exe/args.rs
@@ -51,8 +51,18 @@ The argument is mandatory for testnets, and is optional for mainnet and staging"
     pub offline: bool,
 
     /// Path to file which contains cordoned features
-    #[clap(long, global = true, visible_aliases = &["cf-file", "cfff"])]
+    #[clap(long, global = true, visible_aliases = &["cf-file", "cfff", "cordone"])]
     pub cordoned_features_file: Option<String>,
+
+    /// Override health by data center ID or node ID, e.g. "sg2:healthy". Accepts multiple entries.
+    #[clap(long, global = true, num_args(1..), visible_aliases = &["oh", "override-healths"], help = r#"Override health for nodes. Matches exact data center ID (dc_id) or full node principal.
+Examples:
+    --override-health sg2:healthy
+    --override-health mn2:healthy de1:dead
+    --override-health bo1:degraded z6jp6-245uu-...:healthy
+
+Accepted health values: healthy, degraded, dead, unknown (case-insensitive)."#)]
+    pub override_health: Vec<String>,
 }
 
 #[derive(Debug, Display, Clone)]

--- a/rs/cli/src/operations/hostos_rollout.rs
+++ b/rs/cli/src/operations/hostos_rollout.rs
@@ -699,6 +699,7 @@ pub mod test {
                     node_allowance: 23933,
                     datacenter: None,
                     rewardable_nodes: BTreeMap::new(),
+                    max_rewardable_nodes: BTreeMap::new(),
                     ipv6: "".to_string(),
                 },
                 cached_features: OnceLock::new(),
@@ -713,6 +714,7 @@ pub mod test {
                 is_api_boundary_node,
                 chip_id: None,
                 public_ipv4_config: None,
+                node_reward_type: None,
             };
             n.insert(node.principal, node);
         }

--- a/rs/ic-management-backend/src/health.rs
+++ b/rs/ic-management-backend/src/health.rs
@@ -36,12 +36,7 @@ fn parse_health_overrides() -> Vec<(String, HealthStatus)> {
     }
 }
 
-fn maybe_override_status(
-    status: HealthStatus,
-    node_id_str: &str,
-    dc_id_lower: Option<&str>,
-    overrides: &[(String, HealthStatus)],
-) -> HealthStatus {
+fn maybe_override_status(status: HealthStatus, node_id_str: &str, dc_id_lower: Option<&str>, overrides: &[(String, HealthStatus)]) -> HealthStatus {
     let node_key = node_id_str.to_lowercase();
     if let Some((_, s)) = overrides.iter().find(|(k, _)| k == &node_key) {
         return s.clone();

--- a/rs/ic-management-backend/src/health.rs
+++ b/rs/ic-management-backend/src/health.rs
@@ -14,6 +14,46 @@ use url::Url;
 
 use crate::prometheus;
 
+fn parse_health_overrides() -> Vec<(String, HealthStatus)> {
+    match std::env::var("DRE_OVERRIDE_HEALTH") {
+        Ok(v) if !v.trim().is_empty() => v
+            .split(',')
+            .filter_map(|entry| {
+                let mut parts = entry.split(':');
+                let key = parts.next()?.trim().to_lowercase();
+                let val = parts.next()?.trim().to_lowercase();
+                let status = match val.as_str() {
+                    "healthy" => HealthStatus::Healthy,
+                    "degraded" => HealthStatus::Degraded,
+                    "dead" => HealthStatus::Dead,
+                    "unknown" => HealthStatus::Unknown,
+                    _ => return None,
+                };
+                Some((key, status))
+            })
+            .collect(),
+        _ => vec![],
+    }
+}
+
+fn maybe_override_status(
+    status: HealthStatus,
+    node_id_str: &str,
+    dc_id_lower: Option<&str>,
+    overrides: &[(String, HealthStatus)],
+) -> HealthStatus {
+    let node_key = node_id_str.to_lowercase();
+    if let Some((_, s)) = overrides.iter().find(|(k, _)| k == &node_key) {
+        return s.clone();
+    }
+    if let Some(dc) = dc_id_lower {
+        if let Some((_, s)) = overrides.iter().find(|(k, _)| k == dc) {
+            return s.clone();
+        }
+    }
+    status
+}
+
 pub struct HealthClient {
     implementation: HealthStatusQuerierImplementations,
     local_cache: Option<PathBuf>,
@@ -39,12 +79,20 @@ impl HealthStatusQuerier for HealthClient {
                 // Should load from local cache
                 (true, Some(path)) => {
                     let contents = fs_err::read_to_string(&path)?;
-                    serde_json::from_str(&contents)
-                        .map_err(|e| anyhow::anyhow!("Failed to deserialize from local cache on path `{}` due to: {:?}", path.display(), e))
+                    let mut nodes: Vec<ShortNodeInfo> = serde_json::from_str(&contents)
+                        .map_err(|e| anyhow::anyhow!("Failed to deserialize from local cache on path `{}` due to: {:?}", path.display(), e))?;
+                    let overrides = parse_health_overrides();
+                    if !overrides.is_empty() {
+                        for n in &mut nodes {
+                            let node_id_str = n.node_id.to_string();
+                            n.status = maybe_override_status(n.status.clone(), &node_id_str, None, &overrides);
+                        }
+                    }
+                    Ok(nodes)
                 }
                 // Runing online
                 (false, local_cache) => {
-                    let nodes = match &self.implementation {
+                    let mut nodes = match &self.implementation {
                         HealthStatusQuerierImplementations::Dashboard(public_dashboard_health_client) => {
                             public_dashboard_health_client.get_all_nodes().await?
                         }
@@ -55,6 +103,13 @@ impl HealthStatusQuerier for HealthClient {
                         let contents = serde_json::to_string_pretty(&nodes)?;
                         fs_err::write(&path, &contents)
                             .map_err(|e| anyhow::anyhow!("Failed to update local cache on path `{}` due to: {:?}", path.display(), e))?;
+                    }
+                    let overrides = parse_health_overrides();
+                    if !overrides.is_empty() {
+                        for n in &mut nodes {
+                            let node_id_str = n.node_id.to_string();
+                            n.status = maybe_override_status(n.status.clone(), &node_id_str, None, &overrides);
+                        }
                     }
                     Ok(nodes)
                 }
@@ -150,6 +205,7 @@ impl PublicDashboardHealthClient {
         };
 
         let mut response = vec![];
+        let overrides = parse_health_overrides();
 
         let nodes = match nodes.as_array() {
             None => return Err(anyhow::anyhow!("Unexpected data contract. Couldn't parse response as array")),
@@ -203,6 +259,13 @@ impl PublicDashboardHealthClient {
             };
 
             let status = if node_dc == "mn2" { HealthStatus::Healthy } else { status };
+
+            // Apply overrides by dc_id or node id
+            let status = if overrides.is_empty() {
+                status
+            } else {
+                maybe_override_status(status, &node_id.to_string(), Some(&node_dc.to_lowercase()), &overrides)
+            };
 
             let maybe_subnet = match node.get("subnet_id") {
                 None => None,
@@ -264,6 +327,7 @@ impl PrometheusHealthClient {
 impl PrometheusHealthClient {
     fn get_all_nodes(&self) -> BoxFuture<'_, anyhow::Result<Vec<ShortNodeInfo>>> {
         Box::pin(async move {
+            let overrides = parse_health_overrides();
             let ic_name = self.network.legacy_name();
             let query_up = Selector::new().metric("up").eq("ic", ic_name.as_str()).eq("job", "replica");
 
@@ -296,6 +360,11 @@ impl PrometheusHealthClient {
                             }
                         } else {
                             HealthStatus::Dead
+                        };
+                        let status = if overrides.is_empty() {
+                            status
+                        } else {
+                            maybe_override_status(status, &id.to_string(), None, &overrides)
                         };
                         ShortNodeInfo {
                             node_id: id,


### PR DESCRIPTION
Problem (Why?)

- Need a way to force health states for nodes or data centers for testing and troubleshooting.

Solution (What?)

- Add a CLI option to specify health overrides and propagate them to the backend via an environment variable (DRE_OVERRIDE_HEALTH).
- Backend parses the overrides and applies them to health responses from local cache, Public Dashboard, and Prometheus clients.

Example usages: `--override-health sg2:healthy` or `--override-health mn2:healthy de1:dead`
Accepted values (case-insensitive): healthy, degraded, dead, unknown

Example proposal submitted with this: https://dashboard.internetcomputer.org/proposal/138159
(ignoring the sg2 DC being down/unhealthy)