### PR TITLE
chore(cordoned-features): prune deprecated node_provider entries

### DIFF
--- a/cordoned_features.yaml
+++ b/cordoned_features.yaml
@@ -4,17 +4,5 @@
 # https://github.com/dfinity/dre/blob/main/rs/ic-management-types/src/lib.rs#L317-L324
 features:
   - feature: node_provider
-    value: wlxga-ebupj-sj2nf-g3sii-75i6b-oh64s-qmq7u-gmros-vi2if-3ktdv-cqe
-    explanation: Handing over the servers to another Node provider.
-  - feature: node_provider
-    value: spp3m-vawt7-3gyh6-pjz5d-6zidf-up3qb-yte62-otexv-vfpqg-n6awf-lqe
-    explanation: "Rivonia is selling its nodes as announced in the forum: https://forum.dfinity.org/t/new-node-provider-proposals/16643/1047"
-  - feature: node_provider
     value: dnpkk-x67ir-zwcyz-fkgzz-547t7-papxf-zby5t-i2log-uodsf-pcizd-jae
     explanation: "Cordoning until the UBO audit is completed. https://dfinity.slack.com/archives/C02BEQD3410/p1750167518659589"
-  - feature: node_provider
-    value: qsdw4-ao5ye-6rtq4-y3zhm-icjbj-lutd2-sbejz-4ajqz-pcflr-xrhsg-jae
-    explanation: "Carbon12 is selling its nodes to DEF: https://forum.dfinity.org/t/def-acquiring-nodes-from-carbon12/47236/2"
-  - feature: node_provider
-    value: glrjs-2dbzh-owbdd-fpp5e-eweoz-nsuto-e3jmk-tl42c-wem4f-qfpfa-qqe
-    explanation: "Cordone Zarety LLC due to the IPv6 issues: https://forum.dfinity.org/t/subnet-management-tdb26-nns/33663/93"


### PR DESCRIPTION
- Pruned obsolete node_provider entries from cordoned_features.yaml.
