### PR TITLE
feat(subnet): rename include -> add-nodes and validate node availability

### DIFF
--- a/rs/cli/src/commands/subnet/create.rs
+++ b/rs/cli/src/commands/subnet/create.rs
@@ -26,9 +26,8 @@ pub struct Create {
     #[clap(long, num_args(1..))]
     pub only: Vec<String>,
 
-    #[clap(long, num_args(1..), help = r#"Force the inclusion of the provided nodes for replacement,
-regardless of the decentralization coefficients"#)]
-    pub include: Vec<PrincipalId>,
+    #[clap(long = "add-nodes", num_args(1..), help = r#"Add the provided nodes to the subnet. Fails if a node is unavailable/unhealthy."#, visible_aliases = &["add", "add-node", "add-node-id", "add-node-ids"])]
+    pub add_nodes: Vec<PrincipalId>,
 
     /// Motivation for replacing custom nodes
     #[clap(long, short, aliases = [ "summary" ])]
@@ -75,7 +74,7 @@ impl ExecutableCommand for Create {
                     size: self.size,
                     exclude: self.exclude.clone().into(),
                     only: self.only.clone().into(),
-                    include: self.include.clone().into(),
+                    add_nodes: self.add_nodes.clone().into(),
                 },
                 motivation.to_string(),
                 self.replica_version.clone(),

--- a/rs/cli/src/commands/subnet/replace.rs
+++ b/rs/cli/src/commands/subnet/replace.rs
@@ -10,15 +10,16 @@ use crate::{auth::AuthRequirement, exe::ExecutableCommand, subnet_manager::Subne
 
 #[derive(Args, Debug)]
 pub struct Replace {
-    /// Set of custom nodes to be replaced
-    #[clap(long, short, num_args(1..), visible_aliases = &["node", "nodes", "node-id", "node-ids"])]
+    /// Specific node IDs to remove from the subnet
+    #[clap(long = "remove-nodes", short, num_args(1..), visible_aliases = &["nodes", "node", "node-id", "node-ids", "remove", "remove-node", "remove-nodes", "remove-node-id", "remove-node-ids"])]
     pub nodes: Vec<PrincipalId>,
 
     /// Do not replace unhealthy nodes
     #[clap(long)]
     pub no_heal: bool,
 
-    #[clap(long, short, help = r#"How many nodes to try replacing in the subnet to improve decentralization?"#)]
+    /// Number of nodes to replace (system will pick which to optimize decentralization)
+    #[clap(long = "replace-count", short, visible_aliases = &["optimize", "optimise", "optimize-count"])]
     pub optimize: Option<usize>,
 
     /// Motivation for replacing custom nodes
@@ -33,10 +34,9 @@ pub struct Replace {
     #[clap(long, num_args(1..))]
     pub only: Vec<String>,
 
-    /// Force the inclusion of the provided nodes for replacement, regardless
-    /// of the decentralization coefficients
-    #[clap(long, num_args(1..))]
-    pub include: Vec<PrincipalId>,
+    /// Add specific nodes to the subnet. Fails if a node is unavailable/unhealthy.
+    #[clap(long = "add-nodes", num_args(1..), visible_aliases = &["add", "add-node", "add-node-id", "add-node-ids"])]
+    pub add_nodes: Vec<PrincipalId>,
 
     /// The ID of the subnet.
     #[clap(long, short, alias = "subnet-id")]
@@ -68,7 +68,7 @@ impl ExecutableCommand for Replace {
                 self.optimize,
                 self.exclude.clone().into(),
                 self.only.clone(),
-                self.include.clone().into(),
+                self.add_nodes.clone().into(),
                 &all_nodes,
             )
             .await?;

--- a/rs/cli/src/commands/subnet/resize.rs
+++ b/rs/cli/src/commands/subnet/resize.rs
@@ -29,10 +29,9 @@ pub struct Resize {
     #[clap(long, num_args(1..))]
     pub only: Vec<String>,
 
-    /// Force the inclusion of the provided nodes for replacement,
-    /// regardless of the decentralization
-    #[clap(long, num_args(1..))]
-    pub include: Vec<PrincipalId>,
+    /// Add specific nodes to the subnet. Fails if a node is unavailable/unhealthy.
+    #[clap(long = "add-nodes", num_args(1..), visible_aliases = &["add", "add-node", "add-node-id", "add-node-ids"])]
+    pub add_nodes: Vec<PrincipalId>,
 
     /// Motivation for replacing custom nodes
     #[clap(long, short, aliases = [ "summary" ])]
@@ -64,7 +63,7 @@ impl ExecutableCommand for Resize {
                     remove: self.remove,
                     exclude: self.exclude.clone().into(),
                     only: self.only.clone().into(),
-                    include: self.include.clone().into(),
+                    add_nodes: self.add_nodes.clone().into(),
                 },
                 self.motivation.clone(),
                 &runner.health_of_nodes().await?,

--- a/rs/cli/src/unit_tests/add_nodes.rs
+++ b/rs/cli/src/unit_tests/add_nodes.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use ic_base_types::PrincipalId;
+use indexmap::IndexMap;
+
+use ic_management_backend::{health::MockHealthStatusQuerier, lazy_registry::MockLazyRegistry};
+use ic_management_types::{HealthStatus, Node, Operator, Provider};
+
+use crate::subnet_manager::SubnetManager;
+
+fn test_node(id: u64) -> Node {
+    let principal = PrincipalId::new_node_test_id(id);
+    Node {
+        principal,
+        ip_addr: None,
+        operator: Operator {
+            principal,
+            provider: Provider {
+                principal,
+                name: None,
+                website: None,
+            },
+            node_allowance: 1,
+            datacenter: None,
+            rewardable_nodes: Default::default(),
+            max_rewardable_nodes: Default::default(),
+            ipv6: "".to_string(),
+        },
+        cached_features: Default::default(),
+        hostname: None,
+        hostos_release: None,
+        proposal: None,
+        label: None,
+        duplicates: None,
+        subnet_id: None,
+        hostos_version: String::new(),
+        dfinity_owned: None,
+        is_api_boundary_node: false,
+        chip_id: None,
+        public_ipv4_config: None,
+        node_reward_type: None,
+    }
+}
+
+#[test]
+fn validate_add_nodes_success_and_failure() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    // Build world: two available nodes (1,2). Node 1 healthy, node 2 unhealthy; node 3 not available
+    let available_nodes = vec![test_node(1), test_node(2)];
+    let all_nodes_map: IndexMap<_, _> = available_nodes.iter().map(|n| (n.principal, n.clone())).collect();
+
+    let mut registry = MockLazyRegistry::new();
+    registry.expect_available_nodes().returning({
+        let available_nodes = available_nodes.clone();
+        move || {
+            let available_nodes = available_nodes.clone();
+            Box::pin(async move { Ok(available_nodes) })
+        }
+    });
+    registry.expect_nodes().returning({
+        let all_nodes_map = Arc::new(all_nodes_map.clone());
+        move || {
+            let all_nodes_map = all_nodes_map.clone();
+            Box::pin(async move { Ok(all_nodes_map.clone()) })
+        }
+    });
+
+    let mut health = MockHealthStatusQuerier::new();
+    let mut healths: IndexMap<PrincipalId, HealthStatus> = IndexMap::new();
+    healths.insert(PrincipalId::new_node_test_id(1), HealthStatus::Healthy);
+    healths.insert(PrincipalId::new_node_test_id(2), HealthStatus::Dead);
+    health.expect_nodes().returning({
+        let healths = healths.clone();
+        move || {
+            let healths = healths.clone();
+            Box::pin(async move { Ok(healths) })
+        }
+    });
+
+    // SubnetManager with mocks
+    let manager = SubnetManager::new(
+        Arc::new(registry),
+        Arc::new(crate::cordoned_feature_fetcher::MockCordonedFeatureFetcher::new()),
+        Arc::new(health),
+    );
+
+    // Success: add-nodes contains only node 1
+    let ok = runtime.block_on(manager.validate_nodes_available_and_healthy(&[PrincipalId::new_node_test_id(1)]));
+    assert!(ok.is_ok(), "Expected node 1 to pass validation");
+
+    // Failure: add-nodes contains node 2 (unhealthy) and 3 (not available)
+    let err = runtime.block_on(manager.validate_nodes_available_and_healthy(&[PrincipalId::new_node_test_id(2), PrincipalId::new_node_test_id(3)]));
+    assert!(err.is_err(), "Expected validation to fail for nodes 2 and 3");
+    let msg = format!("{}", err.unwrap_err());
+    assert!(msg.contains("not available"), "Missing not available reason: {}", msg);
+    assert!(msg.contains("not healthy"), "Missing not healthy reason: {}", msg);
+}

--- a/rs/cli/src/unit_tests/args_parse.rs
+++ b/rs/cli/src/unit_tests/args_parse.rs
@@ -1,0 +1,105 @@
+use clap::Parser;
+use ic_base_types::PrincipalId;
+
+use crate::commands::subnet::{Subcommands, Subnet};
+
+fn id(i: u64) -> PrincipalId {
+    PrincipalId::new_node_test_id(i)
+}
+
+#[test]
+fn parse_create_add_nodes_aliases() {
+    let args = ["--size", "13", "--add-nodes", &id(1).to_string(), &id(2).to_string(), "--motivation", "m"];
+    let s = Subnet::parse_from(["subnet"].into_iter().chain(["create"]).chain(args));
+    let Subcommands::Create(c) = s.subcommands else {
+        panic!("expected create")
+    };
+    assert_eq!(c.add_nodes.len(), 2);
+
+    let args = ["--size", "13", "--add", &id(1).to_string(), &id(2).to_string(), "--motivation", "m"];
+    let s = Subnet::parse_from(["subnet"].into_iter().chain(["create"]).chain(args));
+    let Subcommands::Create(c) = s.subcommands else {
+        panic!("expected create")
+    };
+    assert_eq!(c.add_nodes.len(), 2);
+}
+
+#[test]
+fn parse_resize_add_nodes_aliases() {
+    let args = [
+        "--id",
+        &PrincipalId::new_subnet_test_id(1).to_string(),
+        "--motivation",
+        "m",
+        "--add-nodes",
+        &id(1).to_string(),
+        &id(2).to_string(),
+    ];
+    let s = Subnet::parse_from(["subnet"].into_iter().chain(["resize"]).chain(args));
+    let Subcommands::Resize(r) = s.subcommands else {
+        panic!("expected resize")
+    };
+    assert_eq!(r.add_nodes.len(), 2);
+
+    let args = [
+        "--id",
+        &PrincipalId::new_subnet_test_id(1).to_string(),
+        "--motivation",
+        "m",
+        "--add",
+        &id(1).to_string(),
+        &id(2).to_string(),
+    ];
+    let s = Subnet::parse_from(["subnet"].into_iter().chain(["resize"]).chain(args));
+    let Subcommands::Resize(r) = s.subcommands else {
+        panic!("expected resize")
+    };
+    assert_eq!(r.add_nodes.len(), 2);
+}
+
+#[test]
+fn parse_replace_remove_and_count() {
+    let args = [
+        "--id",
+        &PrincipalId::new_subnet_test_id(1).to_string(),
+        "--remove-nodes",
+        &id(1).to_string(),
+        &id(2).to_string(),
+        "--motivation",
+        "m",
+    ];
+    let s = Subnet::parse_from(["subnet"].into_iter().chain(["replace"]).chain(args));
+    let Subcommands::Replace(r) = s.subcommands else {
+        panic!("expected replace")
+    };
+    assert_eq!(r.nodes.len(), 2);
+
+    let args = [
+        "--id",
+        &PrincipalId::new_subnet_test_id(1).to_string(),
+        "--replace-count",
+        "2",
+        "--motivation",
+        "m",
+    ];
+    let s = Subnet::parse_from(["subnet"].into_iter().chain(["replace"]).chain(args));
+    let Subcommands::Replace(r) = s.subcommands else {
+        panic!("expected replace")
+    };
+    assert_eq!(r.optimize, Some(2));
+
+    // alias
+    let args = [
+        "--id",
+        &PrincipalId::new_subnet_test_id(1).to_string(),
+        "--optimize",
+        "2",
+        "--motivation",
+        "m",
+    ];
+    let s = Subnet::parse_from(["subnet"].into_iter().chain(["replace"]).chain(args));
+    let Subcommands::Replace(r) = s.subcommands else {
+        panic!("expected replace")
+    };
+    assert_eq!(r.optimize, Some(2));
+}

--- a/rs/cli/src/unit_tests/mod.rs
+++ b/rs/cli/src/unit_tests/mod.rs
@@ -2,6 +2,8 @@ mod cordoned_feature_fetcher;
 // The DRE context unit tests have been moved to a submodule
 // of the ctx module.  This was accomplished to reduce the
 // visibility of methods of ctx structs.
+mod add_nodes;
+mod args_parse;
 mod health_client;
 mod node_labels;
 mod replace;

--- a/rs/cli/src/unit_tests/node_labels.rs
+++ b/rs/cli/src/unit_tests/node_labels.rs
@@ -113,7 +113,6 @@ fn test_node_labels() {
                 datacenter: "test-dc".to_string(),
                 ipv6: "::1".parse().unwrap(),
                 name: "test-label".to_string(),
-                dfinity_owned: false,
             }])
             .should_succeed(),
     ];

--- a/rs/decentralization/src/network/request.rs
+++ b/rs/decentralization/src/network/request.rs
@@ -51,16 +51,16 @@ impl SubnetChangeRequest {
         change_new
     }
 
-    pub fn including_from_available<T: Identifies<Node>>(self, nodes: Vec<T>) -> Self {
-        Self {
-            include_nodes: self
-                .available_nodes
+    pub fn adding_from_available<T: Identifies<Node>>(self, nodes: Vec<T>) -> Self {
+        let mut include_nodes = self.include_nodes.clone();
+        include_nodes.extend(
+            self.available_nodes
                 .iter()
                 .filter(|node| nodes.iter().match_any(node))
                 .cloned()
                 .collect_vec(),
-            ..self
-        }
+        );
+        Self { include_nodes, ..self }
     }
 
     pub fn excluding_from_available<T: Identifies<Node>>(self, nodes: Vec<T>) -> Self {

--- a/rs/decentralization/src/network/traits.rs
+++ b/rs/decentralization/src/network/traits.rs
@@ -32,7 +32,7 @@ pub trait TopologyManager: SubnetQuerier + AvailableNodesQuerier + Sync {
     fn create_subnet<'a>(
         &'a self,
         size: usize,
-        include_nodes: Vec<PrincipalId>,
+        add_nodes: Vec<PrincipalId>,
         exclude_nodes: Vec<String>,
         only_nodes: Vec<String>,
         health_of_nodes: &'a IndexMap<PrincipalId, HealthStatus>,
@@ -44,9 +44,9 @@ pub trait TopologyManager: SubnetQuerier + AvailableNodesQuerier + Sync {
                 available_nodes: self.available_nodes().await?,
                 ..Default::default()
             }
-            .including_from_available(include_nodes)
+            .adding_from_available(add_nodes)
             .excluding_from_available(exclude_nodes)
-            .including_from_available(only_nodes)
+            .adding_from_available(only_nodes)
             .resize(size, 0, 0, health_of_nodes, cordoned_features, all_nodes)
         })
     }

--- a/rs/ic-management-types/src/requests.rs
+++ b/rs/ic-management-types/src/requests.rs
@@ -7,7 +7,7 @@ pub struct SubnetCreateRequest {
     pub size: usize,
     pub exclude: Option<Vec<String>>,
     pub only: Option<Vec<String>>,
-    pub include: Option<Vec<PrincipalId>>,
+    pub add_nodes: Option<Vec<PrincipalId>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -17,7 +17,7 @@ pub struct SubnetResizeRequest {
     pub remove: usize,
     pub exclude: Option<Vec<String>>,
     pub only: Option<Vec<String>>,
-    pub include: Option<Vec<PrincipalId>>,
+    pub add_nodes: Option<Vec<PrincipalId>>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
### Motivation
- Fail fast when user requests specific nodes that are unavailable/unhealthy.
### Solution
- Rename CLI/requests/traits field include -> add_nodes and add --add-nodes (with aliases); use adding_from_available.
- Add validate_nodes_available_and_healthy and early checks in Runner/SubnetManager; aggregate errors.
### Impact
- Breaking: callers must use add_nodes/--add-nodes instead of include/--include.
### Meta — updated tests accordingly