### PR TITLE
chore: bump Rust toolchain 1.90.0 -> 1.91.1

### DIFF
--- a/docker/runner.Dockerfile
+++ b/docker/runner.Dockerfile
@@ -86,4 +86,4 @@ ENV PATH="/home/runner/.cargo/bin:$PATH"
 ENV PATH="$PATH:/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/"
 ENV CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=rust-lld
 
-RUN cargo install --quiet cargo-zigbuild && rustup toolchain install 1.90.0 && cargo +1.90.0 install git-cliff
+RUN cargo install --quiet cargo-zigbuild && rustup toolchain install 1.91.1 && cargo +1.91.1 install git-cliff

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Make sure docker/Dockerfile has the same Rust toolchain version
-channel = "1.90.0"
+channel = "1.91.1"
 profile = "default"
 components = ["rust-analyzer"]


### PR DESCRIPTION
## Summary
- Bump the pinned Rust toolchain from `1.90.0` to `1.91.1` in `rust-toolchain.toml` and the matching `docker/runner.Dockerfile`.

## Why
Building the CLI (and anything depending on `ic-replicated-state` from dfinity/ic rev `abf88f2`) failed with:

```
error[E0658]: use of unstable library feature `btree_extract_if`
```

The dependency uses the range-based `BTreeMap::extract_if`, which was only stabilized in **Rust 1.91.0**. The repo pinned `1.90.0`, one release too old. Verified empirically: 1.90.0 fails, 1.91.1 compiles.

## Test plan
- [ ] `cargo build` / `cargo run` from `rs/cli` completes without the `btree_extract_if` E0658 error
- [ ] CI green with the new toolchain