### PR TITLE
fix(release-controller): also ignore failed election proposal 142145

### DIFF
--- a/release-index.yaml
+++ b/release-index.yaml
@@ -16,6 +16,7 @@
 #   refuse to re-elect an already blessed version.
 ignored_proposals:
   - 142125 # GuestOS base b95f4a32b41798de115aac9298b51dd1662f1da5 election FAILED: its auto-computed retire list included 62e841d27ea12451f504e74c54843b7cbf93ca4d, which was still deployed to a subnet at execution time. That subnet has since been upgraded off it, so a resubmission can retire it cleanly. Remove this entry once the replacement proposal has been submitted.
+  - 142145 # Resubmission of the same b95f4a32b41798de115aac9298b51dd1662f1da5 election (after ignoring 142125) FAILED again: its retire list still includes 62e841d27ea12451f504e74c54843b7cbf93ca4d, which remains in use by two API boundary nodes still running that version, so the registry invariant rejects unelecting it. This entry only unblocks a fresh resubmission once those API boundary nodes have been upgraded off 62e841d. Remove once the replacement proposal has been submitted.
 releases:
   - rc_name: rc--2026-06-04_04-52
     versions:


### PR DESCRIPTION
## What

Add NNS proposal `142145` to the top-level `ignored_proposals` list in `release-index.yaml` (alongside the existing `142125`).

## Why

`142145` was the resubmission of the `b95f4a32b41798de115aac9298b51dd1662f1da5` GuestOS base election, forced by ignoring the earlier failed `142125`. It **FAILED again**, this time at the registry invariant:

```
Panicked at 'Using a version that isn't elected.
Elected versions: {a47e5434, b090f12a, b95f4a32, fb721da},
in use: {62e841d27…, a47e5434…}.'
rs/registry/canister/src/invariants/replica_version.rs:55
```

The retire list still includes `62e841d27ea12451f504e74c54843b7cbf93ca4d`, which remains **in use** — not by any subnet or the unassigned-nodes config (all on `a47e5434`), but by **two API boundary nodes** still running it:

- `hqakm-buvkm-5onrb-4ja5j-pne2h-mnlgv-ei4sf-nqn7l-3ir4g-z6xq5-zqe`
- `i55je-j5vzn-z4odr-yhmrb-nlf46-gbgfg-6uk5e-gssxu-b7hmf-ntlay-pqe`

These two API BNs are not in the hardcoded mainnet API-boundary-node rollout list in `dre-airflow` (`dags/defaults.py`), so the weekly auto-rollout never moved them off `62e841d…`.

## Important caveat

This entry alone does **not** fix the failure. Forcing another resubmission will fail the same way until those two API boundary nodes are upgraded off `62e841d…`. Once they are, removing `62e841d…` becomes legal and the resubmission elects `b95f4a…` cleanly.

## Follow-up

- [ ] Upgrade the two stranded API boundary nodes off `62e841d…` (and reconcile the hardcoded API-BN list in `dre-airflow`).
- [ ] Once the replacement election for `b95f4a…` is submitted, remove the `142125` and `142145` entries from `ignored_proposals`.

## Notes

- Config only. YAML validated against `release-index-schema.json` (`ignored_proposals` = `[142125, 142145]`).