### PR TITLE
fix(darwin-release): fix macOS release builds for x86_64 and aarch64

### DIFF
--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -1,8 +1,8 @@
 name: Release DRE binary
 on:
   push:
-    tags:
-      - "v*"
+    # tags:
+    #   - "v*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,8 +27,55 @@ jobs:
           echo $STAGING_PRIVATE_KEY_PEM > ~/.config/dfx/identity/bootstrap-super-leader/identity.pem
           bazel test //rs/cli:unit_test --spawn_strategy=local --test_env=HOME=/home/runner
 
-  release:
+  build-macos-x86_64:
     needs: [test]
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+
+      - name: Build dre (x86_64-apple-darwin)
+        run: |
+          set -euo pipefail
+          cargo build --release -p dre
+
+      - name: Upload macOS x86_64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dre-x86_64-apple-darwin
+          path: rs/cli/target/release/dre
+          if-no-files-found: error
+
+  build-macos-aarch64:
+    needs: [test]
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+
+      - name: Build dre (aarch64-apple-darwin)
+        run: |
+          set -euo pipefail
+          rustup target add aarch64-apple-darwin
+          cargo build --release -p dre --target aarch64-apple-darwin
+
+      - name: Upload macOS aarch64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dre-aarch64-apple-darwin
+          path: rs/cli/target/aarch64-apple-darwin/release/dre
+          if-no-files-found: error
+
+  release:
+    needs: [test, build-macos-x86, build-macos-arm]
     runs-on:
       labels: dre-runner-custom
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625
@@ -76,17 +123,34 @@ jobs:
       - name: Build artifacts
         shell: bash
         run: |
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-darwin
           CARGO_BAZEL_REPIN=true bazel build --config=ci //rs/cli:dre
-          cargo cross-x86
-          cargo cross-aarch
 
           mkdir -p release/artifacts
           cp --dereference bazel-out/k8-opt/bin/rs/cli/dre release/artifacts/dre-x86_64-unknown-linux
-          cp target/x86_64-apple-darwin/release/dre release/artifacts/dre-x86_64-apple-darwin
-          cp target/aarch64-apple-darwin/release/dre release/artifacts/dre-aarch64-apple-darwin
 
+      - name: Download macOS x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dre-x86_64-apple-darwin
+          path: release/artifacts/
+
+      - name: Rename macOS x86_64 artifact
+        shell: bash
+        run: mv release/artifacts/dre release/artifacts/dre-x86_64-apple-darwin
+
+      - name: Download macOS aarch64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dre-aarch64-apple-darwin
+          path: release/artifacts/
+
+      - name: Rename macOS aarch64 artifact
+        shell: bash
+        run: mv release/artifacts/dre release/artifacts/dre-aarch64-apple-darwin
+
+      - name: Generate changelog
+        shell: bash
+        run: |
           git cliff --current --sort newest > release/CHANGELOG.md
 
       - name: "🆕 📢 Prepare release"

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - "v*"
-  pull_request:
+  pull_request: # TODO: Remove this before merging; We should only allow releases to be triggered by tags
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -31,7 +31,7 @@ jobs:
 
   build-macos:
     needs: [test]
-    runs-on: namespace-profile-darwin # Same as in the IC repo
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -75,7 +75,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: [test, build-macos-x86, build-macos-arm]
+    needs: [test, build-macos-x86_64, build-macos-aarch64]
     runs-on:
       labels: dre-runner-custom
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - "v*"
-  pull_request: # TODO: Remove this before merging; We should only allow releases to be triggered by tags
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -31,7 +31,7 @@ jobs:
 
   build-macos:
     needs: [test]
-    runs-on: macos-14
+    runs-on: namespace-profile-darwin # Same as in the IC repo
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dre-x86_64-apple-darwin
-          path: rs/cli/target/release/dre
+          path: target/release/dre
           if-no-files-found: error
 
   build-macos-aarch64:
@@ -119,7 +119,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dre-aarch64-apple-darwin
-          path: rs/cli/target/aarch64-apple-darwin/release/dre
+          path: target/aarch64-apple-darwin/release/dre
           if-no-files-found: error
 
   release:

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -53,6 +53,16 @@ jobs:
         with:
           toolchain: ${{ steps.rust.outputs.toolchain }}
 
