### PR TITLE
fix(release-controller): stop resubmitting election proposals for already-elected versions

### DIFF
--- a/release-controller/README.md
+++ b/release-controller/README.md
@@ -224,7 +224,7 @@ next cycle.
 
 ```yaml
 ignored_proposals:
-  - 141776 # GuestOS election proposal rejected; resubmit the version.
+  - 123456 # GuestOS election proposal rejected; resubmit the version.
 releases:
   - rc_name: rc--...
     versions:
@@ -237,9 +237,14 @@ Caveats:
   that is already blessed.  This lever only helps when the prior
   proposal did **not** result in a blessing (typically REJECTED or
   FAILED).
-- Remove the entry from `release-index.yaml` once the replacement
-  proposal has been submitted.  Leaving it in indefinitely silently
-  swallows any future state for the same proposal id.
+- **Remove the entry from `release-index.yaml` once the replacement
+  proposal has been submitted.**  Leaving a stale entry around is
+  harmless for the version it was added for -- the proposal-by-version
+  lookup keeps the largest-id proposal for that version, so a later
+  successful resubmission still takes precedence.  As a safety net, the
+  reconciler also refuses to submit a fresh proposal for a version that
+  is already in the elected (`blessed`) set, logging a clear warning if
+  it sees the situation.
 
 ## Development
 

--- a/release-controller/dre_cli.py
+++ b/release-controller/dre_cli.py
@@ -39,6 +39,64 @@ class ElectionProposal(typing.TypedDict):
     payload: HostosElectionProposalPayload | GuestosElectionProposalPayload
 
 
+def proposals_by_version(
+    proposals: typing.Iterable[ElectionProposal],
+    ignore_ids: typing.Iterable[int] = (),
+) -> tuple[dict[str, ElectionProposal], dict[str, ElectionProposal]]:
+    """
+    Aggregate a flat list of IC OS election proposals into two
+    version -> proposal dicts (GuestOS, HostOS), with three semantics that
+    cooperate to make ``release-index.yaml``'s ``ignored_proposals`` mechanism
+    safe:
+
+    * ``ignore_ids`` is applied **before** aggregation, so dropping a stale
+      proposal does not also drop a perfectly good alternative proposal
+      targeting the same version.
+    * When several proposals target the same version (e.g. a failed attempt
+      was resubmitted), the proposal with the largest ``id`` wins -- there
+      is no reliance on the iteration order of the input.
+    * Proposals with no version in their payload (or with an empty one) are
+      ignored.
+
+    Regression test target: the previous implementation built the dict by
+    unconditional overwrite inside a buggy nested loop, so whichever
+    proposal happened to be assigned last (the oldest given a newest-first
+    input) ended up in the dict.  Combined with a stale ``ignored_proposals``
+    entry, this caused the reconciler to lose track of a successful
+    resubmission and fire a duplicate election proposal on every restart.
+    """
+    guestos: dict[str, ElectionProposal] = {}
+    hostos: dict[str, ElectionProposal] = {}
+    ignored: set[int] = set(ignore_ids)
+
+    def keep_if_newer(
+        store: dict[str, ElectionProposal],
+        version: str,
+        proposal: ElectionProposal,
+    ) -> None:
+        existing = store.get(version)
+        if existing is None or proposal["id"] > existing["id"]:
+            store[version] = proposal
+
+    for proposal in proposals:
+        if proposal["id"] in ignored:
+            continue
+        payload = proposal["payload"]
+        if "replica_version_to_elect" in payload:
+            guestos_version = typing.cast(
+                GuestosElectionProposalPayload, payload
+            ).get("replica_version_to_elect")
+            if guestos_version:
+                keep_if_newer(guestos, guestos_version, proposal)
+        if "hostos_version_to_elect" in payload:
+            hostos_version = typing.cast(
+                HostosElectionProposalPayload, payload
+            ).get("hostos_version_to_elect")
+            if hostos_version:
+                keep_if_newer(hostos, hostos_version, proposal)
+    return guestos, hostos
+
+
 def _mode_flags(dry_run: bool) -> list[str]:
     """
     Return what DRE flag set to use depending on the mode.
@@ -149,28 +207,10 @@ class DRECli:
         """
         Get all IC OS election proposals in two separate dictionaries keyed
         by version -- the first dictionary contains GuestOS proposals, and
-        the second contains HostOS proposals."""
-        d: dict[str, ElectionProposal] = {}
-        od: dict[str, ElectionProposal] = {}
-        known_proposals = self.get_past_election_proposals()
-        for proposal in known_proposals:
-            for proposal in known_proposals:
-                payload = proposal["payload"]
-                if "replica_version_to_elect" in payload:
-                    replica_version = typing.cast(
-                        GuestosElectionProposalPayload, payload
-                    ).get("replica_version_to_elect")
-                    if not replica_version:
-                        continue
-                    d[replica_version] = proposal
-                if "hostos_version_to_elect" in payload:
-                    hostos_version = typing.cast(
-                        HostosElectionProposalPayload, payload
-                    ).get("hostos_version_to_elect")
-                    if not hostos_version:
-                        continue
-                    od[hostos_version] = proposal
-        return d, od
+        the second contains HostOS proposals.  See
+        :func:`proposals_by_version` for the aggregation semantics.
+        """
+        return proposals_by_version(self.get_past_election_proposals())
 
     def propose_to_revise_elected_os_versions(
         self,

--- a/release-controller/public_dashboard.py
+++ b/release-controller/public_dashboard.py
@@ -36,29 +36,10 @@ class DashboardAPI:
         """
         Get IC OS election proposals in two separate dictionaries keyed
         by version -- the first dictionary contains GuestOS proposals, and
-        the second contains HostOS proposals."""
-
-        d: dict[str, dre_cli.ElectionProposal] = {}
-        od: dict[str, dre_cli.ElectionProposal] = {}
-        known_proposals = self.get_past_election_proposals()
-        for proposal in known_proposals:
-            for proposal in known_proposals:
-                payload = proposal["payload"]
-                if "replica_version_to_elect" in payload:
-                    replica_version = typing.cast(
-                        dre_cli.GuestosElectionProposalPayload, payload
-                    ).get("replica_version_to_elect")
-                    if not replica_version:
-                        continue
-                    d[replica_version] = proposal
-                if "hostos_version_to_elect" in payload:
-                    hostos_version = typing.cast(
-                        dre_cli.HostosElectionProposalPayload, payload
-                    ).get("hostos_version_to_elect")
-                    if not hostos_version:
-                        continue
-                    od[hostos_version] = proposal
-        return d, od
+        the second contains HostOS proposals.  See
+        :func:`dre_cli.proposals_by_version` for the aggregation semantics.
+        """
+        return dre_cli.proposals_by_version(self.get_past_election_proposals())
 
 
 if __name__ == "__main__":

--- a/release-controller/reconciler.py
+++ b/release-controller/reconciler.py
@@ -437,13 +437,7 @@ class Reconciler:
 
     @staticmethod
     def _filtered_proposals_retriever(
-        retriever: typing.Callable[
-            [],
-            tuple[
-                dict[str, dre_cli.ElectionProposal],
-                dict[str, dre_cli.ElectionProposal],
-            ],
-        ],
+        raw_retriever: typing.Callable[[], list[dre_cli.ElectionProposal]],
         source: str,
         ignore_proposal_ids: typing.Iterable[int],
     ) -> typing.Callable[
@@ -453,47 +447,40 @@ class Reconciler:
             dict[str, dre_cli.ElectionProposal],
         ],
     ]:
-        """Wrap a proposal retriever so it drops ignored proposal IDs.
+        """Wrap a raw proposal-list retriever into a by-version aggregator
+        that drops ignored proposal IDs *before* aggregating.
 
-        The wrapped retriever omits any proposal whose ``id`` is listed in
-        the index's top-level ``ignored_proposals`` so the affected versions
-        are treated by :class:`reconciler_state.ReconcilerState` as if no
-        proposal had been submitted.
+        Any proposal whose ``id`` is listed in the index's top-level
+        ``ignored_proposals`` is removed from the input list, then the
+        remaining proposals are aggregated by :func:`dre_cli.proposals_by_version`.
+        Filtering at the list level (rather than after aggregation) means a
+        stale ``ignored_proposals`` entry cannot accidentally hide an
+        otherwise-valid proposal that targets the same version -- the
+        next-highest-id proposal for that version simply takes its place.
         """
         ignore_set: set[int] = set(ignore_proposal_ids)
-
-        def _drop_ignored(
-            d: dict[str, dre_cli.ElectionProposal],
-            os_kind: OsKind,
-        ) -> dict[str, dre_cli.ElectionProposal]:
-            out: dict[str, dre_cli.ElectionProposal] = {}
-            for version, proposal in d.items():
-                if proposal["id"] in ignore_set:
-                    LOGGER.warning(
-                        "Ignoring %s %s election proposal %s for version %s"
-                        " (listed in release-index.yaml ignored_proposals);"
-                        " the reconciler will treat this version as not yet"
-                        " proposed.",
-                        source,
-                        os_kind,
-                        proposal["id"],
-                        version,
-                    )
-                    continue
-                out[version] = proposal
-            return out
 
         def wrapped() -> tuple[
             dict[str, dre_cli.ElectionProposal],
             dict[str, dre_cli.ElectionProposal],
         ]:
-            guestos, hostos = retriever()
-            if not ignore_set:
-                return guestos, hostos
-            return (
-                _drop_ignored(guestos, GUESTOS),
-                _drop_ignored(hostos, HOSTOS),
-            )
+            proposals = list(raw_retriever())
+            if ignore_set:
+                kept: list[dre_cli.ElectionProposal] = []
+                for proposal in proposals:
+                    if proposal["id"] in ignore_set:
+                        LOGGER.warning(
+                            "Ignoring %s election proposal %s"
+                            " (listed in release-index.yaml ignored_proposals);"
+                            " the reconciler will treat the targeted version as"
+                            " though this proposal had never been submitted.",
+                            source,
+                            proposal["id"],
+                        )
+                        continue
+                    kept.append(proposal)
+                proposals = kept
+            return dre_cli.proposals_by_version(proposals)
 
         return wrapped
 
@@ -521,7 +508,7 @@ class Reconciler:
         try:
             self.state.update_state(
                 self._filtered_proposals_retriever(
-                    self.dashboard.get_election_proposals_by_version,
+                    self.dashboard.get_past_election_proposals,
                     source="dashboard",
                     ignore_proposal_ids=ignore_proposal_ids,
                 )
@@ -538,7 +525,7 @@ class Reconciler:
         # that have the freshest state (dashboard lags).
         self.state.update_state(
             self._filtered_proposals_retriever(
-                self.dre.get_election_proposals_by_version,
+                self.dre.get_past_election_proposals,
                 source="dre",
                 ignore_proposal_ids=ignore_proposal_ids,
             )
@@ -903,6 +890,30 @@ class Reconciler:
                             "The following revisions will be unelected: %s",
                             unelect_versions,
                         )
+
+                        if release_commit in blessed:
+                            # Safety net: the version is already elected on the
+                            # NNS but no proposal id is recorded in reconciler
+                            # state.  This happens when release-index.yaml's
+                            # ignored_proposals lists every proposal that ever
+                            # targeted this version, so the proposal-retriever
+                            # hides the one that actually elected it.  Submitting
+                            # would create a duplicate that the governance
+                            # canister rejects -- just skip and warn loudly so
+                            # the operator drops the stale entry.
+                            revlogger.warning(
+                                "Version %s is already in the elected %s set but"
+                                " the reconciler has no record of its election"
+                                " proposal; refusing to submit a duplicate."
+                                "  This usually means release-index.yaml's"
+                                " ignored_proposals contains a stale id for the"
+                                " proposal that actually elected this version;"
+                                " remove that entry once the replacement has"
+                                " been submitted.",
+                                release_commit,
+                                v.os_kind,
+                            )
+                            continue
 
                     if v.os_kind == GUESTOS:
                         launch_measurements = fetch_launch_measurements(

--- a/release-controller/tests/test_reconciler_integration.py
+++ b/release-controller/tests/test_reconciler_integration.py
@@ -141,101 +141,122 @@ def _cdf(r: git_repo.GitRepo) -> commit_annotation.ChangeDeterminatorProtocol:
     return commit_annotation.LocalCommitChangeDeterminator(r)
 
 
-def _ignore_filter_retriever_fixture() -> typing.Callable[
-    [],
-    tuple[dict[str, ElectionProposal], dict[str, ElectionProposal]],
-]:
-    """
-    Build a self-contained retriever returning one GuestOS and one HostOS
-    election proposal with distinct IDs.  This bypasses ``MockDashboard``
-    (whose ``_fake_proposal`` always emits ``hostos_version_to_elect``)
-    so the test exercises both branches of the ignore filter.
-    """
-    guestos_commit = "11" * 20
-    hostos_commit = "22" * 20
+_FIXTURE_GUESTOS_COMMIT = "11" * 20
+_FIXTURE_HOSTOS_COMMIT = "22" * 20
 
-    def retriever() -> tuple[
-        dict[str, ElectionProposal], dict[str, ElectionProposal]
-    ]:
-        guestos: dict[str, ElectionProposal] = {
-            guestos_commit: {
-                "id": 200001,
-                "payload": {
-                    "replica_version_to_elect": guestos_commit,
-                    "release_package_sha256_hex": "aa" * 32,
-                },
-                "proposal_timestamp_seconds": 1743789296,
-                "proposer": 61,
-                "status": "REJECTED",
-                "summary": "...stubbed out...",
-                "title": "Elect new IC/GuestOS revision (test fixture)",
-            }
-        }
-        hostos: dict[str, ElectionProposal] = {
-            hostos_commit: {
-                "id": 200002,
-                "payload": {
-                    "hostos_version_to_elect": hostos_commit,
-                    "release_package_sha256_hex": "bb" * 32,
-                },
-                "proposal_timestamp_seconds": 1743789296,
-                "proposer": 61,
-                "status": "REJECTED",
-                "summary": "...stubbed out...",
-                "title": "Elect new IC/HostOS revision (test fixture)",
-            }
-        }
-        return guestos, hostos
 
-    return retriever
+def _ignore_filter_raw_proposals_fixture() -> list[ElectionProposal]:
+    """
+    Return a flat list of raw election proposals -- one GuestOS, one HostOS,
+    with distinct IDs.  This bypasses ``MockDashboard`` (whose ``_fake_proposal``
+    always emits ``hostos_version_to_elect``) so tests exercise both branches
+    of the ignore filter and the by-version aggregator.
+    """
+    return [
+        {
+            "id": 200001,
+            "payload": {
+                "replica_version_to_elect": _FIXTURE_GUESTOS_COMMIT,
+                "release_package_sha256_hex": "aa" * 32,
+            },
+            "proposal_timestamp_seconds": 1743789296,
+            "proposer": 61,
+            "status": "REJECTED",
+            "summary": "...stubbed out...",
+            "title": "Elect new IC/GuestOS revision (test fixture)",
+        },
+        {
+            "id": 200002,
+            "payload": {
+                "hostos_version_to_elect": _FIXTURE_HOSTOS_COMMIT,
+                "release_package_sha256_hex": "bb" * 32,
+            },
+            "proposal_timestamp_seconds": 1743789296,
+            "proposer": 61,
+            "status": "REJECTED",
+            "summary": "...stubbed out...",
+            "title": "Elect new IC/HostOS revision (test fixture)",
+        },
+    ]
 
 
 def test_reconciler_filtered_proposals_retriever_drops_ignored_ids() -> None:
     """
-    With ``ignored_proposals`` set, the wrapper around the proposal
-    retriever must omit any matching proposal so the corresponding
+    With ``ignored_proposals`` set, the wrapper around the raw-list retriever
+    must drop any matching proposal before aggregation, so the corresponding
     version is treated by ``ReconcilerState`` as not yet proposed.
     """
-    retriever = _ignore_filter_retriever_fixture()
-    guestos_commit, hostos_commit = "11" * 20, "22" * 20
     ignored_guestos_id = 200001
     rs = ReconcilerState()
 
     wrapped = Reconciler._filtered_proposals_retriever(
-        retriever,
+        _ignore_filter_raw_proposals_fixture,
         source="dashboard",
         ignore_proposal_ids=[ignored_guestos_id],
     )
     guestos, hostos = wrapped()
 
     assert guestos == {}, guestos
-    assert list(hostos.keys()) == [hostos_commit], hostos
-    assert hostos[hostos_commit]["id"] == 200002
+    assert list(hostos.keys()) == [_FIXTURE_HOSTOS_COMMIT], hostos
+    assert hostos[_FIXTURE_HOSTOS_COMMIT]["id"] == 200002
 
     rs.update_state(wrapped)
     assert isinstance(
-        rs.version_proposal(guestos_commit, const.GUESTOS),
+        rs.version_proposal(_FIXTURE_GUESTOS_COMMIT, const.GUESTOS),
         reconciler_state.NoProposal,
     )
     assert isinstance(
-        rs.version_proposal(hostos_commit, const.HOSTOS),
+        rs.version_proposal(_FIXTURE_HOSTOS_COMMIT, const.HOSTOS),
         reconciler_state.SubmittedProposal,
     )
 
 
 def test_reconciler_filtered_proposals_retriever_is_noop_without_ids() -> None:
-    """Without ``ignored_proposals``, the wrapper returns the data unchanged."""
-    retriever = _ignore_filter_retriever_fixture()
-
-    direct_guestos, direct_hostos = retriever()
+    """Without ``ignored_proposals``, the wrapper aggregates every proposal."""
     wrapped_guestos, wrapped_hostos = Reconciler._filtered_proposals_retriever(
-        retriever,
+        _ignore_filter_raw_proposals_fixture,
         source="dashboard",
         ignore_proposal_ids=[],
     )()
 
-    assert wrapped_guestos == direct_guestos
-    assert wrapped_hostos == direct_hostos
+    assert list(wrapped_guestos.keys()) == [_FIXTURE_GUESTOS_COMMIT]
+    assert wrapped_guestos[_FIXTURE_GUESTOS_COMMIT]["id"] == 200001
+    assert list(wrapped_hostos.keys()) == [_FIXTURE_HOSTOS_COMMIT]
+    assert wrapped_hostos[_FIXTURE_HOSTOS_COMMIT]["id"] == 200002
+
+
+def test_reconciler_filtered_proposals_retriever_falls_back_to_next_highest_id() -> (
+    None
+):
+    """
+    When several proposals target the same version and only the highest-id
+    one is in ``ignored_proposals``, the wrapper must fall back to the next-
+    highest-id proposal for that version, NOT report the version as
+    unproposed.  This is what prevents a stale ``ignored_proposals`` entry
+    from causing the reconciler to fire a duplicate election proposal once
+    the targeted version has been re-elected by a fresh submission.
+    """
+    version = "33" * 20
+
+    def retriever() -> list[ElectionProposal]:
+        return [
+            _guestos_election_proposal(300_005, version, status="FAILED"),
+            _guestos_election_proposal(300_004, version, status="EXECUTED"),
+            _guestos_election_proposal(300_003, version, status="FAILED"),
+        ]
+
+    wrapped = Reconciler._filtered_proposals_retriever(
+        retriever,
+        source="dashboard",
+        ignore_proposal_ids=[300_005],
+    )
+    guestos, hostos = wrapped()
+    assert hostos == {}
+    assert list(guestos.keys()) == [version]
+    assert guestos[version]["id"] == 300_004, (
+        "Wrapper must fall back to the next-highest-id non-ignored proposal,"
+        " not drop the version entirely."
+    )
 
 
 def test_reconciler_picks_up_ignored_proposals_from_release_index(
@@ -329,10 +350,13 @@ The NNS proposal is here: [IC NNS Proposal 138708](https://dashboard.internetcom
 Here is a summary of the changes since the last GuestOS release:
 
 Fake changelog for ('206b61a8616bc93d36d6a014e5cc8edf1ba256ae', 'GuestOS', False)"""
+        # MockDashboard pins two HostOS-encoded proposals (138817 and 138814)
+        # to each of the two top releases.  proposals_by_version keeps the
+        # one with the largest id, so the forum post must reference 138817.
         expected_hostos_post = """Hello there!
 
 We are happy to announce that voting is now open for [a new HostOS release](https://github.com/dfinity/ic/tree/release-2025-09-25_09-52-base).
-The NNS proposal is here: [IC NNS Proposal 138814](https://dashboard.internetcomputer.org/proposal/138814).
+The NNS proposal is here: [IC NNS Proposal 138817](https://dashboard.internetcomputer.org/proposal/138817).
 
 Here is a summary of the changes since the last HostOS release:
 
@@ -527,3 +551,189 @@ To see a full list of commits added since last release, compare the revisions on
 """.rstrip()
         assert guestos_post["cooked"] == expected_guestos_release_notes
         assert hostos_post["cooked"] == expected_hostos_release_notes
+
+
+def _guestos_election_proposal(
+    proposal_id: int, version: str, status: str = "EXECUTED"
+) -> ElectionProposal:
+    return {
+        "id": proposal_id,
+        "payload": {
+            "replica_version_to_elect": version,
+            "release_package_sha256_hex": "aa" * 32,
+        },
+        "proposal_timestamp_seconds": 1743789296,
+        "proposer": 61,
+        "status": status,
+        "summary": "...stubbed out...",
+        "title": f"Elect new IC/GuestOS revision (commit {version[:7]})",
+    }
+
+
+def _hostos_election_proposal(
+    proposal_id: int, version: str, status: str = "EXECUTED"
+) -> ElectionProposal:
+    return {
+        "id": proposal_id,
+        "payload": {
+            "hostos_version_to_elect": version,
+            "release_package_sha256_hex": "bb" * 32,
+        },
+        "proposal_timestamp_seconds": 1743789296,
+        "proposer": 61,
+        "status": status,
+        "summary": "...stubbed out...",
+        "title": f"Elect new IC/HostOS revision (commit {version[:7]})",
+    }
+
+
+def test_dashboard_get_election_proposals_by_version_keeps_highest_id_for_duplicates() -> (
+    None
+):
+    """
+    When several NNS election proposals target the same version (e.g. an
+    earlier attempt failed and was resubmitted), the proposal-by-version
+    lookup must return the proposal with the largest ``id``.
+
+    Regression test: a prior implementation built the dict by unconditional
+    overwrite inside a (buggy) nested loop, so whichever proposal happened to
+    be assigned last (i.e. the oldest, given that the dashboard API returns
+    proposals newest-first) ended up in the dict.  Combined with
+    ``ignored_proposals`` that targeted the failed (oldest) proposal, this
+    caused the reconciler to lose track of the successful resubmission and
+    fire a duplicate election proposal on every restart.
+    """
+    guestos_version = "11" * 20
+    hostos_version = "22" * 20
+
+    class _Dashboard(DashboardAPI):
+        def get_past_election_proposals(self) -> list[ElectionProposal]:
+            # Returned newest-first, matching the real dashboard API ordering.
+            return [
+                _guestos_election_proposal(200_004, guestos_version, status="OPEN"),
+                _guestos_election_proposal(200_003, guestos_version, status="EXECUTED"),
+                _guestos_election_proposal(200_001, guestos_version, status="FAILED"),
+                _hostos_election_proposal(200_002, hostos_version, status="EXECUTED"),
+                _hostos_election_proposal(200_000, hostos_version, status="FAILED"),
+            ]
+
+    guestos, hostos = _Dashboard().get_election_proposals_by_version()
+    assert list(guestos.keys()) == [guestos_version]
+    assert guestos[guestos_version]["id"] == 200_004
+    assert list(hostos.keys()) == [hostos_version]
+    assert hostos[hostos_version]["id"] == 200_002
+
+
+def test_dre_cli_get_election_proposals_by_version_keeps_highest_id_for_duplicates() -> (
+    None
+):
+    """Same contract as the dashboard version (see docstring there)."""
+    guestos_version = "33" * 20
+    hostos_version = "44" * 20
+
+    class _DRECli(dryrun.DRECli):
+        def get_past_election_proposals(self) -> list[ElectionProposal]:
+            return [
+                _guestos_election_proposal(300_004, guestos_version, status="OPEN"),
+                _guestos_election_proposal(300_003, guestos_version, status="EXECUTED"),
+                _guestos_election_proposal(300_001, guestos_version, status="FAILED"),
+                _hostos_election_proposal(300_002, hostos_version, status="EXECUTED"),
+                _hostos_election_proposal(300_000, hostos_version, status="FAILED"),
+            ]
+
+    guestos, hostos = _DRECli().get_election_proposals_by_version()
+    assert list(guestos.keys()) == [guestos_version]
+    assert guestos[guestos_version]["id"] == 300_004
+    assert list(hostos.keys()) == [hostos_version]
+    assert hostos[hostos_version]["id"] == 300_002
+
+
+def test_reconciler_skips_submission_when_version_already_in_blessed_set(
+    ic_repo: git_repo.GitRepo,
+    mocker: pytest_mock.plugin.MockerFixture,
+) -> None:
+    """
+    Safety net: if a version is already in the elected (``blessed``) set but
+    the reconciler has no record of its proposal -- e.g. because the
+    proposal that elected it is listed in ``ignored_proposals`` and the
+    operator forgot to remove it -- the reconciler must NOT submit another
+    election proposal, because the governance canister would reject the
+    duplicate.  See ``release-controller/reconciler.py`` proposal-submission
+    branch for the corresponding short-circuit.
+    """
+    with mocker.patch.object(ic_repo, "push_release_tags"):
+        d, f, n, rs, a, dre, s, rl, p, db = _defaults_for_test()
+        already_elected_version = "45657852c1eca6728ff313808db29b47c862ad13"
+
+        # Dashboard / DRE see no proposals at all for the target version
+        # (the only proposal that ever targeted it was filtered out by
+        # ignored_proposals upstream; we simulate that by returning an empty
+        # list).  Combined with the version being in the elected set, this
+        # is exactly the situation that used to drive duplicate submissions.
+        mocker.patch.object(db, "get_past_election_proposals", return_value=[])
+        mocker.patch.object(dre, "get_past_election_proposals", return_value=[])
+        mocker.patch.object(
+            dre,
+            "get_blessed_hostos_versions",
+            return_value={already_elected_version},
+        )
+        mocker.patch.object(
+            dre,
+            "get_active_hostos_versions",
+            return_value={already_elected_version},
+        )
+        propose_spy = mocker.spy(dre, "propose_to_revise_elected_os_versions")
+
+        rl = StaticReleaseLoader(
+            pydantic_yaml.to_yaml_str(
+                ReleaseIndexModel.model_validate(
+                    {
+                        "releases": [
+                            _release(
+                                "rc--2025-10-02_03-13",
+                                {"base": already_elected_version},
+                            ),
+                            _release(
+                                "rc--2025-09-25_09-52",
+                                {"base": "206b61a8616bc93d36d6a014e5cc8edf1ba256ae"},
+                            ),
+                            # Third RC so find_base_release can resolve a
+                            # base for the second-newest release.
+                            _release(
+                                "rc--2025-09-19_10-17",
+                                {"base": "bf0d4d1b8cb6c0c19a5afa1454ada014847aa5c6"},
+                            ),
+                        ],
+                    }
+                )
+            )
+        )
+        reconciler = Reconciler(
+            f, rl, n, p, "", rs, ic_repo, lambda: _cdf(ic_repo), a, dre, db, s
+        )
+
+        def fake_approved_release_notes(*args):  # type: ignore
+            return f"Fake changelog for {args}"
+
+        rl.proposal_summary = fake_approved_release_notes  # type: ignore
+        reconciler.reconcile()
+
+        # No HostOS election proposal should have been submitted for the
+        # already-elected version.  Submissions for other unrelated test
+        # versions are not prevented.
+        hostos_submitted_versions = [
+            call.kwargs["version"]
+            for call in propose_spy.call_args_list
+            if call.kwargs.get("os_kind") == const.HOSTOS
+        ]
+        assert already_elected_version not in hostos_submitted_versions, (
+            "Reconciler submitted a duplicate election proposal for"
+            f" already-elected version {already_elected_version}:"
+            f" {hostos_submitted_versions}"
+        )
+        # Reconciler state must still be NoProposal for that version, since
+        # the short-circuit deliberately does not synthesise a proposal id.
+        assert isinstance(
+            rs.version_proposal(already_elected_version, const.HOSTOS),
+            reconciler_state.NoProposal,
+        )

--- a/release-index.yaml
+++ b/release-index.yaml
@@ -14,8 +14,7 @@
 #   rejected / failed proposals.  Remove the entry once the replacement
 #   proposal has been submitted; the IC governance canister will still
 #   refuse to re-elect an already blessed version.
-ignored_proposals:
-  - 141776 # GuestOS election proposal rejected; resubmit the version.
+ignored_proposals: []
 releases:
   - rc_name: rc--2026-05-21_04-45
     versions:


### PR DESCRIPTION
## Why

The release-controller fired three different NNS election proposals for commit `c7552446...` (141776 -> failed, 141782 -> executed, then duplicates 141879 and 141880, both rejected by governance) because two latent bugs combined badly with a stale `ignored_proposals` entry that nobody removed once 141782 was executed:

1. **`get_election_proposals_by_version` in `public_dashboard.py` and `dre_cli.py`** had a nested loop and a blind `d[version] = proposal` assignment that kept *whichever proposal was iterated last* per version.  The dashboard API returns proposals newest-first, so the *oldest* (the rejected 141776) won.  After `_filtered_proposals_retriever` then stripped 141776, the version looked unproposed on every cycle, and each pod restart submitted yet another one.
2. The proposal-submission phase already fetched the elected (`blessed`) versions to compute `unelect_versions`, but it never used that set to short-circuit the submission, so the governance canister was left to refuse every duplicate on its own.

## What

- Replace the buggy per-version aggregator with **`dre_cli.proposals_by_version`**, a free helper that:
  - keeps the highest-id proposal per version (no reliance on iteration order), and
  - applies `ignored_proposals` filtering at the raw-list level **before** aggregation, so a stale ignored id can't hide a perfectly good non-ignored proposal targeting the same version -- the wrapper falls back to the next-highest-id automatically.
- Refactor `Reconciler._filtered_proposals_retriever` to take a raw-list retriever (`get_past_election_proposals`) and call the new helper, so the filter happens at the right layer.
- Add a `release_commit in blessed` short-circuit to the `proposal submission` phase that warns loudly and skips submission when the target version is already elected -- safety net for any future operator mistake of the same shape.
- Drop the now-stale `141776` entry from `release-index.yaml` and update the README's example to a synthetic id, plus document the new fallback-to-next-highest-id behaviour in the caveats.

## Tests

New tests in `tests/test_reconciler_integration.py`:

- `test_dashboard_get_election_proposals_by_version_keeps_highest_id_for_duplicates` -- guards the dashboard aggregator.
- `test_dre_cli_get_election_proposals_by_version_keeps_highest_id_for_duplicates` -- guards the dre_cli aggregator.
- `test_reconciler_filtered_proposals_retriever_falls_back_to_next_highest_id` -- guards the filter-before-aggregation ordering (this is the user's exact scenario).
- `test_reconciler_skips_submission_when_version_already_in_blessed_set` -- guards the safety net.

Updated tests:

- `test_reconciler_filtered_proposals_retriever_drops_ignored_ids` / `..._is_noop_without_ids` -- migrated to the new raw-list retriever signature.
- `test_reconciler_reconciles_without_error_already_submitted_proposals` -- expected forum-post id updated from `138814` to `138817` to reflect the now-correct highest-id-wins behaviour.

Local runs:

```
bazel test //release-controller:integration_tests //release-controller:medium_tests
# both PASSED
bazel build //release-controller:public_dashboard //release-controller:dre_cli \
            //release-controller:release-controller //release-controller:dryrun \
            //release-controller:integration_tests //release-controller:medium_tests
# mypy clean
```