### PR TITLE
fix(cli): attach guest launch measurements to GuestOS elections

### DIFF
--- a/rs/cli/src/artifact_downloader.rs
+++ b/rs/cli/src/artifact_downloader.rs
@@ -1,5 +1,9 @@
 #![allow(async_fn_in_trait)]
-use std::{fs::File, io::Write, path::Path};
+use std::{
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use futures::{StreamExt, future::BoxFuture, stream};
 use ic_management_types::Artifact;
@@ -27,6 +31,57 @@ pub trait ArtifactDownloader: Sync + Send {
             "https://download.dfinity.network/ic/{}/{}/update-img/update-img.tar.zst",
             version, s3_subdir
         )
+    }
+
+    fn get_s3_launch_measurements_url<'a>(&'a self, version: &'a str, s3_subdir: &'a str) -> String {
+        format!(
+            "https://download.dfinity.systems/ic/{}/{}/update-img/launch-measurements.json",
+            version, s3_subdir
+        )
+    }
+
+    fn get_r2_launch_measurements_url<'a>(&'a self, version: &'a str, s3_subdir: &'a str) -> String {
+        format!(
+            "https://download.dfinity.network/ic/{}/{}/update-img/launch-measurements.json",
+            version, s3_subdir
+        )
+    }
+
+    /// Downloads the SEV-SNP launch measurements published alongside the update
+    /// image and returns the path they were saved to.
+    ///
+    /// These must reach the election proposal: a version elected without them
+    /// cannot be attested, so its GuestOS refuses to start on a SEV-enabled
+    /// subnet and the subnet halts at the upgrade CUP, unable to move forward
+    /// or back. Callers are expected to treat a missing file as fatal rather
+    /// than electing the version without measurements.
+    fn download_launch_measurements<'a>(&'a self, image: &'a Artifact, version: &'a str) -> BoxFuture<'_, anyhow::Result<PathBuf>> {
+        Box::pin(async move {
+            let urls = vec![
+                self.get_s3_launch_measurements_url(version, &image.s3_folder()),
+                self.get_r2_launch_measurements_url(version, &image.s3_folder()),
+            ];
+
+            let mut errors = vec![];
+            for url in &urls {
+                match download_launch_measurements_from(url).await {
+                    Ok(path) => {
+                        info!("Launch measurements for {} saved at {}", version, path.display());
+                        return Ok(path);
+                    }
+                    Err(err) => {
+                        warn!("Error downloading {}: {}", url, err);
+                        errors.push(format!("{}: {}", url, err));
+                    }
+                }
+            }
+
+            Err(anyhow::anyhow!(
+                "Unable to download the launch measurements for {} from any of the following URLs:\n{}",
+                version,
+                errors.join("\n")
+            ))
+        })
     }
 
     fn download_file_and_get_sha256<'a>(&'a self, download_url: &'a str) -> BoxFuture<'_, anyhow::Result<String>> {
@@ -138,6 +193,30 @@ pub trait ArtifactDownloader: Sync + Send {
             Ok((update_urls, expected_hash))
         })
     }
+}
+
+/// Fetches `launch-measurements.json` from `url` into the same download tree
+/// the update images use, and returns where it landed. The file has to outlive
+/// this call because it is handed to `ic-admin` as a path.
+async fn download_launch_measurements_from(url: &str) -> anyhow::Result<PathBuf> {
+    let parsed = url::Url::parse(url)?;
+    let subdir = format!("{}{}", parsed.domain().expect("url.domain() is None"), parsed.path().to_owned());
+    let subdir = subdir.replace(|c: char| !c.is_ascii_alphanumeric(), "_");
+    let download_dir = format!("{}/tmp/ic/{}", dirs::home_dir().expect("home_dir is not set").as_path().display(), subdir);
+    let download_dir = Path::new(&download_dir);
+    fs_err::create_dir_all(download_dir).unwrap_or_else(|_| panic!("create_dir_all failed for {}", download_dir.display()));
+
+    let response = reqwest::get(url).await?;
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!("Download failed with http_code {}", response.status()));
+    }
+    let content = response.bytes().await?;
+
+    let path = download_dir.join("launch-measurements.json");
+    let mut file = File::create(&path)?;
+    file.write_all(&content)?;
+
+    Ok(path)
 }
 
 impl ArtifactDownloader for ArtifactDownloaderImpl {}

