### PR TITLE
fix(release-controller): resubmit failed GuestOS election 142125

### DIFF
--- a/release-index.yaml
+++ b/release-index.yaml
@@ -14,7 +14,8 @@
 #   rejected / failed proposals.  Remove the entry once the replacement
 #   proposal has been submitted; the IC governance canister will still
 #   refuse to re-elect an already blessed version.
-ignored_proposals: []
+ignored_proposals:
+  - 142125 # GuestOS base b95f4a32b41798de115aac9298b51dd1662f1da5 election FAILED: its auto-computed retire list included 62e841d27ea12451f504e74c54843b7cbf93ca4d, which was still deployed to a subnet at execution time. That subnet has since been upgraded off it, so a resubmission can retire it cleanly. Remove this entry once the replacement proposal has been submitted.
 releases:
   - rc_name: rc--2026-06-04_04-52
     versions:


### PR DESCRIPTION
## What

Add NNS proposal `142125` to the top-level `ignored_proposals` list in `release-index.yaml` so the release controller resubmits the GuestOS election for base `b95f4a32b41798de115aac9298b51dd1662f1da5` (`rc--2026-06-04_04-52`).

## Why

Proposal [142125](https://dashboard.internetcomputer.org/proposal/142125) (`ReviseElectedGuestosVersions`) **FAILED** on execution:

```
[Registry] Cannot retire versions {"62e841d27ea12451f504e74c54843b7cbf93ca4d"},
because they are currently deployed to a subnet!
```

The proposal elects `b95f4a32…` **and** carries an auto-computed retire list (`fa3e237…`, `f31310f…`, `c755244…`, `62e841d…`). `62e841d…` (`rc--2026-05-07_04-27`) was still deployed to a subnet at execution time, so the registry trapped on the retirement and — because the proposal is atomic — `b95f4a32…` was never elected.

`62e841d…` ended up in the retire list because `versions_to_unelect()` derives the active-release window from the Prometheus `> 10` nodes "active versions" query; the subnet still on `62e841d…` had too few reporting nodes to register as active.

The sibling proposal 142127 (electing the `canister-logging` variant `fb721da…`) executed fine because non-base variants get no retire list.

## Why it is now safe to resubmit

All 49 subnets have since been upgraded off `62e841d…` (currently all on `a47e5434…`), so retiring it is now legal. The reconciler treats the FAILED proposal as "already submitted" and will not resubmit on its own; `ignored_proposals` forces it to forget 142125 and submit a fresh election on the next cycle (no redeploy required).

## Follow-up

- [ ] Once the replacement election proposal for `b95f4a32…` is submitted, remove the `142125` entry from `ignored_proposals`.

## Notes

- No code change; config only. YAML validated against `release-index-schema.json` (`ignored_proposals` is an integer array).