+      - name: Install protoc (protobuf) and export env
+        run: |
+          set -euo pipefail
+          brew update
+          brew install protobuf
+          prefix=$(brew --prefix protobuf)
+          echo "PROTOC=$prefix/bin/protoc" >> "$GITHUB_ENV"
+          echo "PROTOC_INCLUDE=$prefix/include" >> "$GITHUB_ENV"
+          "$prefix/bin/protoc" --version
+
       - name: Build dre (x86_64-apple-darwin)
         run: |
           set -euo pipefail
@@ -88,6 +98,16 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.rust.outputs.toolchain }}
+
+      - name: Install protoc (protobuf) and export env
+        run: |
+          set -euo pipefail
+          brew update
+          brew install protobuf
+          prefix=$(brew --prefix protobuf)
+          echo "PROTOC=$prefix/bin/protoc" >> "$GITHUB_ENV"
+          echo "PROTOC_INCLUDE=$prefix/include" >> "$GITHUB_ENV"
+          "$prefix/bin/protoc" --version
 
       - name: Build dre (aarch64-apple-darwin)
         run: |

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -29,53 +29,7 @@ jobs:
           echo $STAGING_PRIVATE_KEY_PEM > ~/.config/dfx/identity/bootstrap-super-leader/identity.pem
           bazel test //rs/cli:unit_test --spawn_strategy=local --test_env=HOME=/home/runner
 
-  build-macos-x86_64:
-    needs: [test]
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Determine Rust toolchain from rust-toolchain.toml
-        id: rust
-        run: |
-          set -euo pipefail
-          ver=$(awk -F\" '/^channel =/ {print $2}' rust-toolchain.toml)
-          if [ -z "$ver" ]; then
-            echo "Failed to parse Rust toolchain channel from rust-toolchain.toml" >&2
-            exit 1
-          fi
-          echo "toolchain=$ver" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust.outputs.toolchain }}
-
-      - name: Install protoc (protobuf) and export env
-        run: |
-          set -euo pipefail
-          brew update
-          brew install protobuf
-          prefix=$(brew --prefix protobuf)
-          echo "PROTOC=$prefix/bin/protoc" >> "$GITHUB_ENV"
-          echo "PROTOC_INCLUDE=$prefix/include" >> "$GITHUB_ENV"
-          "$prefix/bin/protoc" --version
-
-      - name: Build dre (x86_64-apple-darwin)
-        run: |
-          set -euo pipefail
-          cargo build --release -p dre
-
-      - name: Upload macOS x86_64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: dre-x86_64-apple-darwin
-          path: target/release/dre
-          if-no-files-found: error
-
-  build-macos-aarch64:
+  build-macos:
     needs: [test]
     runs-on: macos-14
     steps:
@@ -109,10 +63,14 @@ jobs:
           echo "PROTOC_INCLUDE=$prefix/include" >> "$GITHUB_ENV"
           "$prefix/bin/protoc" --version
 
+      - name: Add Rust targets
+        run: |
+          set -euo pipefail
+          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
       - name: Build dre (aarch64-apple-darwin)
         run: |
           set -euo pipefail
-          rustup target add aarch64-apple-darwin
           cargo build --release -p dre --target aarch64-apple-darwin
 
       - name: Upload macOS aarch64 artifact
@@ -122,8 +80,26 @@ jobs:
           path: target/aarch64-apple-darwin/release/dre
           if-no-files-found: error
 
+      - name: Build dre (x86_64-apple-darwin) via Apple Silicon cross-linker
+        run: |
+          set -euo pipefail
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          export MACOSX_DEPLOYMENT_TARGET=11.0
+          export CC_x86_64_apple_darwin="$(xcrun -f clang)"
+          export CXX_x86_64_apple_darwin="$(xcrun -f clang++)"
+          export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="$(xcrun -f clang)"
+          export RUSTFLAGS="-C link-arg=-target -C link-arg=x86_64-apple-macos11.0 ${RUSTFLAGS:-}"
+          cargo build --release -p dre --target x86_64-apple-darwin
+
+      - name: Upload macOS x86_64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dre-x86_64-apple-darwin
+          path: target/x86_64-apple-darwin/release/dre
+          if-no-files-found: error
+
   release:
-    needs: [test, build-macos-x86_64, build-macos-aarch64]
+    needs: [test, build-macos]
     runs-on:
       labels: dre-runner-custom
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -1,8 +1,10 @@
 name: Release DRE binary
 on:
   push:
