### PR TITLE
fix(release-controller): stop integration test asserting live NNS state

### DIFF
--- a/release-controller/tests/test_reconciler_integration.py
+++ b/release-controller/tests/test_reconciler_integration.py
@@ -76,6 +76,36 @@ class MockDashboard(DashboardAPI):
         ]
 
 
+# The NNS proposals that really elected GuestOS for the two most recent
+# releases of the default fixture index below.
+#
+# ``MockDashboard`` cannot supply these: its ``_fake_proposal`` always emits
+# ``hostos_version_to_elect``, whatever ``os_type`` it is handed, so it only
+# ever populates the HostOS half of :func:`dre_cli.proposals_by_version`.  The
+# GuestOS half was therefore left to ``dryrun.DRECli``, which does *not*
+# override ``get_past_election_proposals`` and so shells out to the real
+# ``dre proposals filter -t ic-os-version-election`` against the live
+# governance canister.  That query returns only the 100 most recent election
+# proposals, so the moment one of these two scrolled out of the window the
+# tests started asserting against whatever the chain happened to hold that
+# minute -- the same commit passed CI at one push and failed at the next.
+# Pin them instead.
+_FIXTURE_GUESTOS_ELECTION_PROPOSALS: dict[str, int] = {
+    "45657852c1eca6728ff313808db29b47c862ad13": 138814,
+    "206b61a8616bc93d36d6a014e5cc8edf1ba256ae": 138708,
+}
+
+
+class StubDRECli(dryrun.DRECli):
+    """``dryrun.DRECli`` with the live governance canister query stubbed out."""
+
+    def get_past_election_proposals(self) -> list[ElectionProposal]:
+        return [
+            _guestos_election_proposal(proposal_id, version)
+            for version, proposal_id in _FIXTURE_GUESTOS_ELECTION_PROPOSALS.items()
+        ]
+
+
 class MockActiveVersionProvider(object):
     def __init__(self, active_versions: list[str] | None = None):
         self.vers = active_versions if active_versions else []
@@ -125,7 +155,7 @@ def _defaults_for_test(
         dryrun.ReleaseNotesClient(),
         ReconcilerState(),
         MockActiveVersionProvider(),
-        dryrun.DRECli(),
+        StubDRECli(),
         dryrun.MockSlackAnnouncer(),
         StaticReleaseLoader(
             pydantic_yaml.to_yaml_str(


### PR DESCRIPTION
## Problem

`//release-controller:integration_tests` is red on every open PR, including changes that touch nothing near it — [#2101](https://github.com/dfinity/dre/pull/2101) (images only) and `pmarco/guestos-launch-measurements` both failed on it today:

```
FAILED tests/test_reconciler_integration.py::test_reconciler_reconciles_without_error_already_submitted_proposals
  - Hello there!
  + We're preparing [a new IC release](.../release-2025-09-25_09-52-base).
  - We are happy to announce that voting is now open for [a new GuestOS release](...)
  - The NNS proposal is here: [IC NNS Proposal 138708](...)
  + The following is a **draft** of the list of changes since the last GuestOS release:
```

It is not deterministic. On `pmarco/fix-annotator-cc-symlink` the pipeline **passed** at 14:29 UTC and **failed** at 14:33 UTC on two commits with byte-identical trees (`images/BUILD.bazel` blob `55124ab4` in both) — only the commit message differed.

## Root cause

The test asserts that the GuestOS forum post references NNS proposal `138708`, but no fixture supplies that id.

`MockDashboard._fake_proposal` writes `hostos_version_to_elect` into the payload regardless of the `os_type` argument it is handed, so `dre_cli.proposals_by_version` only ever populates the **HostOS** half of the mapping — its two `const.GUESTOS` entries land in the HostOS dict as well. The GuestOS half was therefore left to `dryrun.DRECli`, which does **not** override `get_past_election_proposals` and so shells out to the real thing:

```
dre proposals filter -t ic-os-version-election
```

against the live governance canister. `138708` is a real proposal (`ReviseElectedGuestosVersions` for commit `206b61a`, executed 2025-09-29) — the test was reading it off-chain.

`dre proposals filter` defaults to `--limit 100` ([`rs/cli/src/commands/proposals/filter.rs`](rs/cli/src/commands/proposals/filter.rs)). Once `138708` scrolled out of that sliding window the reconciler saw GuestOS `206b61a8` as un-proposed, took the draft-release-notes path, and the assertion compared the draft post against the "voting is now open" post. The newer `138814` was still in window, which is why only this one assertion broke.

## Fix

Pin the two GuestOS election proposals the fixture index needs, via a `StubDRECli` that overrides `get_past_election_proposals` — the same idiom already used by `test_dre_cli_get_election_proposals_by_version_keeps_highest_id_for_duplicates` and `test_reconciler_skips_submission_when_version_already_in_elected_set`. The pinned ids are the real ones, so every existing expectation is unchanged.

`MockDashboard`'s payload-key bug is deliberately left alone: fixing it would make the dashboard supply GuestOS `138814` for *both* versions (the fixture reuses ids across releases), which would change the expected post contents. It is documented in a comment instead.

## Verification

Ran the suite outside Bazel with a `dre` on `PATH` that logs and exits 90 if invoked:

```
9 passed, 4 warnings in 128.49s
=== dre invocations ===
(none)
```

So the whole integration suite now has **zero** live-NNS dependency — previously three of the four `reconcile()` tests reached the governance canister.

Causal chain confirmed by reverting only `StubDRECli()` → `dryrun.DRECli()` with a `dre` stub printing `[]` (simulating the proposal having aged out), which reproduces the CI failure exactly:

```
>           assert guestos_post["raw"] == expected_guestos_post
E           assert "We're prepar...stOS', False)" == "Hello there!...stOS', False)"
```

`mypy --strict` clean.

## Note

This unblocks [#2101](https://github.com/dfinity/dre/pull/2101) and `pmarco/guestos-launch-measurements`; neither caused the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)