### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-runner.yaml
+++ b/.github/workflows/build-runner.yaml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "🔧 Login to GitHub Container Registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/clean-bazel-caches.yaml
+++ b/.github/workflows/clean-bazel-caches.yaml
@@ -18,12 +18,12 @@ jobs:
       matrix:
         runner: [1, 2, 3, 4] # We currently have 4 runners, adjust this number if more runners are added
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: "☁️ Setup bazelisk"
-        uses: bazelbuild/setup-bazelisk@v3
+        uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3
 
       - name: Clean Bazel Cache
         run: |

--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -21,13 +21,13 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "🚀 Building"
         run: |
           docker build -t ghcr.io/dfinity/dre/ic-management-frontend:$GITHUB_SHA -f dashboard/Dockerfile dashboard
 
       - name: "🔧 Login to GitHub Container Registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/dre-release.yaml
+++ b/.github/workflows/dre-release.yaml
@@ -14,7 +14,7 @@ jobs:
       labels: dre-runner-custom
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "☁️ Setup runner"
         uses: ./.github/workflows/manage-runner-pre
@@ -31,7 +31,7 @@ jobs:
     needs: [test]
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
           echo "toolchain=$ver" >> "$GITHUB_OUTPUT"
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ steps.rust.outputs.toolchain }}
 
@@ -79,7 +79,7 @@ jobs:
           cargo build --release -p dre --target aarch64-apple-darwin
 
       - name: Upload macOS aarch64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dre-aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release/dre
@@ -97,7 +97,7 @@ jobs:
           cargo build --release -p dre --target x86_64-apple-darwin
 
       - name: Upload macOS x86_64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dre-x86_64-apple-darwin
           path: target/x86_64-apple-darwin/release/dre
@@ -113,7 +113,7 @@ jobs:
       packages: write
       pages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -125,7 +125,7 @@ jobs:
       # If regular secrets.GITHUB_TOKEN is used instead, the push will not trigger any actions
       # https://github.com/orgs/community/discussions/25702
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -158,7 +158,7 @@ jobs:
           cp --dereference bazel-out/k8-opt/bin/rs/cli/dre release/artifacts/dre-x86_64-unknown-linux
 
       - name: Download macOS x86_64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dre-x86_64-apple-darwin
           path: release/artifacts/
@@ -168,7 +168,7 @@ jobs:
         run: mv release/artifacts/dre release/artifacts/dre-x86_64-apple-darwin
 
       - name: Download macOS aarch64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dre-aarch64-apple-darwin
           path: release/artifacts/