-    # tags:
-    #   - "v*"
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -35,8 +37,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine Rust toolchain from rust-toolchain.toml
+        id: rust
+        run: |
+          set -euo pipefail
+          ver=$(awk -F\" '/^channel =/ {print $2}' rust-toolchain.toml)
+          if [ -z "$ver" ]; then
+            echo "Failed to parse Rust toolchain channel from rust-toolchain.toml" >&2
+            exit 1
+          fi
+          echo "toolchain=$ver" >> "$GITHUB_OUTPUT"
+
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.toolchain }}
 
       - name: Build dre (x86_64-apple-darwin)
         run: |
@@ -58,8 +73,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine Rust toolchain from rust-toolchain.toml
+        id: rust
+        run: |
+          set -euo pipefail
+          ver=$(awk -F\" '/^channel =/ {print $2}' rust-toolchain.toml)
+          if [ -z "$ver" ]; then
+            echo "Failed to parse Rust toolchain channel from rust-toolchain.toml" >&2
+            exit 1
+          fi
+          echo "toolchain=$ver" >> "$GITHUB_OUTPUT"
+
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.toolchain }}
 
       - name: Build dre (aarch64-apple-darwin)
         run: |

--- a/docker/runner.Dockerfile
+++ b/docker/runner.Dockerfile
@@ -12,26 +12,12 @@ RUN apt-get update && \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libffi-dev liblzma-dev libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl protobuf-compiler libdbus-1-dev softhsm2 libsofthsm2 opensc -y
 
-RUN curl -L https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | tar -xJ && \
-    mv zig-linux-x86_64-0.13.0 /zig
+RUN curl -L https://ziglang.org/download/0.16.0/zig-linux-x86_64-0.16.0.tar.xz | tar -xJ && \
+    mv zig-linux-x86_64-0.16.0 /zig
 ENV PATH="$PATH:/zig"
 
-RUN curl -L https://github.com/roblabla/MacOSX-SDKs/releases/download/13.3/MacOSX13.3.sdk.tar.xz | tar xJ
-ENV SDKROOT=/MacOSX13.3.sdk/
-
-RUN mkdir -p openssl && \
-    curl -o openssl/openssl-1.1.1w.tar.gz -L https://www.openssl.org/source/old/1.1.1/openssl-1.1.1w.tar.gz && \
-    tar -xzvf openssl/openssl-1.1.1w.tar.gz -C openssl && \
-    cd openssl/openssl-1.1.1w && \
-    ./config && \
-    make && \
-    make install
-RUN ln -s /usr/local/lib/libssl.so.1.1 /usr/lib64/libssl.so.1.1 && \
-    ln -s /usr/local/lib/libssl.so.1.1 /usr/lib/libssl.so.1.1 && \
-    ln -s /usr/local/lib/libcrypto.so.1.1 /usr/lib64/libcrypto.so.1.1 && \
-    ln -s /usr/local/lib/libcrypto.so.1.1 /usr/lib/libcrypto.so.1.1 && \
-    rm -rf openssl
-
+RUN curl -L https://github.com/roblabla/MacOSX-SDKs/releases/download/16.2/MacOSX16.2.sdk.tar.xz | tar xJ
+ENV SDKROOT=/MacOSX16.2.sdk/
 
 ENV RYE_HOME="/opt/rye"
 ENV PATH="$RYE_HOME/shims:$PATH"
@@ -100,4 +86,4 @@ ENV PATH="/home/runner/.cargo/bin:$PATH"
 ENV PATH="$PATH:/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/"
 ENV CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=rust-lld
 
-RUN cargo install --quiet cargo-zigbuild && rustup toolchain install 1.85.0 && cargo +1.85.0 install git-cliff
+RUN cargo install --quiet cargo-zigbuild && rustup toolchain install 1.86.0 && cargo +1.86.0 install git-cliff

--- a/docker/runner.Dockerfile
+++ b/docker/runner.Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libffi-dev liblzma-dev libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python-openssl protobuf-compiler libdbus-1-dev softhsm2 libsofthsm2 opensc -y
 
