### PR TITLE
docs(release-controller): update navigation and release notes docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
       - "NNS Proposals": nns-proposals.md
       - "Submitting Motion Proposals": nns-motion-proposals.md
       - "Running Qualification": qualification/running-qualification.md
-      - "Release Controller": release.md
+      - "Release Controller and Release Notes": ../release-controller/README.md
       - "Being a DRE": be-dr-dre.md
   - "Development":
       - "Kubernetes":
@@ -33,6 +33,8 @@ nav:
           - "Elastic configuration": k8s/elastic-commands.md
       - "Bazel":
           - "Tips and Tricks": bazel/tips-and-tricks.md
+      - "CLI Tool": ../rs/cli/README.md
+      - "Trusted Neurons Alerts": ../trusted-neurons-alerts/README.md
 
 theme:
   name: material

--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -307,7 +307,9 @@ bazel run //release-controller:commit-annotator \
 
 ### Generate release notes locally
 
-Release notes can be generated locally, using the following command:
+Release notes can be generated locally using several approaches:
+
+#### Method 1: Using Bazel with specific RC names
 
 ```sh
 PREV_RC=rc--2025-03-27_03-14-base
@@ -318,6 +320,28 @@ bazel run //release-controller:release-notes -- \
    $PREV_RC $PREV_COMMIT $CURR_RC $CURR_COMMIT \
   --verbose
 ```
+
+#### Method 2: Using Bazel with generic names and local commit annotator
+
+```sh
+bazel run //release-controller:release-notes -- prev bf0d4d1b8cb6c0c19a5afa1454ada014847aa5c6 curr 07c01746ee3fa7700eb0eb781a7c26a53f989b1a --commit-annotator=local
+```
+
+#### Method 3: Using Rye (Python environment)
+
+First, ensure your Python environment is set up:
+
+```sh
+rye sync
+```
+
+Then run the release notes script directly:
+
+```sh
+rye run python3 release-controller/release_notes.py prev bf0d4d1b8cb6c0c19a5afa1454ada014847aa5c6 curr 07c01746ee3fa7700eb0eb781a7c26a53f989b1a --commit-annotator=local
+```
+
+#### Commit Annotator Options
 
 The form of the command above requires you to run a commit annotator in
 parallel.  If you want to use the internal commit annotator that does not


### PR DESCRIPTION
### Motivation
- Improve discoverability of Release Controller docs and release notes workflow.

### Solution
- Update mkdocs.yml nav to rename Release Controller to "Release Controller and Release Notes" and add links for CLI Tool and Trusted Neurons Alerts.
- Expand release-controller/README.md with three approaches to generate release notes: Method 1 (named RCs via Bazel), Method 2 (generic names with local commit annotator), and Method 3 (Rye/Python).

### Meta
updated docs to reflect new RC release notes workflow