### PR TITLE
feat(release-index): pin changelog base for the 2026-07-23 security hotfixes

### DIFF
--- a/release-index.yaml
+++ b/release-index.yaml
@@ -27,8 +27,16 @@ releases:
         version: b7225383ebc592fa5f4e1eac1c8e403e1e098ef1
       - name: security-hotfix
         version: 0c121276f3156e97de98151d5f6bec6b73695f9f
+        changelog_base:
+          GuestOS:
+            rc_name: rc--2026-07-17_04-19
+            name: base
       - name: deterministic-tracker-security-hotfix
         version: bd3d261559a96ef4f55521111527b5e2ff6242a6
+        changelog_base:
+          GuestOS:
+            rc_name: rc--2026-07-23_04-21
+            name: security-hotfix
   - rc_name: rc--2026-07-17_04-19
     versions:
       - name: base


### PR DESCRIPTION
## What

Pin `changelog_base` for the two security hotfix versions of `rc--2026-07-23_04-21`, which were previously letting `find_base_release()` choose:

| version | commit | GuestOS changelog base | resolves to |
|---|---|---|---|
| `security-hotfix` | `0c121276f3` | `rc--2026-07-17_04-19` / `base` | `a268b428dde2317819a15f5ab9123ffa3b9719e9` |
| `deterministic-tracker-security-hotfix` | `bd3d261559` | `rc--2026-07-23_04-21` / `security-hotfix` | `0c121276f3156e97de98151d5f6bec6b73695f9f` |

## Notes on the shape

`changelog_base` refers to **another `(rc_name, name)` entry in the index**, not a raw commit, and it is keyed per OS variant. [reconciler.py:711](https://github.com/dfinity/dre/blob/main/release-controller/reconciler.py#L711) resolves it with `index.root.version(rc_name, name)` and **raises `KeyError` on a miss** — a typo is a hard reconciler failure, not a silent fallback. Both targets already exist in the index.

Only `GuestOS` is set. HostOS is processed solely for a release's base version (`if os_kind == GUESTOS or v_idx == 0`), and these are versions 3 and 4 in the block, so a `HostOS:` override would be dead config.

`deterministic-tracker-security-hotfix` referencing `security-hotfix` within the same RC is fine — resolution is a flat index lookup, not a graph walk.

## Verification

```
JSON schema (release-index-schema.json): OK
pydantic model:                          OK
OK   security-hotfix
       GuestOS base -> rc--2026-07-17_04-19 / base = a268b428dde2317819a15f5ab9123ffa3b9719e9
OK   deterministic-tracker-security-hotfix
       GuestOS base -> rc--2026-07-23_04-21 / security-hotfix = 0c121276f3156e97de98151d5f6bec6b73695f9f
rest of index unchanged:                  OK
```

Validated against both `release-index-schema.json` and the generated pydantic model, resolving each base exactly the way the reconciler does. The diff is additive only — every other entry byte-identical.

## ⚠️ Merging this alone changes nothing

Release notes for both versions were **already generated and uploaded** on the base `find_base_release()` picked. Two existence-only guards mean this config will be ignored while those drafts exist:

1. [reconciler.py:684](https://github.com/dfinity/dre/blob/main/release-controller/reconciler.py#L684) — `if markdown_file(release_commit, os_kind)` short-circuits past the whole changelog block; `changelog_base` is only read in the `else`.
2. [google_docs.py:81](https://github.com/dfinity/dre/blob/main/release-controller/google_docs.py#L81) — `ensure()` returns the existing doc untouched.

Drive lookup is a title substring match on `{os_kind} Release Notes - {release_tag} ({release_commit})`, keyed on the *release commit*. The base is not in the title, so changing it cannot invalidate the doc. The live log confirms the short-circuit is active:

```
II:...security-hotfix.GuestOS                        — Has release notes in editor.  Going to next phase.
II:...deterministic-tracker-security-hotfix.GuestOS  — Has release notes in editor.  Going to next phase.
```

**So: merge this first, then delete the two docs** from Drive folder `1y-nuH29Gd5Err3pazYH6-LzcDShcOIFf`:

- `GuestOS Release Notes - release-2026-07-23_04-21-security-hotfix (0c121276f3156e97de98151d5f6bec6b73695f9f)`
- `GuestOS Release Notes - release-2026-07-23_04-21-deterministic-tracker-security-hotfix (bd3d261559a96ef4f55521111527b5e2ff6242a6)`

Order matters: the reconciler polls continuously, so deleting before this merges just regenerates them on the old base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)