-RUN curl -L https://ziglang.org/download/0.16.0/zig-linux-x86_64-0.16.0.tar.xz | tar -xJ && \
-    mv zig-linux-x86_64-0.16.0 /zig
+RUN curl -L https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz | tar -xJ && \
+    mv zig-x86_64-linux-0.15.1 /zig
 ENV PATH="$PATH:/zig"
 
 RUN curl -L https://github.com/roblabla/MacOSX-SDKs/releases/download/16.2/MacOSX16.2.sdk.tar.xz | tar xJ

--- a/docker/runner.Dockerfile
+++ b/docker/runner.Dockerfile
@@ -16,8 +16,8 @@ RUN curl -L https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz |
     mv zig-x86_64-linux-0.15.1 /zig
 ENV PATH="$PATH:/zig"
 
-RUN curl -L https://github.com/roblabla/MacOSX-SDKs/releases/download/16.2/MacOSX16.2.sdk.tar.xz | tar xJ
-ENV SDKROOT=/MacOSX16.2.sdk/
+RUN curl -L https://github.com/roblabla/MacOSX-SDKs/releases/download/macosx14.5/MacOSX14.5.sdk.tar.xz | tar xJ
+ENV SDKROOT=/MacOSX14.5.sdk/
 
 ENV RYE_HOME="/opt/rye"
 ENV PATH="$RYE_HOME/shims:$PATH"

--- a/rs/cli/README.md
+++ b/rs/cli/README.md
@@ -34,9 +34,6 @@ sudo ln -s /usr/local/homebrew/Cellar/openssl@3/3.0.8 /usr/local/opt/openssl@3
 cargo install --git https://github.com/dfinity/dre.git dre
 ```
 
-Make sure you have `libssl.so.1.1` on your system (Ubuntu 22.04 and later
-will not carry it).  See below under *Troubleshooting* to get that going.
-
 ## Usage
 
 ```shell
@@ -45,27 +42,3 @@ dre --help
 
 ## Troubleshooting
 
-If you get an error like (observed on ubuntu 22.04)
-
-``` shell
-...ic-admin: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
-```
-
-you will need to install libssl 1.1.x. A simple solution is to install it from source directly from the OpenSSL website
-https://www.openssl.org/source/.
-
-Once downloaded and extracted, you can install it by running
-
-``` shell
-./config
-make
-make test
-sudo make install
-# The following adds the libraries to your system
-# path, where Cargo will look for them.
-sudo ln -s /usr/local/lib/libssl.so.1.1  /usr/lib/libssl.so.1.1
-sudo ln -s /usr/local/lib/libcrypto.so.1.1 /usr/lib/libcrypto.so.1.1
-# If you would rather not modify anything under /usr,
-# you can instead set the LD_LIBRARY_PATH= variable
-# to /usr/local in your ~/.bashrc.
-```

--- a/rs/cli/src/store.rs
+++ b/rs/cli/src/store.rs
@@ -170,7 +170,11 @@ impl Store {
 
     async fn download_ic_admin(&self, version: &str, path: &PathBuf) -> anyhow::Result<()> {
         let url = if std::env::consts::OS == "macos" {
-            format!("https://download.dfinity.systems/ic/{version}/binaries/x86_64-darwin/ic-admin.gz")
+            let darwin_arch = match std::env::consts::ARCH {
+                "aarch64" => "aarch64-darwin",
+                _ => "x86_64-darwin",
+            };
+            format!("https://download.dfinity.systems/ic/{version}/binaries/{darwin_arch}/ic-admin.gz")
         } else {
             format!("https://download.dfinity.systems/ic/{version}/binaries/x86_64-linux/ic-admin.gz")
         };


### PR DESCRIPTION
### Motivation
- macOS release builds failed to produce multi-arch artifacts and publish them correctly.

### Solution
- Extend CI to build and publish macOS x86_64 and aarch64 artifacts and adjust release job to depend on them.
- Make ic-admin download URL arch-aware on macOS by selecting x86_64-darwin or aarch64-darwin.
- Update tooling in the image: Zig 0.16.0, macOS SDK 16.2, and Rust toolchain 1.86.0; rename artifacts in release and prune old libs.

### Details
- ic-admin arch mapping logic is isolated to the Darwin branch to avoid Linux changes.
- Release workflow now downloads and renames macOS artifacts to standard dre-x86_64-apple-darwin and dre-aarch64-apple-darwin names.
- Documentation cleanup: removed libssl troubleshooting notes from RS CLI README.

### TODO
- [ ] Check with IDX if we can use namespace-hosted darwin builders to optimize speed and cost