@@ -202,7 +202,7 @@ jobs:
           rm -rf release
 
       - name: "🆕 Create a new Pull Request with the changes"
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           commit-message: "chore(release): New release of `dre` version ${{ steps.tag.outputs.tag }}"
           branch: bot-release-${{ steps.tag.outputs.tag }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
       packages: write
       pages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
 
@@ -45,7 +45,7 @@ jobs:
       # If regular secrets.GITHUB_TOKEN is used instead, the push will not trigger any actions
       # https://github.com/orgs/community/discussions/25702
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: "🧪 Upload test artifacts"
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-artifacts
           path: bazel-out/k8-opt/bin/rs/ic-observability/multiservice-discovery/multiservice-discovery

--- a/.github/workflows/msd-diff.yaml
+++ b/.github/workflows/msd-diff.yaml
@@ -19,7 +19,7 @@ jobs:
     # This image is based on ubuntu:20.04
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/workflows/manage-runner-pre
 
       - name: "📥 Download main test artifact"
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
         with:
           name: test-artifacts
           branch: main

--- a/.github/workflows/pull-request-update.yaml
+++ b/.github/workflows/pull-request-update.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-      - uses: chinthakagodawita/autoupdate@v1.7.0
+      - uses: chinthakagodawita/autoupdate@0707656cd062a3b0cf8fa9b2cda1d1404d74437e # v1.7.0
         env:
           GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
           MERGE_MSG: "Branch was auto-updated."

--- a/.github/workflows/release-controller.yaml
+++ b/.github/workflows/release-controller.yaml
@@ -42,7 +42,7 @@ jobs:
       packages: write
       pages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
 
@@ -50,7 +50,7 @@ jobs:
       # If regular secrets.GITHUB_TOKEN is used instead, the push will not trigger any actions
       # https://github.com/orgs/community/discussions/25702
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625
     name: Check changed release index files
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Run checks for release index
         run: |
           rye sync

--- a/.github/workflows/required-checks.yaml
+++ b/.github/workflows/required-checks.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for running jobs
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
         with:
           ref: ${{ github.ref }}
           running-workflow-name: Wait for required jobs to complete or be skipped

--- a/.github/workflows/trusted-neurons-alerts.yaml
+++ b/.github/workflows/trusted-neurons-alerts.yaml
@@ -38,7 +38,7 @@ jobs:
       packages: write
       pages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
 
@@ -46,7 +46,7 @@ jobs:
       # If regular secrets.GITHUB_TOKEN is used instead, the push will not trigger any actions
       # https://github.com/orgs/community/discussions/25702
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -11,12 +11,12 @@ jobs:
     container: ghcr.io/dfinity/dre/actions-runner:6413f2909a49329ecbf5371ee7ddf07a9799b625
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "🔧 Setup runner"
         uses: ./.github/workflows/manage-runner-pre
 
@@ -57,7 +57,7 @@ jobs:
           ./bin/release-controller-update-data-model.sh
 
       - name: "🆕 Create a new Pull Request with the changes"
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           commit-message: "chore(deps): Update dependencies"
           branch: bot-update-deps


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `docker/login-action@v3` -> `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0`
  - Version: v3.7.0 | Latest: v4.1.0 | Release age: 35d
  - Commit: https://github.com/docker/login-action/commit/c94ce9fb468520275223c153574b00df6fe4bcc9
  - Warnings: Latest release v4.1.0 is only 5 day(s) old (< 7 days). Using previous safe release.

- `bazelbuild/setup-bazelisk@v3` -> `bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3`
  - Version: v3 | Latest: v3.0.0 | Release age: 795d
  - Commit: https://github.com/bazelbuild/setup-bazelisk/commit/b39c379c82683a5f25d34f0d062761f62693e0b2

- `dtolnay/rust-toolchain@master` -> `dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master`
  - Version: master | Latest: v1 | Release age: 1362d
  - Commit: https://github.com/dtolnay/rust-toolchain/commit/3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 22d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `actions/create-github-app-token@v2` -> `actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2`
  - Version: v2.2.2 | Latest: v3.0.0 | Release age: 25d
  - Commit: https://github.com/actions/create-github-app-token/commit/fee1f7d63c2ff003460e3d139729b119787bc349

- `actions/download-artifact@v4` -> `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0`
  - Version: v4.3.0 | Latest: v3.1.0-node20 | Release age: 22d
  - Commit: https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `peter-evans/create-pull-request@v7` -> `peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11`
  - Version: v7.0.11 | Latest: v8.1.0 | Release age: 77d
  - Commit: https://github.com/peter-evans/create-pull-request/commit/22a9089034f40e5a961c8808d113e2c98fb63676

- `dawidd6/action-download-artifact@v11` -> `dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11`
  - Version: v11 | Latest: v20 | Release age: 21d
  - Commit: https://github.com/dawidd6/action-download-artifact/commit/ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
  - Warnings: Latest release v20 is only 5 day(s) old (< 7 days). Using previous safe release., 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `chinthakagodawita/autoupdate@v1.7.0` -> `chinthakagodawita/autoupdate@0707656cd062a3b0cf8fa9b2cda1d1404d74437e # v1.7.0`
  - Version: v1.7.0 | Latest: v1.7.0 | Release age: 1109d
  - Commit: https://github.com/chinthakagodawita/autoupdate/commit/0707656cd062a3b0cf8fa9b2cda1d1404d74437e

- `lewagon/wait-on-check-action@v1.3.4` -> `lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4`
  - Version: v1.3.4 | Latest: v1.6.1 | Release age: 10d
  - Commit: https://github.com/lewagon/wait-on-check-action/commit/ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc
  - Warnings: Latest release v1.6.1 is only 2 day(s) old (< 7 days). Using previous safe release.


### Files modified

- `.github/workflows/build-runner.yaml`
- `.github/workflows/clean-bazel-caches.yaml`
- `.github/workflows/dashboard.yaml`
- `.github/workflows/dre-release.yaml`
- `.github/workflows/main.yaml`
- `.github/workflows/msd-diff.yaml`
- `.github/workflows/pull-request-update.yaml`
- `.github/workflows/release-controller.yaml`
- `.github/workflows/release.yaml`
- `.github/workflows/required-checks.yaml`
- `.github/workflows/trusted-neurons-alerts.yaml`
- `.github/workflows/update-dependencies.yaml`

### Security warnings

- Latest release v4.1.0 is only 5 day(s) old (< 7 days). Using previous safe release.
- 1 security advisory(ies) found
- Action has 1 known advisory(ies)
- Latest release v20 is only 5 day(s) old (< 7 days). Using previous safe release.
- Latest release v1.6.1 is only 2 day(s) old (< 7 days). Using previous safe release.