--- a/rs/cli/src/runner.rs
+++ b/rs/cli/src/runner.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use ahash::AHashMap;
@@ -315,6 +316,19 @@ impl Runner {
             .download_images_and_validate_sha256(release_artifact, version, ignore_missing_urls)
             .await?;
 
+        // GuestOS elections must carry the SEV-SNP launch measurements. Without
+        // them the version cannot be attested, so its GuestOS refuses to start
+        // on a SEV-enabled subnet: the subnet halts at the upgrade CUP and only
+        // NNS intervention gets it back. Fail here rather than submit a
+        // proposal electing a version that cannot be launched.
+        //
+        // HostOS measurements are not supported by ic-admin yet, mirroring
+        // `release-controller/dre_cli.py`.
+        let launch_measurements_path = match release_artifact {
+            Artifact::GuestOs => Some(self.artifact_downloader.download_launch_measurements(release_artifact, version).await?),
+            Artifact::HostOs => None,
+        };
+
         let summary = match security_fix {
             true => format_security_hotfix(),
             false => format_regular_version_upgrade_summary(version, release_artifact, release_tag)?,
@@ -347,6 +361,7 @@ impl Runner {
                 summary,
                 update_urls,
                 versions_to_retire: retire_versions.clone(),
+                launch_measurements_path,
             })
         }
     }
@@ -1189,6 +1204,9 @@ pub struct UpdateVersion {
     pub update_urls: Vec<String>,
     pub stringified_hash: String,
     pub versions_to_retire: Option<Vec<String>>,
+    /// Path to the downloaded `launch-measurements.json`. Always set for
+    /// GuestOS; `None` for HostOS, whose measurements ic-admin cannot take yet.
+    pub launch_measurements_path: Option<PathBuf>,
 }
 
 impl UpdateVersion {
@@ -1217,6 +1235,10 @@ impl UpdateVersion {
                     versions,
                 ]
                 .concat(),
+                None => vec![],
+            },
+            match &self.launch_measurements_path {
+                Some(path) => vec!["--guest-launch-measurements-path".to_string(), path.display().to_string()],
                 None => vec![],
             },
         ]

