### PR TITLE
fix(release-controller): tolerate plain-list ic-admin blessed versions output

### DIFF
--- a/release-controller/dre_cli.py
+++ b/release-controller/dre_cli.py
@@ -147,17 +147,27 @@ class DRECli:
 
     def get_blessed_guestos_versions(self) -> set[str]:
         """Query the blessed GuestOS versions."""
-        return set(
-            typing.cast(
-                list[str],
-                json.loads(
-                    subprocess.check_output(
-                        [self.cli, "get", "blessed-replica-versions", "--json"],
-                        env=self.env,
-                    )
-                )["value"]["blessed_version_ids"],
+        # `dre get` forwards its arguments verbatim to `ic-admin`, so the
+        # output format is dictated by the ic-admin build that matches the
+        # currently deployed registry canister (downloaded at runtime), not
+        # by this code.  Newer ic-admin releases ignore `--json` for this
+        # subcommand and print a plain newline-separated list of version IDs;
+        # older ones wrapped it in {"value": {"blessed_version_ids": [...]}}.
+        # Accept both so a registry-canister upgrade can't break us again.
+        output = subprocess.check_output(
+            [self.cli, "get", "blessed-replica-versions", "--json"],
+            env=self.env,
+            text=True,
+        ).strip()
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            return set(
+                typing.cast(list[str], parsed["value"]["blessed_version_ids"])
             )
-        )
+        return {line.strip() for line in output.splitlines() if line.strip()}
 
     def get_blessed_hostos_versions(self) -> set[str]:
         """Query the blessed HostOS versions."""


### PR DESCRIPTION
## Problem

The reconciler crashes every cycle and never submits any proposal:

```
File ".../reconciler.py", line 849, in reconcile
    blessed = self.dre.get_blessed_guestos_versions()
File ".../dre_cli.py", line 153, in get_blessed_guestos_versions
    json.loads(...)
json.decoder.JSONDecodeError: Extra data: line 1 column 7 (char 6)
```

`get_blessed_guestos_versions()` runs `dre get blessed-replica-versions --json` and parses the output as `{"value": {"blessed_version_ids": [...]}}`.

## Root cause

`dre get` is a transparent passthrough to `ic-admin` (`commands/get.rs`: "Arbitrary ic-admin args" -> `ctx.get(args)`). The `ic-admin` binary is **not** bundled in the image; it is downloaded at runtime to match the **registry canister's `git_commit_id`**, cached for 24h (`store.rs` -> `registry_canister_version()` -> `ic-canisters/.../canister_version`).

A recent registry-canister upgrade (to `a0f359b3…`) pulled an `ic-admin` that **ignores `--json` for this subcommand and prints a plain newline-separated list** of version IDs instead of the JSON envelope. `json.loads` then reads the first hex line `62e841…` as the float `62e841` and trips on the `d` at char 6 -> `Extra data`.

Confirmed in-cluster: `ic-admin get-blessed-replica-versions --json` returns byte-identical output with and without `--json` (a plain list).

This is independent of the release-controller version: `dre_cli.py` is byte-identical on `main` and the deployed commit, and the trigger is the runtime `ic-admin`, not this code. It would crash on any image version.

## Fix

Parse both shapes in `get_blessed_guestos_versions()`: keep the legacy `{"value": {"blessed_version_ids": [...]}}` envelope when present, otherwise fall back to the newline-separated list.

Only this one call site is affected — the HostOS path and proposal lookups use `dre registry` / `dre proposals` (native dre JSON), which are unaffected.

## Test plan

- [ ] `bazel test //release-controller/...`
- [ ] Build + deploy the image; confirm the reconciler completes a cycle (no `get_blessed_guestos_versions` traceback) and proceeds to submit the pending `b95f4a32…` election.