### PR TITLE
chore(releases): update repro-check script path to ci/scripts

### DIFF
--- a/release-controller/release_index_loader.py
+++ b/release-controller/release_index_loader.py
@@ -29,7 +29,7 @@ To build and verify the IC-OS {os_kind} disk image, after installing curl if nec
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-curl -fsSL https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check | python3 - -c {version} --{os_kind.lower()}
+curl -fsSL https://raw.githubusercontent.com/dfinity/ic/{version}/ci/scripts/repro-check | python3 - -c {version} --{os_kind.lower()}
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.

--- a/release-controller/tests/test_release_index_loader.py
+++ b/release-controller/tests/test_release_index_loader.py
@@ -106,7 +106,7 @@ To build and verify the IC-OS GuestOS disk image, after installing curl if neces
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-curl -fsSL https://raw.githubusercontent.com/dfinity/ic/35bfcadd0f2a474057e42393917b8b3ac269627a/ci/tools/repro-check | python3 - -c 35bfcadd0f2a474057e42393917b8b3ac269627a --guestos
+curl -fsSL https://raw.githubusercontent.com/dfinity/ic/35bfcadd0f2a474057e42393917b8b3ac269627a/ci/scripts/repro-check | python3 - -c 35bfcadd0f2a474057e42393917b8b3ac269627a --guestos
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image, must be identical, and must match the SHA256 from the payload of the NNS proposal.

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -1253,7 +1253,7 @@ To build and verify the IC-OS {artifact_name} disk image, after installing curl 
 
 ```
 # From https://github.com/dfinity/ic#verifying-releases
-curl -fsSL https://raw.githubusercontent.com/dfinity/ic/{version}/ci/tools/repro-check | python3 - -c {version} {artifact_str}
+curl -fsSL https://raw.githubusercontent.com/dfinity/ic/{version}/ci/scripts/repro-check | python3 - -c {version} {artifact_str}
 ```
 
 The two SHA256 sums printed above from a) the downloaded CDN image and b) the locally built image,


### PR DESCRIPTION
### Motivation
- Update repro-check script URL to ci/scripts/repro-check to align with upstream changes.

### Solution
- Replace ci/tools/repro-check with ci/scripts/repro-check in release_index_loader.py, test_release_index_loader.py, and rs/cli/src/runner.rs.

### Details
- No functional changes; only string literals.

### Meta
updated tests accordingly