--- a/rs/cli/src/unit_tests/registry_versions.rs
+++ b/rs/cli/src/unit_tests/registry_versions.rs
@@ -76,6 +76,9 @@ async fn dump_versions_outputs_records_sorted() {
     artifact_downloader
         .expect_download_images_and_validate_sha256()
         .returning(|_, _, _| Box::pin(async { Ok((vec![], String::new())) }));
+    artifact_downloader
+        .expect_download_launch_measurements()
+        .returning(|_, _| Box::pin(async { Ok(std::path::PathBuf::from("/tmp/launch-measurements.json")) }));
 
     let ctx = get_mocked_ctx(
         Network::mainnet_unchecked().unwrap(),
@@ -153,6 +156,9 @@ async fn list_versions_only_outputs_numbers() {
     artifact_downloader
         .expect_download_images_and_validate_sha256()
         .returning(|_, _, _| Box::pin(async { Ok((vec![], String::new())) }));
+    artifact_downloader
+        .expect_download_launch_measurements()
+        .returning(|_, _| Box::pin(async { Ok(std::path::PathBuf::from("/tmp/launch-measurements.json")) }));
 
     let ctx = get_mocked_ctx(
         Network::mainnet_unchecked().unwrap(),
@@ -236,6 +242,9 @@ async fn dump_versions_rejects_reversed_range() {
     artifact_downloader
         .expect_download_images_and_validate_sha256()
         .returning(|_, _, _| Box::pin(async { Ok((vec![], String::new())) }));
+    artifact_downloader
+        .expect_download_launch_measurements()
+        .returning(|_, _| Box::pin(async { Ok(std::path::PathBuf::from("/tmp/launch-measurements.json")) }));
 
     let ctx = get_mocked_ctx(
         Network::mainnet_unchecked().unwrap(),

--- a/rs/cli/src/unit_tests/version.rs
+++ b/rs/cli/src/unit_tests/version.rs
@@ -72,6 +72,9 @@ async fn guest_os_elect_version_tests() {
                 async move { Ok((downloads_urls_clone, sha_clone)) }
             })
         });
+    artifact_downloader
+        .expect_download_launch_measurements()
+        .returning(|_, _| Box::pin(async { Ok(std::path::PathBuf::from("/tmp/launch-measurements.json")) }));
 
     let ctx = get_mocked_ctx(
         Network::mainnet_unchecked().unwrap(),
@@ -145,7 +148,94 @@ async fn guest_os_elect_version_tests() {
             args[5],
         );
 
+        // Every GuestOS election must carry the launch measurements, security
+        // patches included -- a version elected without them cannot be attested
+        // and so cannot start on a SEV-enabled subnet.
+        let flag_position = args.iter().position(|arg| arg == "--guest-launch-measurements-path");
+        assert!(
+            flag_position.is_some(),
+            "Test {} did not pass the launch measurements to ic-admin. Got [{}]",
+            name,
+            args.iter().join(", ")
+        );
+        assert_eq!(
+            args[flag_position.unwrap() + 1],
+            "/tmp/launch-measurements.json",
+            "Test {} passed the wrong launch measurements path",
+            name
+        );
+
         // Prepare for next test
         *captured_cmd = None;
     }
+}
+
+/// A GuestOS version whose launch measurements cannot be fetched must not be
+/// elected at all. Electing one is what halts SEV-enabled subnets at the
+/// upgrade CUP, so failing the command is strictly better than submitting a
+/// proposal that looks correct and is not.
+#[tokio::test]
+async fn guest_os_elect_version_fails_without_launch_measurements() {
+    let submitted: Arc<RwLock<bool>> = Arc::new(RwLock::new(false));
+    let submitted_clone = submitted.clone();
+
+    let mut ic_admin = MockIcAdmin::new();
+    ic_admin.expect_simulate_proposal().returning(|_, _| Box::pin(async { Ok(()) }));
+    ic_admin.expect_submit_proposal().returning(move |_cmd, _forum_post| {
+        *submitted_clone.write().unwrap() = true;
+        Box::pin(ok("Proposal 123".to_string()))
+    });
+
+    let mut git = MockLazyGit::new();
+    git.expect_guestos_releases()
+        .returning(|| Box::pin(ok(Arc::new(ArtifactReleases::new(ic_management_types::Artifact::GuestOs)))));
+
+    let mut registry = MockLazyRegistry::new();
+    registry.expect_subnets().returning(|| Box::pin(ok(Arc::new(IndexMap::new()))));
+    registry
+        .expect_unassigned_nodes_replica_version()
+        .returning(|| Box::pin(ok(Arc::new("some_ver".to_string()))));
+
+    let mut proposal_agent = MockProposalAgent::new();
+    proposal_agent
+        .expect_list_open_elect_replica_proposals()
+        .returning(|| Box::pin(ok(vec![])));
+
+    let mut artifact_downloader = MockArtifactDownloader::new();
+    artifact_downloader
+        .expect_download_images_and_validate_sha256()
+        .returning(|_, _, _| Box::pin(async { Ok((vec!["https://ver1.download.link".to_string()], "sha_of_ver".to_string())) }));
+    artifact_downloader
+        .expect_download_launch_measurements()
+        .returning(|_, _| Box::pin(async { Err(anyhow::anyhow!("404 Not Found")) }));
+
+    let ctx = get_mocked_ctx(
+        Network::mainnet_unchecked().unwrap(),
+        Neuron::anonymous_neuron(),
+        Arc::new(registry),
+        Arc::new(ic_admin),
+        Arc::new(git),
+        Arc::new(proposal_agent),
+        Arc::new(artifact_downloader),
+        Arc::new(MockCordonedFeatureFetcher::new()),
+        Arc::new(MockHealthStatusQuerier::new()),
+    );
+
+    let cmd = crate::commands::version::revise::guest_os::GuestOs {
+        version: "new_version".to_string(),
+        release_tag: Some("rel_tag".to_string()),
+        ignore_missing_urls: true,
+        security_fix: true,
+        submission_parameters: SubmissionParameters {
+            forum_parameters: fake_forum_parameters(),
+            confirmation_mode: mock_confirmation_mode(),
+        },
+    };
+
+    let resp = cmd.execute(ctx).await;
+    assert!(resp.is_err(), "Expected the election to fail without launch measurements");
+    assert!(
+        !*submitted.read().unwrap(),
+        "No proposal may be submitted when the launch measurements are missing"
+    );
 }


### PR DESCRIPTION
## Problem

`dre version revise guest-os` builds its ic-admin arguments in Rust ([`runner.rs::get_update_cmd_args`](https://github.com/dfinity/dre/blob/main/rs/cli/src/runner.rs)) and had no way to pass `--guest-launch-measurements-path`. Every version elected through it therefore landed in the registry with `guest_launch_measurements: null`.

The release-controller cannot produce that payload — `reconciler.py` fetches the measurements and `dre_cli.py` raises `ValueError("Guest launch measurements missing. Cannot proceed.")` if they are absent. The manual Rust path, which is the one used for security patches (`--security-fix`), could and did.

## What it caused

Proposal [143078](https://dashboard.internetcomputer.org/proposal/143078) ("Security patch update") elected `b6c0f508…` with `guest_launch_measurements: null`, even though `launch-measurements.json` had been published to the CDN two hours earlier. Proposal [143097](https://dashboard.internetcomputer.org/proposal/143097) then deployed it to `re2t4…`, the SEV-enabled confidential subnet.

Every orchestrator there looped:

```
Starting version upgrade at CUP registry version 62472: a268b428… -> b6c0f508…
guestos upgrade written to slot B
Check for upgrade failed: Failed to upgrade: Server start error:
  Replica version b6c0f508… does not have guest launch measurements
```

The subnet sat halted at the upgrade CUP for ~8 hours. Rolling the subnet back did not help — the orchestrator reads the target version at the CUP's pinned registry version, so it never saw the new subnet record — and recovery required an NNS recovery-CUP proposal ([143100](https://dashboard.internetcomputer.org/proposal/143100)).

## Change

- `ArtifactDownloader::download_launch_measurements()` fetches `launch-measurements.json` from `download.dfinity.systems`, falling back to `download.dfinity.network`, into the same download tree the update images use. It returns a path because ic-admin takes `--guest-launch-measurements-path`, so the file must outlive the call.
- GuestOS elections now **fail** when the measurements cannot be fetched, instead of electing a version that cannot be launched under SEV. This matches the Python path's behaviour. `--ignore-missing-urls` does not bypass it: that flag is about CDN mirrors.
- HostOS passes `None`, mirroring the existing TODO in `dre_cli.py` — ic-admin does not accept HostOS measurements yet.

## Tests

- `guest_os_elect_version_tests` now asserts the flag and path reach ic-admin, over both the regular and the security-fix case.
- New `guest_os_elect_version_fails_without_launch_measurements`: the download fails, the command errors, and no proposal is submitted.

## Not covered here

`dre subnet deploy` still allows an already-elected measurement-less version to be pushed to a `sev_enabled` subnet. `b6c0f508…` is still elected with `null`, and `x4jtx…` is still a SEV subnet on the previous version, so that path remains live. Happy to add the deploy-side guard here if reviewers prefer it in one PR.
