### PR TITLE
Add new release candidate rc--2026-07-31_04-23

### DIFF
--- a/release-index.yaml
+++ b/release-index.yaml
@@ -19,6 +19,12 @@ ignored_proposals:
   - 142145 # Resubmission of the same b95f4a32b41798de115aac9298b51dd1662f1da5 election (after ignoring 142125) FAILED again: its retire list still includes 62e841d27ea12451f504e74c54843b7cbf93ca4d, which remains in use by two API boundary nodes still running that version, so the registry invariant rejects unelecting it. This entry only unblocks a fresh resubmission once those API boundary nodes have been upgraded off 62e841d. Remove once the replacement proposal has been submitted.
   - 142444 # GuestOS base 63e7f8649be744b7ea75bd5571189a2c04ac49bd election FAILED: poorly formated list of version.
 releases:
+  - rc_name: rc--2026-07-31_04-23
+    versions:
+      - name: base
+        version: e3d101b22ae3fa02aca737f9fb96cc6c4ca83ac3
+      - name: reverts-deterministic-tracker
+        version: 0f974949344626daf5d28f578a0de26c5734e580
   - rc_name: rc--2026-07-23_04-21
     versions:
       - name: base


### PR DESCRIPTION
Added new release candidate with versions for base and reverts-deterministic-tracker.